### PR TITLE
Set up Kokoro for Lite samples testing 

### DIFF
--- a/.kokoro/continuous/java11-samples.cfg
+++ b/.kokoro/continuous/java11-samples.cfg
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download secrets from Cloud Storage.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java-docs-samples"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}
+
+# Tell trampoline which tests to run.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/java-pubsublite/.kokoro/run_samples_tests.sh"
+}

--- a/.kokoro/continuous/java8-samples.cfg
+++ b/.kokoro/continuous/java8-samples.cfg
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download secrets from Cloud Storage.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java-docs-samples"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}
+
+# Tell trampoline which tests to run.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/java-pubsublite/.kokoro/run_samples_tests.sh"
+}

--- a/.kokoro/nightly/java11-samples.cfg
+++ b/.kokoro/nightly/java11-samples.cfg
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download secrets from Cloud Storage.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java-docs-samples"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}
+
+# Tell trampoline which tests to run.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/java-pubsublite/.kokoro/run_samples_tests.sh"
+}

--- a/.kokoro/nightly/java8-samples.cfg
+++ b/.kokoro/nightly/java8-samples.cfg
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download secrets from Cloud Storage.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java-docs-samples"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}
+
+# Tell trampoline which tests to run.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/java-pubsublite/.kokoro/run_samples_tests.sh"
+}

--- a/.kokoro/presubmit/java11-samples.cfg
+++ b/.kokoro/presubmit/java11-samples.cfg
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download secrets from Cloud Storage.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java-docs-samples"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}
+
+# Tell trampoline which tests to run.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/java-pubsublite/.kokoro/run_samples_tests.sh"
+}

--- a/.kokoro/presubmit/java8-samples.cfg
+++ b/.kokoro/presubmit/java8-samples.cfg
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download secrets from Cloud Storage.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java-docs-samples"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}
+
+# Tell trampoline which tests to run.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/java-pubsublite/.kokoro/run_samples_tests.sh"
+}

--- a/.kokoro/run_samples_tests.sh
+++ b/.kokoro/run_samples_tests.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# `-e` enables the script to automatically fail when a command fails
+# `-o pipefail` sets the exit code to the rightmost comment to exit with a non-zero
+set -eo pipefail
+
+echo "********** MAVEN INFO  ***********"
+mvn -v
+
+# Get the directory of the build script
+scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+## cd to the parent directory, i.e. the root of the git repo
+cd ${scriptDir}/..
+
+# include common functions
+source ${scriptDir}/common.sh
+
+# TODO Setup required env variables
+source ${KOKORO_GFILE_DIR}/pubsublite_secrets.txt
+echo "********** Successfully Set All Environment Variables **********"
+
+# Attempt to install 3 times with exponential backoff (starting with 10 seconds)
+retry_with_backoff 3 10 \
+  mvn install -B -V \
+    -DskipTests=true \
+    -Dclirr.skip=true \
+    -Denforcer.skip=true \
+    -Dmaven.javadoc.skip=true \
+    -Dgcloud.download.skip=true \
+    -T 1C
+
+# Activate service account
+gcloud auth activate-service-account \
+    --key-file="$GOOGLE_APPLICATION_CREDENTIALS" \
+    --project="$GOOGLE_CLOUD_PROJECT"
+
+# Move into the samples directory
+cd samples/
+
+echo -e "\n******************** RUNNING SAMPLE TESTS ********************"
+
+mvn --fail-at-end clean verify


### PR DESCRIPTION
I added these 7 files in `.kokoro/` using @stephaniewang526's [PR](https://github.com/googleapis/java-bigquery/pull/61) for reference.

```
.kokoro/
├── continuous
│   ├── java11-samples.cfg
│   ├── java8-samples.cfg
├── nightly
│   ├── java11-samples.cfg
│   ├── java8-samples.cfg
├── presubmit
│   ├── java11-samples.cfg
│   ├── java8-samples.cfg
├── run_samples_tests.sh
```

The only difference between the referenced PR and this one is in `.kokoro/commons.cfg`. A later [commit](https://github.com/googleapis/java-bigquery/commit/60c1198790bd4e29ef215cf057dcc4e4c190e7bf#diff-c447a223495bb4300d1729f0935cda5f) removes what's got added in the referenced PR. 

I have separately tested the test service account from `java-docs-samples-testing` for samples and it WAI.