### PR TITLE
fix: create inFlightSeek on stream reinitialize

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberImpl.java
@@ -166,7 +166,11 @@ public class SubscriberImpl extends ProxyService
             checkArgument(connectedSubscriber.isPresent());
             nextOffsetTracker
                 .requestForRestart()
-                .ifPresent(request -> connectedSubscriber.get().seek(request));
+                .ifPresent(
+                    request -> {
+                      inFlightSeek = Optional.of(SettableApiFuture.create());
+                      connectedSubscriber.get().seek(request);
+                    });
             tokenCounter
                 .requestForRestart()
                 .ifPresent(request -> connectedSubscriber.get().allowFlow(request));


### PR DESCRIPTION
When a stream reconnects, a seek request is made on occasion.  We need to set an inFlightSeek, otherwise we run into the following permanent error:

https://github.com/googleapis/java-pubsublite/blob/master/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberImpl.java#L211

