### PR TITLE
fix: add wait in retry test

### DIFF
--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/PublisherImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/PublisherImplTest.java
@@ -247,6 +247,10 @@ public class PublisherImplTest {
         .when(mockPublisherFactory)
         .New(any(), any(), eq(INITIAL_PUBLISH_REQUEST));
     leakedOffsetStream.onError(Status.UNKNOWN.asRuntimeException());
+
+    // wait for retry to complete
+    Thread.sleep(500);
+
     verify(mockBatchPublisher).close();
     verifyNoMoreInteractions(mockBatchPublisher);
     verify(mockPublisherFactory, times(2)).New(any(), any(), eq(INITIAL_PUBLISH_REQUEST));


### PR DESCRIPTION
Adding a wait in the retry test to ensure that the scheduled retry completes.
