### PR TITLE
fix: use right x-version-update in POM files

### DIFF
--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsublite</artifactId>
-      <version>0.1.4</version><!-- {x-version-update:google-cloud-pubsublite:current} -->
+      <version>0.1.4</version><!-- {x-version-update:google-cloud-pubsublite:released} -->
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsublite</artifactId>
-      <version>0.1.4</version><!-- {x-version-update:google-cloud-pubsublite:current} -->
+      <version>0.1.4</version><!-- {x-version-update:google-cloud-pubsublite:released} -->
     </dependency>
     <!-- A logging dependency used by the underlying library  -->
     <dependency>


### PR DESCRIPTION
Use `<!-- {x-version-update:google-cloud-pubsublite:released} -->` in `samples/install-without-bom`, and `samples/snippets` (for now, to be removed later).

Use `<!-- {x-version-update:google-cloud-pubsublite:current} -->` in `samples/snapshot`. 

---

Kokoro - Test: Java 11 and Kokoro - Test: Java 8 are flaky. Kokoro - CI seems stuck Other libraries have migrated to using GitHub actions for these.