### PR TITLE
style: format grpc library and protos

### DIFF
--- a/grpc-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/AdminServiceGrpc.java
+++ b/grpc-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/AdminServiceGrpc.java
@@ -1,21 +1,15 @@
 package com.google.cloud.pubsublite.proto;
 
 import static io.grpc.MethodDescriptor.generateFullMethodName;
-import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
-import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncUnaryCall;
-import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.futureUnaryCall;
-import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
-import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
 
 /**
+ *
+ *
  * <pre>
  * The service that a client application uses to manage topics and
  * subscriptions, such creating, listing, and deleting topics and subscriptions.
@@ -31,491 +25,688 @@ public final class AdminServiceGrpc {
   public static final String SERVICE_NAME = "google.cloud.pubsublite.v1.AdminService";
 
   // Static method descriptors that strictly reflect the proto.
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.CreateTopicRequest,
-      com.google.cloud.pubsublite.proto.Topic> getCreateTopicMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.CreateTopicRequest,
+          com.google.cloud.pubsublite.proto.Topic>
+      getCreateTopicMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "CreateTopic",
       requestType = com.google.cloud.pubsublite.proto.CreateTopicRequest.class,
       responseType = com.google.cloud.pubsublite.proto.Topic.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.CreateTopicRequest,
-      com.google.cloud.pubsublite.proto.Topic> getCreateTopicMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.CreateTopicRequest, com.google.cloud.pubsublite.proto.Topic> getCreateTopicMethod;
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.CreateTopicRequest,
+          com.google.cloud.pubsublite.proto.Topic>
+      getCreateTopicMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.CreateTopicRequest,
+            com.google.cloud.pubsublite.proto.Topic>
+        getCreateTopicMethod;
     if ((getCreateTopicMethod = AdminServiceGrpc.getCreateTopicMethod) == null) {
       synchronized (AdminServiceGrpc.class) {
         if ((getCreateTopicMethod = AdminServiceGrpc.getCreateTopicMethod) == null) {
-          AdminServiceGrpc.getCreateTopicMethod = getCreateTopicMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.CreateTopicRequest, com.google.cloud.pubsublite.proto.Topic>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateTopic"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.CreateTopicRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.Topic.getDefaultInstance()))
-              .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("CreateTopic"))
-              .build();
+          AdminServiceGrpc.getCreateTopicMethod =
+              getCreateTopicMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.CreateTopicRequest,
+                          com.google.cloud.pubsublite.proto.Topic>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateTopic"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.CreateTopicRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.Topic.getDefaultInstance()))
+                      .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("CreateTopic"))
+                      .build();
         }
       }
     }
     return getCreateTopicMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.GetTopicRequest,
-      com.google.cloud.pubsublite.proto.Topic> getGetTopicMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.GetTopicRequest,
+          com.google.cloud.pubsublite.proto.Topic>
+      getGetTopicMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "GetTopic",
       requestType = com.google.cloud.pubsublite.proto.GetTopicRequest.class,
       responseType = com.google.cloud.pubsublite.proto.Topic.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.GetTopicRequest,
-      com.google.cloud.pubsublite.proto.Topic> getGetTopicMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.GetTopicRequest, com.google.cloud.pubsublite.proto.Topic> getGetTopicMethod;
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.GetTopicRequest,
+          com.google.cloud.pubsublite.proto.Topic>
+      getGetTopicMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.GetTopicRequest,
+            com.google.cloud.pubsublite.proto.Topic>
+        getGetTopicMethod;
     if ((getGetTopicMethod = AdminServiceGrpc.getGetTopicMethod) == null) {
       synchronized (AdminServiceGrpc.class) {
         if ((getGetTopicMethod = AdminServiceGrpc.getGetTopicMethod) == null) {
-          AdminServiceGrpc.getGetTopicMethod = getGetTopicMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.GetTopicRequest, com.google.cloud.pubsublite.proto.Topic>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetTopic"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.GetTopicRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.Topic.getDefaultInstance()))
-              .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("GetTopic"))
-              .build();
+          AdminServiceGrpc.getGetTopicMethod =
+              getGetTopicMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.GetTopicRequest,
+                          com.google.cloud.pubsublite.proto.Topic>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetTopic"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.GetTopicRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.Topic.getDefaultInstance()))
+                      .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("GetTopic"))
+                      .build();
         }
       }
     }
     return getGetTopicMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest,
-      com.google.cloud.pubsublite.proto.TopicPartitions> getGetTopicPartitionsMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest,
+          com.google.cloud.pubsublite.proto.TopicPartitions>
+      getGetTopicPartitionsMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "GetTopicPartitions",
       requestType = com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest.class,
       responseType = com.google.cloud.pubsublite.proto.TopicPartitions.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest,
-      com.google.cloud.pubsublite.proto.TopicPartitions> getGetTopicPartitionsMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest, com.google.cloud.pubsublite.proto.TopicPartitions> getGetTopicPartitionsMethod;
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest,
+          com.google.cloud.pubsublite.proto.TopicPartitions>
+      getGetTopicPartitionsMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest,
+            com.google.cloud.pubsublite.proto.TopicPartitions>
+        getGetTopicPartitionsMethod;
     if ((getGetTopicPartitionsMethod = AdminServiceGrpc.getGetTopicPartitionsMethod) == null) {
       synchronized (AdminServiceGrpc.class) {
         if ((getGetTopicPartitionsMethod = AdminServiceGrpc.getGetTopicPartitionsMethod) == null) {
-          AdminServiceGrpc.getGetTopicPartitionsMethod = getGetTopicPartitionsMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest, com.google.cloud.pubsublite.proto.TopicPartitions>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetTopicPartitions"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.TopicPartitions.getDefaultInstance()))
-              .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("GetTopicPartitions"))
-              .build();
+          AdminServiceGrpc.getGetTopicPartitionsMethod =
+              getGetTopicPartitionsMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest,
+                          com.google.cloud.pubsublite.proto.TopicPartitions>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetTopicPartitions"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.TopicPartitions
+                                  .getDefaultInstance()))
+                      .setSchemaDescriptor(
+                          new AdminServiceMethodDescriptorSupplier("GetTopicPartitions"))
+                      .build();
         }
       }
     }
     return getGetTopicPartitionsMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.ListTopicsRequest,
-      com.google.cloud.pubsublite.proto.ListTopicsResponse> getListTopicsMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.ListTopicsRequest,
+          com.google.cloud.pubsublite.proto.ListTopicsResponse>
+      getListTopicsMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "ListTopics",
       requestType = com.google.cloud.pubsublite.proto.ListTopicsRequest.class,
       responseType = com.google.cloud.pubsublite.proto.ListTopicsResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.ListTopicsRequest,
-      com.google.cloud.pubsublite.proto.ListTopicsResponse> getListTopicsMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.ListTopicsRequest, com.google.cloud.pubsublite.proto.ListTopicsResponse> getListTopicsMethod;
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.ListTopicsRequest,
+          com.google.cloud.pubsublite.proto.ListTopicsResponse>
+      getListTopicsMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.ListTopicsRequest,
+            com.google.cloud.pubsublite.proto.ListTopicsResponse>
+        getListTopicsMethod;
     if ((getListTopicsMethod = AdminServiceGrpc.getListTopicsMethod) == null) {
       synchronized (AdminServiceGrpc.class) {
         if ((getListTopicsMethod = AdminServiceGrpc.getListTopicsMethod) == null) {
-          AdminServiceGrpc.getListTopicsMethod = getListTopicsMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.ListTopicsRequest, com.google.cloud.pubsublite.proto.ListTopicsResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListTopics"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.ListTopicsRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.ListTopicsResponse.getDefaultInstance()))
-              .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("ListTopics"))
-              .build();
+          AdminServiceGrpc.getListTopicsMethod =
+              getListTopicsMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.ListTopicsRequest,
+                          com.google.cloud.pubsublite.proto.ListTopicsResponse>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListTopics"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.ListTopicsRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.ListTopicsResponse
+                                  .getDefaultInstance()))
+                      .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("ListTopics"))
+                      .build();
         }
       }
     }
     return getListTopicsMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.UpdateTopicRequest,
-      com.google.cloud.pubsublite.proto.Topic> getUpdateTopicMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.UpdateTopicRequest,
+          com.google.cloud.pubsublite.proto.Topic>
+      getUpdateTopicMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "UpdateTopic",
       requestType = com.google.cloud.pubsublite.proto.UpdateTopicRequest.class,
       responseType = com.google.cloud.pubsublite.proto.Topic.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.UpdateTopicRequest,
-      com.google.cloud.pubsublite.proto.Topic> getUpdateTopicMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.UpdateTopicRequest, com.google.cloud.pubsublite.proto.Topic> getUpdateTopicMethod;
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.UpdateTopicRequest,
+          com.google.cloud.pubsublite.proto.Topic>
+      getUpdateTopicMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.UpdateTopicRequest,
+            com.google.cloud.pubsublite.proto.Topic>
+        getUpdateTopicMethod;
     if ((getUpdateTopicMethod = AdminServiceGrpc.getUpdateTopicMethod) == null) {
       synchronized (AdminServiceGrpc.class) {
         if ((getUpdateTopicMethod = AdminServiceGrpc.getUpdateTopicMethod) == null) {
-          AdminServiceGrpc.getUpdateTopicMethod = getUpdateTopicMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.UpdateTopicRequest, com.google.cloud.pubsublite.proto.Topic>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateTopic"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.UpdateTopicRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.Topic.getDefaultInstance()))
-              .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("UpdateTopic"))
-              .build();
+          AdminServiceGrpc.getUpdateTopicMethod =
+              getUpdateTopicMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.UpdateTopicRequest,
+                          com.google.cloud.pubsublite.proto.Topic>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateTopic"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.UpdateTopicRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.Topic.getDefaultInstance()))
+                      .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("UpdateTopic"))
+                      .build();
         }
       }
     }
     return getUpdateTopicMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.DeleteTopicRequest,
-      com.google.protobuf.Empty> getDeleteTopicMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.DeleteTopicRequest, com.google.protobuf.Empty>
+      getDeleteTopicMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "DeleteTopic",
       requestType = com.google.cloud.pubsublite.proto.DeleteTopicRequest.class,
       responseType = com.google.protobuf.Empty.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.DeleteTopicRequest,
-      com.google.protobuf.Empty> getDeleteTopicMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.DeleteTopicRequest, com.google.protobuf.Empty> getDeleteTopicMethod;
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.DeleteTopicRequest, com.google.protobuf.Empty>
+      getDeleteTopicMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.DeleteTopicRequest, com.google.protobuf.Empty>
+        getDeleteTopicMethod;
     if ((getDeleteTopicMethod = AdminServiceGrpc.getDeleteTopicMethod) == null) {
       synchronized (AdminServiceGrpc.class) {
         if ((getDeleteTopicMethod = AdminServiceGrpc.getDeleteTopicMethod) == null) {
-          AdminServiceGrpc.getDeleteTopicMethod = getDeleteTopicMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.DeleteTopicRequest, com.google.protobuf.Empty>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteTopic"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.DeleteTopicRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.protobuf.Empty.getDefaultInstance()))
-              .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("DeleteTopic"))
-              .build();
+          AdminServiceGrpc.getDeleteTopicMethod =
+              getDeleteTopicMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.DeleteTopicRequest,
+                          com.google.protobuf.Empty>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteTopic"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.DeleteTopicRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.protobuf.Empty.getDefaultInstance()))
+                      .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("DeleteTopic"))
+                      .build();
         }
       }
     }
     return getDeleteTopicMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest,
-      com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse> getListTopicSubscriptionsMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest,
+          com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse>
+      getListTopicSubscriptionsMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "ListTopicSubscriptions",
       requestType = com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest.class,
       responseType = com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest,
-      com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse> getListTopicSubscriptionsMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest, com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse> getListTopicSubscriptionsMethod;
-    if ((getListTopicSubscriptionsMethod = AdminServiceGrpc.getListTopicSubscriptionsMethod) == null) {
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest,
+          com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse>
+      getListTopicSubscriptionsMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest,
+            com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse>
+        getListTopicSubscriptionsMethod;
+    if ((getListTopicSubscriptionsMethod = AdminServiceGrpc.getListTopicSubscriptionsMethod)
+        == null) {
       synchronized (AdminServiceGrpc.class) {
-        if ((getListTopicSubscriptionsMethod = AdminServiceGrpc.getListTopicSubscriptionsMethod) == null) {
-          AdminServiceGrpc.getListTopicSubscriptionsMethod = getListTopicSubscriptionsMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest, com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListTopicSubscriptions"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse.getDefaultInstance()))
-              .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("ListTopicSubscriptions"))
-              .build();
+        if ((getListTopicSubscriptionsMethod = AdminServiceGrpc.getListTopicSubscriptionsMethod)
+            == null) {
+          AdminServiceGrpc.getListTopicSubscriptionsMethod =
+              getListTopicSubscriptionsMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest,
+                          com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+                      .setFullMethodName(
+                          generateFullMethodName(SERVICE_NAME, "ListTopicSubscriptions"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse
+                                  .getDefaultInstance()))
+                      .setSchemaDescriptor(
+                          new AdminServiceMethodDescriptorSupplier("ListTopicSubscriptions"))
+                      .build();
         }
       }
     }
     return getListTopicSubscriptionsMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.CreateSubscriptionRequest,
-      com.google.cloud.pubsublite.proto.Subscription> getCreateSubscriptionMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.CreateSubscriptionRequest,
+          com.google.cloud.pubsublite.proto.Subscription>
+      getCreateSubscriptionMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "CreateSubscription",
       requestType = com.google.cloud.pubsublite.proto.CreateSubscriptionRequest.class,
       responseType = com.google.cloud.pubsublite.proto.Subscription.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.CreateSubscriptionRequest,
-      com.google.cloud.pubsublite.proto.Subscription> getCreateSubscriptionMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.CreateSubscriptionRequest, com.google.cloud.pubsublite.proto.Subscription> getCreateSubscriptionMethod;
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.CreateSubscriptionRequest,
+          com.google.cloud.pubsublite.proto.Subscription>
+      getCreateSubscriptionMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.CreateSubscriptionRequest,
+            com.google.cloud.pubsublite.proto.Subscription>
+        getCreateSubscriptionMethod;
     if ((getCreateSubscriptionMethod = AdminServiceGrpc.getCreateSubscriptionMethod) == null) {
       synchronized (AdminServiceGrpc.class) {
         if ((getCreateSubscriptionMethod = AdminServiceGrpc.getCreateSubscriptionMethod) == null) {
-          AdminServiceGrpc.getCreateSubscriptionMethod = getCreateSubscriptionMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.CreateSubscriptionRequest, com.google.cloud.pubsublite.proto.Subscription>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateSubscription"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.CreateSubscriptionRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance()))
-              .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("CreateSubscription"))
-              .build();
+          AdminServiceGrpc.getCreateSubscriptionMethod =
+              getCreateSubscriptionMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.CreateSubscriptionRequest,
+                          com.google.cloud.pubsublite.proto.Subscription>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateSubscription"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.CreateSubscriptionRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance()))
+                      .setSchemaDescriptor(
+                          new AdminServiceMethodDescriptorSupplier("CreateSubscription"))
+                      .build();
         }
       }
     }
     return getCreateSubscriptionMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.GetSubscriptionRequest,
-      com.google.cloud.pubsublite.proto.Subscription> getGetSubscriptionMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.GetSubscriptionRequest,
+          com.google.cloud.pubsublite.proto.Subscription>
+      getGetSubscriptionMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "GetSubscription",
       requestType = com.google.cloud.pubsublite.proto.GetSubscriptionRequest.class,
       responseType = com.google.cloud.pubsublite.proto.Subscription.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.GetSubscriptionRequest,
-      com.google.cloud.pubsublite.proto.Subscription> getGetSubscriptionMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.GetSubscriptionRequest, com.google.cloud.pubsublite.proto.Subscription> getGetSubscriptionMethod;
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.GetSubscriptionRequest,
+          com.google.cloud.pubsublite.proto.Subscription>
+      getGetSubscriptionMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.GetSubscriptionRequest,
+            com.google.cloud.pubsublite.proto.Subscription>
+        getGetSubscriptionMethod;
     if ((getGetSubscriptionMethod = AdminServiceGrpc.getGetSubscriptionMethod) == null) {
       synchronized (AdminServiceGrpc.class) {
         if ((getGetSubscriptionMethod = AdminServiceGrpc.getGetSubscriptionMethod) == null) {
-          AdminServiceGrpc.getGetSubscriptionMethod = getGetSubscriptionMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.GetSubscriptionRequest, com.google.cloud.pubsublite.proto.Subscription>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetSubscription"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.GetSubscriptionRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance()))
-              .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("GetSubscription"))
-              .build();
+          AdminServiceGrpc.getGetSubscriptionMethod =
+              getGetSubscriptionMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.GetSubscriptionRequest,
+                          com.google.cloud.pubsublite.proto.Subscription>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetSubscription"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.GetSubscriptionRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance()))
+                      .setSchemaDescriptor(
+                          new AdminServiceMethodDescriptorSupplier("GetSubscription"))
+                      .build();
         }
       }
     }
     return getGetSubscriptionMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.ListSubscriptionsRequest,
-      com.google.cloud.pubsublite.proto.ListSubscriptionsResponse> getListSubscriptionsMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.ListSubscriptionsRequest,
+          com.google.cloud.pubsublite.proto.ListSubscriptionsResponse>
+      getListSubscriptionsMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "ListSubscriptions",
       requestType = com.google.cloud.pubsublite.proto.ListSubscriptionsRequest.class,
       responseType = com.google.cloud.pubsublite.proto.ListSubscriptionsResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.ListSubscriptionsRequest,
-      com.google.cloud.pubsublite.proto.ListSubscriptionsResponse> getListSubscriptionsMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.ListSubscriptionsRequest, com.google.cloud.pubsublite.proto.ListSubscriptionsResponse> getListSubscriptionsMethod;
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.ListSubscriptionsRequest,
+          com.google.cloud.pubsublite.proto.ListSubscriptionsResponse>
+      getListSubscriptionsMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.ListSubscriptionsRequest,
+            com.google.cloud.pubsublite.proto.ListSubscriptionsResponse>
+        getListSubscriptionsMethod;
     if ((getListSubscriptionsMethod = AdminServiceGrpc.getListSubscriptionsMethod) == null) {
       synchronized (AdminServiceGrpc.class) {
         if ((getListSubscriptionsMethod = AdminServiceGrpc.getListSubscriptionsMethod) == null) {
-          AdminServiceGrpc.getListSubscriptionsMethod = getListSubscriptionsMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.ListSubscriptionsRequest, com.google.cloud.pubsublite.proto.ListSubscriptionsResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListSubscriptions"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.ListSubscriptionsRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.ListSubscriptionsResponse.getDefaultInstance()))
-              .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("ListSubscriptions"))
-              .build();
+          AdminServiceGrpc.getListSubscriptionsMethod =
+              getListSubscriptionsMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.ListSubscriptionsRequest,
+                          com.google.cloud.pubsublite.proto.ListSubscriptionsResponse>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListSubscriptions"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.ListSubscriptionsRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.ListSubscriptionsResponse
+                                  .getDefaultInstance()))
+                      .setSchemaDescriptor(
+                          new AdminServiceMethodDescriptorSupplier("ListSubscriptions"))
+                      .build();
         }
       }
     }
     return getListSubscriptionsMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest,
-      com.google.cloud.pubsublite.proto.Subscription> getUpdateSubscriptionMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest,
+          com.google.cloud.pubsublite.proto.Subscription>
+      getUpdateSubscriptionMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "UpdateSubscription",
       requestType = com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest.class,
       responseType = com.google.cloud.pubsublite.proto.Subscription.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest,
-      com.google.cloud.pubsublite.proto.Subscription> getUpdateSubscriptionMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest, com.google.cloud.pubsublite.proto.Subscription> getUpdateSubscriptionMethod;
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest,
+          com.google.cloud.pubsublite.proto.Subscription>
+      getUpdateSubscriptionMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest,
+            com.google.cloud.pubsublite.proto.Subscription>
+        getUpdateSubscriptionMethod;
     if ((getUpdateSubscriptionMethod = AdminServiceGrpc.getUpdateSubscriptionMethod) == null) {
       synchronized (AdminServiceGrpc.class) {
         if ((getUpdateSubscriptionMethod = AdminServiceGrpc.getUpdateSubscriptionMethod) == null) {
-          AdminServiceGrpc.getUpdateSubscriptionMethod = getUpdateSubscriptionMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest, com.google.cloud.pubsublite.proto.Subscription>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateSubscription"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance()))
-              .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("UpdateSubscription"))
-              .build();
+          AdminServiceGrpc.getUpdateSubscriptionMethod =
+              getUpdateSubscriptionMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest,
+                          com.google.cloud.pubsublite.proto.Subscription>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateSubscription"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance()))
+                      .setSchemaDescriptor(
+                          new AdminServiceMethodDescriptorSupplier("UpdateSubscription"))
+                      .build();
         }
       }
     }
     return getUpdateSubscriptionMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest,
-      com.google.protobuf.Empty> getDeleteSubscriptionMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest, com.google.protobuf.Empty>
+      getDeleteSubscriptionMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "DeleteSubscription",
       requestType = com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest.class,
       responseType = com.google.protobuf.Empty.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest,
-      com.google.protobuf.Empty> getDeleteSubscriptionMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest, com.google.protobuf.Empty> getDeleteSubscriptionMethod;
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest, com.google.protobuf.Empty>
+      getDeleteSubscriptionMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest, com.google.protobuf.Empty>
+        getDeleteSubscriptionMethod;
     if ((getDeleteSubscriptionMethod = AdminServiceGrpc.getDeleteSubscriptionMethod) == null) {
       synchronized (AdminServiceGrpc.class) {
         if ((getDeleteSubscriptionMethod = AdminServiceGrpc.getDeleteSubscriptionMethod) == null) {
-          AdminServiceGrpc.getDeleteSubscriptionMethod = getDeleteSubscriptionMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest, com.google.protobuf.Empty>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteSubscription"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.protobuf.Empty.getDefaultInstance()))
-              .setSchemaDescriptor(new AdminServiceMethodDescriptorSupplier("DeleteSubscription"))
-              .build();
+          AdminServiceGrpc.getDeleteSubscriptionMethod =
+              getDeleteSubscriptionMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest,
+                          com.google.protobuf.Empty>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteSubscription"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.protobuf.Empty.getDefaultInstance()))
+                      .setSchemaDescriptor(
+                          new AdminServiceMethodDescriptorSupplier("DeleteSubscription"))
+                      .build();
         }
       }
     }
     return getDeleteSubscriptionMethod;
   }
 
-  /**
-   * Creates a new async stub that supports all call types for the service
-   */
+  /** Creates a new async stub that supports all call types for the service */
   public static AdminServiceStub newStub(io.grpc.Channel channel) {
     io.grpc.stub.AbstractStub.StubFactory<AdminServiceStub> factory =
-      new io.grpc.stub.AbstractStub.StubFactory<AdminServiceStub>() {
-        @java.lang.Override
-        public AdminServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-          return new AdminServiceStub(channel, callOptions);
-        }
-      };
+        new io.grpc.stub.AbstractStub.StubFactory<AdminServiceStub>() {
+          @java.lang.Override
+          public AdminServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AdminServiceStub(channel, callOptions);
+          }
+        };
     return AdminServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
-  public static AdminServiceBlockingStub newBlockingStub(
-      io.grpc.Channel channel) {
+  public static AdminServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
     io.grpc.stub.AbstractStub.StubFactory<AdminServiceBlockingStub> factory =
-      new io.grpc.stub.AbstractStub.StubFactory<AdminServiceBlockingStub>() {
-        @java.lang.Override
-        public AdminServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-          return new AdminServiceBlockingStub(channel, callOptions);
-        }
-      };
+        new io.grpc.stub.AbstractStub.StubFactory<AdminServiceBlockingStub>() {
+          @java.lang.Override
+          public AdminServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AdminServiceBlockingStub(channel, callOptions);
+          }
+        };
     return AdminServiceBlockingStub.newStub(factory, channel);
   }
 
-  /**
-   * Creates a new ListenableFuture-style stub that supports unary calls on the service
-   */
-  public static AdminServiceFutureStub newFutureStub(
-      io.grpc.Channel channel) {
+  /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
+  public static AdminServiceFutureStub newFutureStub(io.grpc.Channel channel) {
     io.grpc.stub.AbstractStub.StubFactory<AdminServiceFutureStub> factory =
-      new io.grpc.stub.AbstractStub.StubFactory<AdminServiceFutureStub>() {
-        @java.lang.Override
-        public AdminServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-          return new AdminServiceFutureStub(channel, callOptions);
-        }
-      };
+        new io.grpc.stub.AbstractStub.StubFactory<AdminServiceFutureStub>() {
+          @java.lang.Override
+          public AdminServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AdminServiceFutureStub(channel, callOptions);
+          }
+        };
     return AdminServiceFutureStub.newStub(factory, channel);
   }
 
   /**
+   *
+   *
    * <pre>
    * The service that a client application uses to manage topics and
    * subscriptions, such creating, listing, and deleting topics and subscriptions.
    * </pre>
    */
-  public static abstract class AdminServiceImplBase implements io.grpc.BindableService {
+  public abstract static class AdminServiceImplBase implements io.grpc.BindableService {
 
     /**
+     *
+     *
      * <pre>
      * Creates a new topic.
      * </pre>
      */
-    public void createTopic(com.google.cloud.pubsublite.proto.CreateTopicRequest request,
+    public void createTopic(
+        com.google.cloud.pubsublite.proto.CreateTopicRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Topic> responseObserver) {
       asyncUnimplementedUnaryCall(getCreateTopicMethod(), responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the topic configuration.
      * </pre>
      */
-    public void getTopic(com.google.cloud.pubsublite.proto.GetTopicRequest request,
+    public void getTopic(
+        com.google.cloud.pubsublite.proto.GetTopicRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Topic> responseObserver) {
       asyncUnimplementedUnaryCall(getGetTopicMethod(), responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the partition information for the requested topic.
      * </pre>
      */
-    public void getTopicPartitions(com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.TopicPartitions> responseObserver) {
+    public void getTopicPartitions(
+        com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest request,
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.TopicPartitions>
+            responseObserver) {
       asyncUnimplementedUnaryCall(getGetTopicPartitionsMethod(), responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the list of topics for the given project.
      * </pre>
      */
-    public void listTopics(com.google.cloud.pubsublite.proto.ListTopicsRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListTopicsResponse> responseObserver) {
+    public void listTopics(
+        com.google.cloud.pubsublite.proto.ListTopicsRequest request,
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListTopicsResponse>
+            responseObserver) {
       asyncUnimplementedUnaryCall(getListTopicsMethod(), responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Updates properties of the specified topic.
      * </pre>
      */
-    public void updateTopic(com.google.cloud.pubsublite.proto.UpdateTopicRequest request,
+    public void updateTopic(
+        com.google.cloud.pubsublite.proto.UpdateTopicRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Topic> responseObserver) {
       asyncUnimplementedUnaryCall(getUpdateTopicMethod(), responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Deletes the specified topic.
      * </pre>
      */
-    public void deleteTopic(com.google.cloud.pubsublite.proto.DeleteTopicRequest request,
+    public void deleteTopic(
+        com.google.cloud.pubsublite.proto.DeleteTopicRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnimplementedUnaryCall(getDeleteTopicMethod(), responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Lists the subscriptions attached to the specified topic.
      * (-- aip.dev/not-precedent: ListTopicSubscriptions returns only a list of
@@ -524,236 +715,285 @@ public final class AdminServiceGrpc {
      * --)
      * </pre>
      */
-    public void listTopicSubscriptions(com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse> responseObserver) {
+    public void listTopicSubscriptions(
+        com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest request,
+        io.grpc.stub.StreamObserver<
+                com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse>
+            responseObserver) {
       asyncUnimplementedUnaryCall(getListTopicSubscriptionsMethod(), responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Creates a new subscription.
      * </pre>
      */
-    public void createSubscription(com.google.cloud.pubsublite.proto.CreateSubscriptionRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription> responseObserver) {
+    public void createSubscription(
+        com.google.cloud.pubsublite.proto.CreateSubscriptionRequest request,
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription>
+            responseObserver) {
       asyncUnimplementedUnaryCall(getCreateSubscriptionMethod(), responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the subscription configuration.
      * </pre>
      */
-    public void getSubscription(com.google.cloud.pubsublite.proto.GetSubscriptionRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription> responseObserver) {
+    public void getSubscription(
+        com.google.cloud.pubsublite.proto.GetSubscriptionRequest request,
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription>
+            responseObserver) {
       asyncUnimplementedUnaryCall(getGetSubscriptionMethod(), responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the list of subscriptions for the given project.
      * </pre>
      */
-    public void listSubscriptions(com.google.cloud.pubsublite.proto.ListSubscriptionsRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListSubscriptionsResponse> responseObserver) {
+    public void listSubscriptions(
+        com.google.cloud.pubsublite.proto.ListSubscriptionsRequest request,
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListSubscriptionsResponse>
+            responseObserver) {
       asyncUnimplementedUnaryCall(getListSubscriptionsMethod(), responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Updates properties of the specified subscription.
      * </pre>
      */
-    public void updateSubscription(com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription> responseObserver) {
+    public void updateSubscription(
+        com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest request,
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription>
+            responseObserver) {
       asyncUnimplementedUnaryCall(getUpdateSubscriptionMethod(), responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Deletes the specified subscription.
      * </pre>
      */
-    public void deleteSubscription(com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest request,
+    public void deleteSubscription(
+        com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnimplementedUnaryCall(getDeleteSubscriptionMethod(), responseObserver);
     }
 
-    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+    @java.lang.Override
+    public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getCreateTopicMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.CreateTopicRequest,
-                com.google.cloud.pubsublite.proto.Topic>(
-                  this, METHODID_CREATE_TOPIC)))
+              getCreateTopicMethod(),
+              asyncUnaryCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.CreateTopicRequest,
+                      com.google.cloud.pubsublite.proto.Topic>(this, METHODID_CREATE_TOPIC)))
           .addMethod(
-            getGetTopicMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.GetTopicRequest,
-                com.google.cloud.pubsublite.proto.Topic>(
-                  this, METHODID_GET_TOPIC)))
+              getGetTopicMethod(),
+              asyncUnaryCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.GetTopicRequest,
+                      com.google.cloud.pubsublite.proto.Topic>(this, METHODID_GET_TOPIC)))
           .addMethod(
-            getGetTopicPartitionsMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest,
-                com.google.cloud.pubsublite.proto.TopicPartitions>(
-                  this, METHODID_GET_TOPIC_PARTITIONS)))
+              getGetTopicPartitionsMethod(),
+              asyncUnaryCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest,
+                      com.google.cloud.pubsublite.proto.TopicPartitions>(
+                      this, METHODID_GET_TOPIC_PARTITIONS)))
           .addMethod(
-            getListTopicsMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.ListTopicsRequest,
-                com.google.cloud.pubsublite.proto.ListTopicsResponse>(
-                  this, METHODID_LIST_TOPICS)))
+              getListTopicsMethod(),
+              asyncUnaryCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.ListTopicsRequest,
+                      com.google.cloud.pubsublite.proto.ListTopicsResponse>(
+                      this, METHODID_LIST_TOPICS)))
           .addMethod(
-            getUpdateTopicMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.UpdateTopicRequest,
-                com.google.cloud.pubsublite.proto.Topic>(
-                  this, METHODID_UPDATE_TOPIC)))
+              getUpdateTopicMethod(),
+              asyncUnaryCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.UpdateTopicRequest,
+                      com.google.cloud.pubsublite.proto.Topic>(this, METHODID_UPDATE_TOPIC)))
           .addMethod(
-            getDeleteTopicMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.DeleteTopicRequest,
-                com.google.protobuf.Empty>(
-                  this, METHODID_DELETE_TOPIC)))
+              getDeleteTopicMethod(),
+              asyncUnaryCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.DeleteTopicRequest,
+                      com.google.protobuf.Empty>(this, METHODID_DELETE_TOPIC)))
           .addMethod(
-            getListTopicSubscriptionsMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest,
-                com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse>(
-                  this, METHODID_LIST_TOPIC_SUBSCRIPTIONS)))
+              getListTopicSubscriptionsMethod(),
+              asyncUnaryCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest,
+                      com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse>(
+                      this, METHODID_LIST_TOPIC_SUBSCRIPTIONS)))
           .addMethod(
-            getCreateSubscriptionMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.CreateSubscriptionRequest,
-                com.google.cloud.pubsublite.proto.Subscription>(
-                  this, METHODID_CREATE_SUBSCRIPTION)))
+              getCreateSubscriptionMethod(),
+              asyncUnaryCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.CreateSubscriptionRequest,
+                      com.google.cloud.pubsublite.proto.Subscription>(
+                      this, METHODID_CREATE_SUBSCRIPTION)))
           .addMethod(
-            getGetSubscriptionMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.GetSubscriptionRequest,
-                com.google.cloud.pubsublite.proto.Subscription>(
-                  this, METHODID_GET_SUBSCRIPTION)))
+              getGetSubscriptionMethod(),
+              asyncUnaryCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.GetSubscriptionRequest,
+                      com.google.cloud.pubsublite.proto.Subscription>(
+                      this, METHODID_GET_SUBSCRIPTION)))
           .addMethod(
-            getListSubscriptionsMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.ListSubscriptionsRequest,
-                com.google.cloud.pubsublite.proto.ListSubscriptionsResponse>(
-                  this, METHODID_LIST_SUBSCRIPTIONS)))
+              getListSubscriptionsMethod(),
+              asyncUnaryCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.ListSubscriptionsRequest,
+                      com.google.cloud.pubsublite.proto.ListSubscriptionsResponse>(
+                      this, METHODID_LIST_SUBSCRIPTIONS)))
           .addMethod(
-            getUpdateSubscriptionMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest,
-                com.google.cloud.pubsublite.proto.Subscription>(
-                  this, METHODID_UPDATE_SUBSCRIPTION)))
+              getUpdateSubscriptionMethod(),
+              asyncUnaryCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest,
+                      com.google.cloud.pubsublite.proto.Subscription>(
+                      this, METHODID_UPDATE_SUBSCRIPTION)))
           .addMethod(
-            getDeleteSubscriptionMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest,
-                com.google.protobuf.Empty>(
-                  this, METHODID_DELETE_SUBSCRIPTION)))
+              getDeleteSubscriptionMethod(),
+              asyncUnaryCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest,
+                      com.google.protobuf.Empty>(this, METHODID_DELETE_SUBSCRIPTION)))
           .build();
     }
   }
 
   /**
+   *
+   *
    * <pre>
    * The service that a client application uses to manage topics and
    * subscriptions, such creating, listing, and deleting topics and subscriptions.
    * </pre>
    */
-  public static final class AdminServiceStub extends io.grpc.stub.AbstractAsyncStub<AdminServiceStub> {
-    private AdminServiceStub(
-        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+  public static final class AdminServiceStub
+      extends io.grpc.stub.AbstractAsyncStub<AdminServiceStub> {
+    private AdminServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected AdminServiceStub build(
-        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+    protected AdminServiceStub build(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new AdminServiceStub(channel, callOptions);
     }
 
     /**
+     *
+     *
      * <pre>
      * Creates a new topic.
      * </pre>
      */
-    public void createTopic(com.google.cloud.pubsublite.proto.CreateTopicRequest request,
+    public void createTopic(
+        com.google.cloud.pubsublite.proto.CreateTopicRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Topic> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateTopicMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getCreateTopicMethod(), getCallOptions()),
+          request,
+          responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the topic configuration.
      * </pre>
      */
-    public void getTopic(com.google.cloud.pubsublite.proto.GetTopicRequest request,
+    public void getTopic(
+        com.google.cloud.pubsublite.proto.GetTopicRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Topic> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(getGetTopicMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the partition information for the requested topic.
      * </pre>
      */
-    public void getTopicPartitions(com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.TopicPartitions> responseObserver) {
+    public void getTopicPartitions(
+        com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest request,
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.TopicPartitions>
+            responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetTopicPartitionsMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getGetTopicPartitionsMethod(), getCallOptions()),
+          request,
+          responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the list of topics for the given project.
      * </pre>
      */
-    public void listTopics(com.google.cloud.pubsublite.proto.ListTopicsRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListTopicsResponse> responseObserver) {
+    public void listTopics(
+        com.google.cloud.pubsublite.proto.ListTopicsRequest request,
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListTopicsResponse>
+            responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(getListTopicsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Updates properties of the specified topic.
      * </pre>
      */
-    public void updateTopic(com.google.cloud.pubsublite.proto.UpdateTopicRequest request,
+    public void updateTopic(
+        com.google.cloud.pubsublite.proto.UpdateTopicRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Topic> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateTopicMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUpdateTopicMethod(), getCallOptions()),
+          request,
+          responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Deletes the specified topic.
      * </pre>
      */
-    public void deleteTopic(com.google.cloud.pubsublite.proto.DeleteTopicRequest request,
+    public void deleteTopic(
+        com.google.cloud.pubsublite.proto.DeleteTopicRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteTopicMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getDeleteTopicMethod(), getCallOptions()),
+          request,
+          responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Lists the subscriptions attached to the specified topic.
      * (-- aip.dev/not-precedent: ListTopicSubscriptions returns only a list of
@@ -762,77 +1002,113 @@ public final class AdminServiceGrpc {
      * --)
      * </pre>
      */
-    public void listTopicSubscriptions(com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse> responseObserver) {
+    public void listTopicSubscriptions(
+        com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest request,
+        io.grpc.stub.StreamObserver<
+                com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse>
+            responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListTopicSubscriptionsMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getListTopicSubscriptionsMethod(), getCallOptions()),
+          request,
+          responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Creates a new subscription.
      * </pre>
      */
-    public void createSubscription(com.google.cloud.pubsublite.proto.CreateSubscriptionRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription> responseObserver) {
+    public void createSubscription(
+        com.google.cloud.pubsublite.proto.CreateSubscriptionRequest request,
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription>
+            responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateSubscriptionMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getCreateSubscriptionMethod(), getCallOptions()),
+          request,
+          responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the subscription configuration.
      * </pre>
      */
-    public void getSubscription(com.google.cloud.pubsublite.proto.GetSubscriptionRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription> responseObserver) {
+    public void getSubscription(
+        com.google.cloud.pubsublite.proto.GetSubscriptionRequest request,
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription>
+            responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetSubscriptionMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getGetSubscriptionMethod(), getCallOptions()),
+          request,
+          responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the list of subscriptions for the given project.
      * </pre>
      */
-    public void listSubscriptions(com.google.cloud.pubsublite.proto.ListSubscriptionsRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListSubscriptionsResponse> responseObserver) {
+    public void listSubscriptions(
+        com.google.cloud.pubsublite.proto.ListSubscriptionsRequest request,
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListSubscriptionsResponse>
+            responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListSubscriptionsMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getListSubscriptionsMethod(), getCallOptions()),
+          request,
+          responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Updates properties of the specified subscription.
      * </pre>
      */
-    public void updateSubscription(com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription> responseObserver) {
+    public void updateSubscription(
+        com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest request,
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription>
+            responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateSubscriptionMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getUpdateSubscriptionMethod(), getCallOptions()),
+          request,
+          responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Deletes the specified subscription.
      * </pre>
      */
-    public void deleteSubscription(com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest request,
+    public void deleteSubscription(
+        com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteSubscriptionMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getDeleteSubscriptionMethod(), getCallOptions()),
+          request,
+          responseObserver);
     }
   }
 
   /**
+   *
+   *
    * <pre>
    * The service that a client application uses to manage topics and
    * subscriptions, such creating, listing, and deleting topics and subscriptions.
    * </pre>
    */
-  public static final class AdminServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<AdminServiceBlockingStub> {
-    private AdminServiceBlockingStub(
-        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+  public static final class AdminServiceBlockingStub
+      extends io.grpc.stub.AbstractBlockingStub<AdminServiceBlockingStub> {
+    private AdminServiceBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
@@ -843,66 +1119,81 @@ public final class AdminServiceGrpc {
     }
 
     /**
+     *
+     *
      * <pre>
      * Creates a new topic.
      * </pre>
      */
-    public com.google.cloud.pubsublite.proto.Topic createTopic(com.google.cloud.pubsublite.proto.CreateTopicRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateTopicMethod(), getCallOptions(), request);
+    public com.google.cloud.pubsublite.proto.Topic createTopic(
+        com.google.cloud.pubsublite.proto.CreateTopicRequest request) {
+      return blockingUnaryCall(getChannel(), getCreateTopicMethod(), getCallOptions(), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the topic configuration.
      * </pre>
      */
-    public com.google.cloud.pubsublite.proto.Topic getTopic(com.google.cloud.pubsublite.proto.GetTopicRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetTopicMethod(), getCallOptions(), request);
+    public com.google.cloud.pubsublite.proto.Topic getTopic(
+        com.google.cloud.pubsublite.proto.GetTopicRequest request) {
+      return blockingUnaryCall(getChannel(), getGetTopicMethod(), getCallOptions(), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the partition information for the requested topic.
      * </pre>
      */
-    public com.google.cloud.pubsublite.proto.TopicPartitions getTopicPartitions(com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest request) {
+    public com.google.cloud.pubsublite.proto.TopicPartitions getTopicPartitions(
+        com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest request) {
       return blockingUnaryCall(
           getChannel(), getGetTopicPartitionsMethod(), getCallOptions(), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the list of topics for the given project.
      * </pre>
      */
-    public com.google.cloud.pubsublite.proto.ListTopicsResponse listTopics(com.google.cloud.pubsublite.proto.ListTopicsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListTopicsMethod(), getCallOptions(), request);
+    public com.google.cloud.pubsublite.proto.ListTopicsResponse listTopics(
+        com.google.cloud.pubsublite.proto.ListTopicsRequest request) {
+      return blockingUnaryCall(getChannel(), getListTopicsMethod(), getCallOptions(), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Updates properties of the specified topic.
      * </pre>
      */
-    public com.google.cloud.pubsublite.proto.Topic updateTopic(com.google.cloud.pubsublite.proto.UpdateTopicRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateTopicMethod(), getCallOptions(), request);
+    public com.google.cloud.pubsublite.proto.Topic updateTopic(
+        com.google.cloud.pubsublite.proto.UpdateTopicRequest request) {
+      return blockingUnaryCall(getChannel(), getUpdateTopicMethod(), getCallOptions(), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Deletes the specified topic.
      * </pre>
      */
-    public com.google.protobuf.Empty deleteTopic(com.google.cloud.pubsublite.proto.DeleteTopicRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteTopicMethod(), getCallOptions(), request);
+    public com.google.protobuf.Empty deleteTopic(
+        com.google.cloud.pubsublite.proto.DeleteTopicRequest request) {
+      return blockingUnaryCall(getChannel(), getDeleteTopicMethod(), getCallOptions(), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Lists the subscriptions attached to the specified topic.
      * (-- aip.dev/not-precedent: ListTopicSubscriptions returns only a list of
@@ -911,71 +1202,88 @@ public final class AdminServiceGrpc {
      * --)
      * </pre>
      */
-    public com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse listTopicSubscriptions(com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest request) {
+    public com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse listTopicSubscriptions(
+        com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest request) {
       return blockingUnaryCall(
           getChannel(), getListTopicSubscriptionsMethod(), getCallOptions(), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Creates a new subscription.
      * </pre>
      */
-    public com.google.cloud.pubsublite.proto.Subscription createSubscription(com.google.cloud.pubsublite.proto.CreateSubscriptionRequest request) {
+    public com.google.cloud.pubsublite.proto.Subscription createSubscription(
+        com.google.cloud.pubsublite.proto.CreateSubscriptionRequest request) {
       return blockingUnaryCall(
           getChannel(), getCreateSubscriptionMethod(), getCallOptions(), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the subscription configuration.
      * </pre>
      */
-    public com.google.cloud.pubsublite.proto.Subscription getSubscription(com.google.cloud.pubsublite.proto.GetSubscriptionRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetSubscriptionMethod(), getCallOptions(), request);
+    public com.google.cloud.pubsublite.proto.Subscription getSubscription(
+        com.google.cloud.pubsublite.proto.GetSubscriptionRequest request) {
+      return blockingUnaryCall(getChannel(), getGetSubscriptionMethod(), getCallOptions(), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the list of subscriptions for the given project.
      * </pre>
      */
-    public com.google.cloud.pubsublite.proto.ListSubscriptionsResponse listSubscriptions(com.google.cloud.pubsublite.proto.ListSubscriptionsRequest request) {
+    public com.google.cloud.pubsublite.proto.ListSubscriptionsResponse listSubscriptions(
+        com.google.cloud.pubsublite.proto.ListSubscriptionsRequest request) {
       return blockingUnaryCall(
           getChannel(), getListSubscriptionsMethod(), getCallOptions(), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Updates properties of the specified subscription.
      * </pre>
      */
-    public com.google.cloud.pubsublite.proto.Subscription updateSubscription(com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest request) {
+    public com.google.cloud.pubsublite.proto.Subscription updateSubscription(
+        com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest request) {
       return blockingUnaryCall(
           getChannel(), getUpdateSubscriptionMethod(), getCallOptions(), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Deletes the specified subscription.
      * </pre>
      */
-    public com.google.protobuf.Empty deleteSubscription(com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest request) {
+    public com.google.protobuf.Empty deleteSubscription(
+        com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest request) {
       return blockingUnaryCall(
           getChannel(), getDeleteSubscriptionMethod(), getCallOptions(), request);
     }
   }
 
   /**
+   *
+   *
    * <pre>
    * The service that a client application uses to manage topics and
    * subscriptions, such creating, listing, and deleting topics and subscriptions.
    * </pre>
    */
-  public static final class AdminServiceFutureStub extends io.grpc.stub.AbstractFutureStub<AdminServiceFutureStub> {
-    private AdminServiceFutureStub(
-        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+  public static final class AdminServiceFutureStub
+      extends io.grpc.stub.AbstractFutureStub<AdminServiceFutureStub> {
+    private AdminServiceFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
@@ -986,72 +1294,90 @@ public final class AdminServiceGrpc {
     }
 
     /**
+     *
+     *
      * <pre>
      * Creates a new topic.
      * </pre>
      */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.pubsublite.proto.Topic> createTopic(
-        com.google.cloud.pubsublite.proto.CreateTopicRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<
+            com.google.cloud.pubsublite.proto.Topic>
+        createTopic(com.google.cloud.pubsublite.proto.CreateTopicRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getCreateTopicMethod(), getCallOptions()), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the topic configuration.
      * </pre>
      */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.pubsublite.proto.Topic> getTopic(
-        com.google.cloud.pubsublite.proto.GetTopicRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetTopicMethod(), getCallOptions()), request);
+    public com.google.common.util.concurrent.ListenableFuture<
+            com.google.cloud.pubsublite.proto.Topic>
+        getTopic(com.google.cloud.pubsublite.proto.GetTopicRequest request) {
+      return futureUnaryCall(getChannel().newCall(getGetTopicMethod(), getCallOptions()), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the partition information for the requested topic.
      * </pre>
      */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.pubsublite.proto.TopicPartitions> getTopicPartitions(
-        com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<
+            com.google.cloud.pubsublite.proto.TopicPartitions>
+        getTopicPartitions(com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getGetTopicPartitionsMethod(), getCallOptions()), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the list of topics for the given project.
      * </pre>
      */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.pubsublite.proto.ListTopicsResponse> listTopics(
-        com.google.cloud.pubsublite.proto.ListTopicsRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<
+            com.google.cloud.pubsublite.proto.ListTopicsResponse>
+        listTopics(com.google.cloud.pubsublite.proto.ListTopicsRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getListTopicsMethod(), getCallOptions()), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Updates properties of the specified topic.
      * </pre>
      */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.pubsublite.proto.Topic> updateTopic(
-        com.google.cloud.pubsublite.proto.UpdateTopicRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<
+            com.google.cloud.pubsublite.proto.Topic>
+        updateTopic(com.google.cloud.pubsublite.proto.UpdateTopicRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getUpdateTopicMethod(), getCallOptions()), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Deletes the specified topic.
      * </pre>
      */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> deleteTopic(
-        com.google.cloud.pubsublite.proto.DeleteTopicRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
+        deleteTopic(com.google.cloud.pubsublite.proto.DeleteTopicRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getDeleteTopicMethod(), getCallOptions()), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Lists the subscriptions attached to the specified topic.
      * (-- aip.dev/not-precedent: ListTopicSubscriptions returns only a list of
@@ -1060,63 +1386,79 @@ public final class AdminServiceGrpc {
      * --)
      * </pre>
      */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse> listTopicSubscriptions(
-        com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<
+            com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse>
+        listTopicSubscriptions(
+            com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getListTopicSubscriptionsMethod(), getCallOptions()), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Creates a new subscription.
      * </pre>
      */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.pubsublite.proto.Subscription> createSubscription(
-        com.google.cloud.pubsublite.proto.CreateSubscriptionRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<
+            com.google.cloud.pubsublite.proto.Subscription>
+        createSubscription(com.google.cloud.pubsublite.proto.CreateSubscriptionRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getCreateSubscriptionMethod(), getCallOptions()), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the subscription configuration.
      * </pre>
      */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.pubsublite.proto.Subscription> getSubscription(
-        com.google.cloud.pubsublite.proto.GetSubscriptionRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<
+            com.google.cloud.pubsublite.proto.Subscription>
+        getSubscription(com.google.cloud.pubsublite.proto.GetSubscriptionRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getGetSubscriptionMethod(), getCallOptions()), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns the list of subscriptions for the given project.
      * </pre>
      */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.pubsublite.proto.ListSubscriptionsResponse> listSubscriptions(
-        com.google.cloud.pubsublite.proto.ListSubscriptionsRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<
+            com.google.cloud.pubsublite.proto.ListSubscriptionsResponse>
+        listSubscriptions(com.google.cloud.pubsublite.proto.ListSubscriptionsRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getListSubscriptionsMethod(), getCallOptions()), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Updates properties of the specified subscription.
      * </pre>
      */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.pubsublite.proto.Subscription> updateSubscription(
-        com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<
+            com.google.cloud.pubsublite.proto.Subscription>
+        updateSubscription(com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getUpdateSubscriptionMethod(), getCallOptions()), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Deletes the specified subscription.
      * </pre>
      */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> deleteSubscription(
-        com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
+        deleteSubscription(com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getDeleteSubscriptionMethod(), getCallOptions()), request);
     }
@@ -1135,11 +1477,11 @@ public final class AdminServiceGrpc {
   private static final int METHODID_UPDATE_SUBSCRIPTION = 10;
   private static final int METHODID_DELETE_SUBSCRIPTION = 11;
 
-  private static final class MethodHandlers<Req, Resp> implements
-      io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
-      io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
-      io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
-      io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
+  private static final class MethodHandlers<Req, Resp>
+      implements io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
+          io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
+          io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
+          io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
     private final AdminServiceImplBase serviceImpl;
     private final int methodId;
 
@@ -1153,51 +1495,75 @@ public final class AdminServiceGrpc {
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
         case METHODID_CREATE_TOPIC:
-          serviceImpl.createTopic((com.google.cloud.pubsublite.proto.CreateTopicRequest) request,
-              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Topic>) responseObserver);
+          serviceImpl.createTopic(
+              (com.google.cloud.pubsublite.proto.CreateTopicRequest) request,
+              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Topic>)
+                  responseObserver);
           break;
         case METHODID_GET_TOPIC:
-          serviceImpl.getTopic((com.google.cloud.pubsublite.proto.GetTopicRequest) request,
-              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Topic>) responseObserver);
+          serviceImpl.getTopic(
+              (com.google.cloud.pubsublite.proto.GetTopicRequest) request,
+              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Topic>)
+                  responseObserver);
           break;
         case METHODID_GET_TOPIC_PARTITIONS:
-          serviceImpl.getTopicPartitions((com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest) request,
-              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.TopicPartitions>) responseObserver);
+          serviceImpl.getTopicPartitions(
+              (com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest) request,
+              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.TopicPartitions>)
+                  responseObserver);
           break;
         case METHODID_LIST_TOPICS:
-          serviceImpl.listTopics((com.google.cloud.pubsublite.proto.ListTopicsRequest) request,
-              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListTopicsResponse>) responseObserver);
+          serviceImpl.listTopics(
+              (com.google.cloud.pubsublite.proto.ListTopicsRequest) request,
+              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListTopicsResponse>)
+                  responseObserver);
           break;
         case METHODID_UPDATE_TOPIC:
-          serviceImpl.updateTopic((com.google.cloud.pubsublite.proto.UpdateTopicRequest) request,
-              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Topic>) responseObserver);
+          serviceImpl.updateTopic(
+              (com.google.cloud.pubsublite.proto.UpdateTopicRequest) request,
+              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Topic>)
+                  responseObserver);
           break;
         case METHODID_DELETE_TOPIC:
-          serviceImpl.deleteTopic((com.google.cloud.pubsublite.proto.DeleteTopicRequest) request,
+          serviceImpl.deleteTopic(
+              (com.google.cloud.pubsublite.proto.DeleteTopicRequest) request,
               (io.grpc.stub.StreamObserver<com.google.protobuf.Empty>) responseObserver);
           break;
         case METHODID_LIST_TOPIC_SUBSCRIPTIONS:
-          serviceImpl.listTopicSubscriptions((com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest) request,
-              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse>) responseObserver);
+          serviceImpl.listTopicSubscriptions(
+              (com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest) request,
+              (io.grpc.stub.StreamObserver<
+                      com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse>)
+                  responseObserver);
           break;
         case METHODID_CREATE_SUBSCRIPTION:
-          serviceImpl.createSubscription((com.google.cloud.pubsublite.proto.CreateSubscriptionRequest) request,
-              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription>) responseObserver);
+          serviceImpl.createSubscription(
+              (com.google.cloud.pubsublite.proto.CreateSubscriptionRequest) request,
+              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription>)
+                  responseObserver);
           break;
         case METHODID_GET_SUBSCRIPTION:
-          serviceImpl.getSubscription((com.google.cloud.pubsublite.proto.GetSubscriptionRequest) request,
-              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription>) responseObserver);
+          serviceImpl.getSubscription(
+              (com.google.cloud.pubsublite.proto.GetSubscriptionRequest) request,
+              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription>)
+                  responseObserver);
           break;
         case METHODID_LIST_SUBSCRIPTIONS:
-          serviceImpl.listSubscriptions((com.google.cloud.pubsublite.proto.ListSubscriptionsRequest) request,
-              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListSubscriptionsResponse>) responseObserver);
+          serviceImpl.listSubscriptions(
+              (com.google.cloud.pubsublite.proto.ListSubscriptionsRequest) request,
+              (io.grpc.stub.StreamObserver<
+                      com.google.cloud.pubsublite.proto.ListSubscriptionsResponse>)
+                  responseObserver);
           break;
         case METHODID_UPDATE_SUBSCRIPTION:
-          serviceImpl.updateSubscription((com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest) request,
-              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription>) responseObserver);
+          serviceImpl.updateSubscription(
+              (com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest) request,
+              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.Subscription>)
+                  responseObserver);
           break;
         case METHODID_DELETE_SUBSCRIPTION:
-          serviceImpl.deleteSubscription((com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest) request,
+          serviceImpl.deleteSubscription(
+              (com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest) request,
               (io.grpc.stub.StreamObserver<com.google.protobuf.Empty>) responseObserver);
           break;
         default:
@@ -1216,8 +1582,9 @@ public final class AdminServiceGrpc {
     }
   }
 
-  private static abstract class AdminServiceBaseDescriptorSupplier
-      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private abstract static class AdminServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier,
+          io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     AdminServiceBaseDescriptorSupplier() {}
 
     @java.lang.Override
@@ -1259,21 +1626,23 @@ public final class AdminServiceGrpc {
       synchronized (AdminServiceGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
-          serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new AdminServiceFileDescriptorSupplier())
-              .addMethod(getCreateTopicMethod())
-              .addMethod(getGetTopicMethod())
-              .addMethod(getGetTopicPartitionsMethod())
-              .addMethod(getListTopicsMethod())
-              .addMethod(getUpdateTopicMethod())
-              .addMethod(getDeleteTopicMethod())
-              .addMethod(getListTopicSubscriptionsMethod())
-              .addMethod(getCreateSubscriptionMethod())
-              .addMethod(getGetSubscriptionMethod())
-              .addMethod(getListSubscriptionsMethod())
-              .addMethod(getUpdateSubscriptionMethod())
-              .addMethod(getDeleteSubscriptionMethod())
-              .build();
+          serviceDescriptor =
+              result =
+                  io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
+                      .setSchemaDescriptor(new AdminServiceFileDescriptorSupplier())
+                      .addMethod(getCreateTopicMethod())
+                      .addMethod(getGetTopicMethod())
+                      .addMethod(getGetTopicPartitionsMethod())
+                      .addMethod(getListTopicsMethod())
+                      .addMethod(getUpdateTopicMethod())
+                      .addMethod(getDeleteTopicMethod())
+                      .addMethod(getListTopicSubscriptionsMethod())
+                      .addMethod(getCreateSubscriptionMethod())
+                      .addMethod(getGetSubscriptionMethod())
+                      .addMethod(getListSubscriptionsMethod())
+                      .addMethod(getUpdateSubscriptionMethod())
+                      .addMethod(getDeleteSubscriptionMethod())
+                      .build();
         }
       }
     }

--- a/grpc-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CursorServiceGrpc.java
+++ b/grpc-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CursorServiceGrpc.java
@@ -2,20 +2,17 @@ package com.google.cloud.pubsublite.proto;
 
 import static io.grpc.MethodDescriptor.generateFullMethodName;
 import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
-import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ClientCalls.asyncUnaryCall;
-import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
 import static io.grpc.stub.ClientCalls.blockingUnaryCall;
 import static io.grpc.stub.ClientCalls.futureUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
 import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
 
 /**
+ *
+ *
  * <pre>
  * The service that a subscriber client application uses to manage committed
  * cursors while receiving messsages. A cursor represents a subscriber's
@@ -32,272 +29,361 @@ public final class CursorServiceGrpc {
   public static final String SERVICE_NAME = "google.cloud.pubsublite.v1.CursorService";
 
   // Static method descriptors that strictly reflect the proto.
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest,
-      com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse> getStreamingCommitCursorMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest,
+          com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse>
+      getStreamingCommitCursorMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "StreamingCommitCursor",
       requestType = com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest.class,
       responseType = com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest,
-      com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse> getStreamingCommitCursorMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest, com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse> getStreamingCommitCursorMethod;
-    if ((getStreamingCommitCursorMethod = CursorServiceGrpc.getStreamingCommitCursorMethod) == null) {
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest,
+          com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse>
+      getStreamingCommitCursorMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest,
+            com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse>
+        getStreamingCommitCursorMethod;
+    if ((getStreamingCommitCursorMethod = CursorServiceGrpc.getStreamingCommitCursorMethod)
+        == null) {
       synchronized (CursorServiceGrpc.class) {
-        if ((getStreamingCommitCursorMethod = CursorServiceGrpc.getStreamingCommitCursorMethod) == null) {
-          CursorServiceGrpc.getStreamingCommitCursorMethod = getStreamingCommitCursorMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest, com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "StreamingCommitCursor"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse.getDefaultInstance()))
-              .setSchemaDescriptor(new CursorServiceMethodDescriptorSupplier("StreamingCommitCursor"))
-              .build();
+        if ((getStreamingCommitCursorMethod = CursorServiceGrpc.getStreamingCommitCursorMethod)
+            == null) {
+          CursorServiceGrpc.getStreamingCommitCursorMethod =
+              getStreamingCommitCursorMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest,
+                          com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+                      .setFullMethodName(
+                          generateFullMethodName(SERVICE_NAME, "StreamingCommitCursor"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse
+                                  .getDefaultInstance()))
+                      .setSchemaDescriptor(
+                          new CursorServiceMethodDescriptorSupplier("StreamingCommitCursor"))
+                      .build();
         }
       }
     }
     return getStreamingCommitCursorMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.CommitCursorRequest,
-      com.google.cloud.pubsublite.proto.CommitCursorResponse> getCommitCursorMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.CommitCursorRequest,
+          com.google.cloud.pubsublite.proto.CommitCursorResponse>
+      getCommitCursorMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "CommitCursor",
       requestType = com.google.cloud.pubsublite.proto.CommitCursorRequest.class,
       responseType = com.google.cloud.pubsublite.proto.CommitCursorResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.CommitCursorRequest,
-      com.google.cloud.pubsublite.proto.CommitCursorResponse> getCommitCursorMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.CommitCursorRequest, com.google.cloud.pubsublite.proto.CommitCursorResponse> getCommitCursorMethod;
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.CommitCursorRequest,
+          com.google.cloud.pubsublite.proto.CommitCursorResponse>
+      getCommitCursorMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.CommitCursorRequest,
+            com.google.cloud.pubsublite.proto.CommitCursorResponse>
+        getCommitCursorMethod;
     if ((getCommitCursorMethod = CursorServiceGrpc.getCommitCursorMethod) == null) {
       synchronized (CursorServiceGrpc.class) {
         if ((getCommitCursorMethod = CursorServiceGrpc.getCommitCursorMethod) == null) {
-          CursorServiceGrpc.getCommitCursorMethod = getCommitCursorMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.CommitCursorRequest, com.google.cloud.pubsublite.proto.CommitCursorResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CommitCursor"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.CommitCursorRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.CommitCursorResponse.getDefaultInstance()))
-              .setSchemaDescriptor(new CursorServiceMethodDescriptorSupplier("CommitCursor"))
-              .build();
+          CursorServiceGrpc.getCommitCursorMethod =
+              getCommitCursorMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.CommitCursorRequest,
+                          com.google.cloud.pubsublite.proto.CommitCursorResponse>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CommitCursor"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.CommitCursorRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.CommitCursorResponse
+                                  .getDefaultInstance()))
+                      .setSchemaDescriptor(
+                          new CursorServiceMethodDescriptorSupplier("CommitCursor"))
+                      .build();
         }
       }
     }
     return getCommitCursorMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest,
-      com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse> getListPartitionCursorsMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest,
+          com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse>
+      getListPartitionCursorsMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "ListPartitionCursors",
       requestType = com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest.class,
       responseType = com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest,
-      com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse> getListPartitionCursorsMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest, com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse> getListPartitionCursorsMethod;
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest,
+          com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse>
+      getListPartitionCursorsMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest,
+            com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse>
+        getListPartitionCursorsMethod;
     if ((getListPartitionCursorsMethod = CursorServiceGrpc.getListPartitionCursorsMethod) == null) {
       synchronized (CursorServiceGrpc.class) {
-        if ((getListPartitionCursorsMethod = CursorServiceGrpc.getListPartitionCursorsMethod) == null) {
-          CursorServiceGrpc.getListPartitionCursorsMethod = getListPartitionCursorsMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest, com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListPartitionCursors"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse.getDefaultInstance()))
-              .setSchemaDescriptor(new CursorServiceMethodDescriptorSupplier("ListPartitionCursors"))
-              .build();
+        if ((getListPartitionCursorsMethod = CursorServiceGrpc.getListPartitionCursorsMethod)
+            == null) {
+          CursorServiceGrpc.getListPartitionCursorsMethod =
+              getListPartitionCursorsMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest,
+                          com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+                      .setFullMethodName(
+                          generateFullMethodName(SERVICE_NAME, "ListPartitionCursors"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse
+                                  .getDefaultInstance()))
+                      .setSchemaDescriptor(
+                          new CursorServiceMethodDescriptorSupplier("ListPartitionCursors"))
+                      .build();
         }
       }
     }
     return getListPartitionCursorsMethod;
   }
 
-  /**
-   * Creates a new async stub that supports all call types for the service
-   */
+  /** Creates a new async stub that supports all call types for the service */
   public static CursorServiceStub newStub(io.grpc.Channel channel) {
     io.grpc.stub.AbstractStub.StubFactory<CursorServiceStub> factory =
-      new io.grpc.stub.AbstractStub.StubFactory<CursorServiceStub>() {
-        @java.lang.Override
-        public CursorServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-          return new CursorServiceStub(channel, callOptions);
-        }
-      };
+        new io.grpc.stub.AbstractStub.StubFactory<CursorServiceStub>() {
+          @java.lang.Override
+          public CursorServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new CursorServiceStub(channel, callOptions);
+          }
+        };
     return CursorServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
-  public static CursorServiceBlockingStub newBlockingStub(
-      io.grpc.Channel channel) {
+  public static CursorServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
     io.grpc.stub.AbstractStub.StubFactory<CursorServiceBlockingStub> factory =
-      new io.grpc.stub.AbstractStub.StubFactory<CursorServiceBlockingStub>() {
-        @java.lang.Override
-        public CursorServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-          return new CursorServiceBlockingStub(channel, callOptions);
-        }
-      };
+        new io.grpc.stub.AbstractStub.StubFactory<CursorServiceBlockingStub>() {
+          @java.lang.Override
+          public CursorServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new CursorServiceBlockingStub(channel, callOptions);
+          }
+        };
     return CursorServiceBlockingStub.newStub(factory, channel);
   }
 
-  /**
-   * Creates a new ListenableFuture-style stub that supports unary calls on the service
-   */
-  public static CursorServiceFutureStub newFutureStub(
-      io.grpc.Channel channel) {
+  /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
+  public static CursorServiceFutureStub newFutureStub(io.grpc.Channel channel) {
     io.grpc.stub.AbstractStub.StubFactory<CursorServiceFutureStub> factory =
-      new io.grpc.stub.AbstractStub.StubFactory<CursorServiceFutureStub>() {
-        @java.lang.Override
-        public CursorServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-          return new CursorServiceFutureStub(channel, callOptions);
-        }
-      };
+        new io.grpc.stub.AbstractStub.StubFactory<CursorServiceFutureStub>() {
+          @java.lang.Override
+          public CursorServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new CursorServiceFutureStub(channel, callOptions);
+          }
+        };
     return CursorServiceFutureStub.newStub(factory, channel);
   }
 
   /**
+   *
+   *
    * <pre>
    * The service that a subscriber client application uses to manage committed
    * cursors while receiving messsages. A cursor represents a subscriber's
    * progress within a topic partition for a given subscription.
    * </pre>
    */
-  public static abstract class CursorServiceImplBase implements io.grpc.BindableService {
+  public abstract static class CursorServiceImplBase implements io.grpc.BindableService {
 
     /**
+     *
+     *
      * <pre>
      * Establishes a stream with the server for managing committed cursors.
      * </pre>
      */
-    public io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest> streamingCommitCursor(
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse> responseObserver) {
+    public io.grpc.stub.StreamObserver<
+            com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest>
+        streamingCommitCursor(
+            io.grpc.stub.StreamObserver<
+                    com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse>
+                responseObserver) {
       return asyncUnimplementedStreamingCall(getStreamingCommitCursorMethod(), responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Updates the committed cursor.
      * </pre>
      */
-    public void commitCursor(com.google.cloud.pubsublite.proto.CommitCursorRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.CommitCursorResponse> responseObserver) {
+    public void commitCursor(
+        com.google.cloud.pubsublite.proto.CommitCursorRequest request,
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.CommitCursorResponse>
+            responseObserver) {
       asyncUnimplementedUnaryCall(getCommitCursorMethod(), responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns all committed cursor information for a subscription.
      * </pre>
      */
-    public void listPartitionCursors(com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse> responseObserver) {
+    public void listPartitionCursors(
+        com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest request,
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse>
+            responseObserver) {
       asyncUnimplementedUnaryCall(getListPartitionCursorsMethod(), responseObserver);
     }
 
-    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+    @java.lang.Override
+    public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getStreamingCommitCursorMethod(),
-            asyncBidiStreamingCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest,
-                com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse>(
-                  this, METHODID_STREAMING_COMMIT_CURSOR)))
+              getStreamingCommitCursorMethod(),
+              asyncBidiStreamingCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest,
+                      com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse>(
+                      this, METHODID_STREAMING_COMMIT_CURSOR)))
           .addMethod(
-            getCommitCursorMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.CommitCursorRequest,
-                com.google.cloud.pubsublite.proto.CommitCursorResponse>(
-                  this, METHODID_COMMIT_CURSOR)))
+              getCommitCursorMethod(),
+              asyncUnaryCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.CommitCursorRequest,
+                      com.google.cloud.pubsublite.proto.CommitCursorResponse>(
+                      this, METHODID_COMMIT_CURSOR)))
           .addMethod(
-            getListPartitionCursorsMethod(),
-            asyncUnaryCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest,
-                com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse>(
-                  this, METHODID_LIST_PARTITION_CURSORS)))
+              getListPartitionCursorsMethod(),
+              asyncUnaryCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest,
+                      com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse>(
+                      this, METHODID_LIST_PARTITION_CURSORS)))
           .build();
     }
   }
 
   /**
+   *
+   *
    * <pre>
    * The service that a subscriber client application uses to manage committed
    * cursors while receiving messsages. A cursor represents a subscriber's
    * progress within a topic partition for a given subscription.
    * </pre>
    */
-  public static final class CursorServiceStub extends io.grpc.stub.AbstractAsyncStub<CursorServiceStub> {
-    private CursorServiceStub(
-        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+  public static final class CursorServiceStub
+      extends io.grpc.stub.AbstractAsyncStub<CursorServiceStub> {
+    private CursorServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected CursorServiceStub build(
-        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+    protected CursorServiceStub build(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new CursorServiceStub(channel, callOptions);
     }
 
     /**
+     *
+     *
      * <pre>
      * Establishes a stream with the server for managing committed cursors.
      * </pre>
      */
-    public io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest> streamingCommitCursor(
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse> responseObserver) {
+    public io.grpc.stub.StreamObserver<
+            com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest>
+        streamingCommitCursor(
+            io.grpc.stub.StreamObserver<
+                    com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse>
+                responseObserver) {
       return asyncBidiStreamingCall(
-          getChannel().newCall(getStreamingCommitCursorMethod(), getCallOptions()), responseObserver);
+          getChannel().newCall(getStreamingCommitCursorMethod(), getCallOptions()),
+          responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Updates the committed cursor.
      * </pre>
      */
-    public void commitCursor(com.google.cloud.pubsublite.proto.CommitCursorRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.CommitCursorResponse> responseObserver) {
+    public void commitCursor(
+        com.google.cloud.pubsublite.proto.CommitCursorRequest request,
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.CommitCursorResponse>
+            responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCommitCursorMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getCommitCursorMethod(), getCallOptions()),
+          request,
+          responseObserver);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns all committed cursor information for a subscription.
      * </pre>
      */
-    public void listPartitionCursors(com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest request,
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse> responseObserver) {
+    public void listPartitionCursors(
+        com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest request,
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse>
+            responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListPartitionCursorsMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getListPartitionCursorsMethod(), getCallOptions()),
+          request,
+          responseObserver);
     }
   }
 
   /**
+   *
+   *
    * <pre>
    * The service that a subscriber client application uses to manage committed
    * cursors while receiving messsages. A cursor represents a subscriber's
    * progress within a topic partition for a given subscription.
    * </pre>
    */
-  public static final class CursorServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<CursorServiceBlockingStub> {
-    private CursorServiceBlockingStub(
-        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+  public static final class CursorServiceBlockingStub
+      extends io.grpc.stub.AbstractBlockingStub<CursorServiceBlockingStub> {
+    private CursorServiceBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
@@ -308,36 +394,43 @@ public final class CursorServiceGrpc {
     }
 
     /**
+     *
+     *
      * <pre>
      * Updates the committed cursor.
      * </pre>
      */
-    public com.google.cloud.pubsublite.proto.CommitCursorResponse commitCursor(com.google.cloud.pubsublite.proto.CommitCursorRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCommitCursorMethod(), getCallOptions(), request);
+    public com.google.cloud.pubsublite.proto.CommitCursorResponse commitCursor(
+        com.google.cloud.pubsublite.proto.CommitCursorRequest request) {
+      return blockingUnaryCall(getChannel(), getCommitCursorMethod(), getCallOptions(), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns all committed cursor information for a subscription.
      * </pre>
      */
-    public com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse listPartitionCursors(com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest request) {
+    public com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse listPartitionCursors(
+        com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest request) {
       return blockingUnaryCall(
           getChannel(), getListPartitionCursorsMethod(), getCallOptions(), request);
     }
   }
 
   /**
+   *
+   *
    * <pre>
    * The service that a subscriber client application uses to manage committed
    * cursors while receiving messsages. A cursor represents a subscriber's
    * progress within a topic partition for a given subscription.
    * </pre>
    */
-  public static final class CursorServiceFutureStub extends io.grpc.stub.AbstractFutureStub<CursorServiceFutureStub> {
-    private CursorServiceFutureStub(
-        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+  public static final class CursorServiceFutureStub
+      extends io.grpc.stub.AbstractFutureStub<CursorServiceFutureStub> {
+    private CursorServiceFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
@@ -348,23 +441,30 @@ public final class CursorServiceGrpc {
     }
 
     /**
+     *
+     *
      * <pre>
      * Updates the committed cursor.
      * </pre>
      */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.pubsublite.proto.CommitCursorResponse> commitCursor(
-        com.google.cloud.pubsublite.proto.CommitCursorRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<
+            com.google.cloud.pubsublite.proto.CommitCursorResponse>
+        commitCursor(com.google.cloud.pubsublite.proto.CommitCursorRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getCommitCursorMethod(), getCallOptions()), request);
     }
 
     /**
+     *
+     *
      * <pre>
      * Returns all committed cursor information for a subscription.
      * </pre>
      */
-    public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse> listPartitionCursors(
-        com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<
+            com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse>
+        listPartitionCursors(
+            com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getListPartitionCursorsMethod(), getCallOptions()), request);
     }
@@ -374,11 +474,11 @@ public final class CursorServiceGrpc {
   private static final int METHODID_LIST_PARTITION_CURSORS = 1;
   private static final int METHODID_STREAMING_COMMIT_CURSOR = 2;
 
-  private static final class MethodHandlers<Req, Resp> implements
-      io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
-      io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
-      io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
-      io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
+  private static final class MethodHandlers<Req, Resp>
+      implements io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
+          io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
+          io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
+          io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
     private final CursorServiceImplBase serviceImpl;
     private final int methodId;
 
@@ -392,12 +492,17 @@ public final class CursorServiceGrpc {
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
         case METHODID_COMMIT_CURSOR:
-          serviceImpl.commitCursor((com.google.cloud.pubsublite.proto.CommitCursorRequest) request,
-              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.CommitCursorResponse>) responseObserver);
+          serviceImpl.commitCursor(
+              (com.google.cloud.pubsublite.proto.CommitCursorRequest) request,
+              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.CommitCursorResponse>)
+                  responseObserver);
           break;
         case METHODID_LIST_PARTITION_CURSORS:
-          serviceImpl.listPartitionCursors((com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest) request,
-              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse>) responseObserver);
+          serviceImpl.listPartitionCursors(
+              (com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest) request,
+              (io.grpc.stub.StreamObserver<
+                      com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse>)
+                  responseObserver);
           break;
         default:
           throw new AssertionError();
@@ -410,16 +515,20 @@ public final class CursorServiceGrpc {
         io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
         case METHODID_STREAMING_COMMIT_CURSOR:
-          return (io.grpc.stub.StreamObserver<Req>) serviceImpl.streamingCommitCursor(
-              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse>) responseObserver);
+          return (io.grpc.stub.StreamObserver<Req>)
+              serviceImpl.streamingCommitCursor(
+                  (io.grpc.stub.StreamObserver<
+                          com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse>)
+                      responseObserver);
         default:
           throw new AssertionError();
       }
     }
   }
 
-  private static abstract class CursorServiceBaseDescriptorSupplier
-      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private abstract static class CursorServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier,
+          io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     CursorServiceBaseDescriptorSupplier() {}
 
     @java.lang.Override
@@ -461,12 +570,14 @@ public final class CursorServiceGrpc {
       synchronized (CursorServiceGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
-          serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new CursorServiceFileDescriptorSupplier())
-              .addMethod(getStreamingCommitCursorMethod())
-              .addMethod(getCommitCursorMethod())
-              .addMethod(getListPartitionCursorsMethod())
-              .build();
+          serviceDescriptor =
+              result =
+                  io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
+                      .setSchemaDescriptor(new CursorServiceFileDescriptorSupplier())
+                      .addMethod(getStreamingCommitCursorMethod())
+                      .addMethod(getCommitCursorMethod())
+                      .addMethod(getListPartitionCursorsMethod())
+                      .build();
         }
       }
     }

--- a/grpc-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PublisherServiceGrpc.java
+++ b/grpc-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PublisherServiceGrpc.java
@@ -2,20 +2,12 @@ package com.google.cloud.pubsublite.proto;
 
 import static io.grpc.MethodDescriptor.generateFullMethodName;
 import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
-import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
-import static io.grpc.stub.ClientCalls.asyncUnaryCall;
-import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
-import static io.grpc.stub.ClientCalls.blockingUnaryCall;
-import static io.grpc.stub.ClientCalls.futureUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
 
 /**
+ *
+ *
  * <pre>
  * The service that a publisher client application uses to publish messages to
  * topics. Published messages are retained by the service for the duration of
@@ -33,82 +25,96 @@ public final class PublisherServiceGrpc {
   public static final String SERVICE_NAME = "google.cloud.pubsublite.v1.PublisherService";
 
   // Static method descriptors that strictly reflect the proto.
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.PublishRequest,
-      com.google.cloud.pubsublite.proto.PublishResponse> getPublishMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.PublishRequest,
+          com.google.cloud.pubsublite.proto.PublishResponse>
+      getPublishMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "Publish",
       requestType = com.google.cloud.pubsublite.proto.PublishRequest.class,
       responseType = com.google.cloud.pubsublite.proto.PublishResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.PublishRequest,
-      com.google.cloud.pubsublite.proto.PublishResponse> getPublishMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.PublishRequest, com.google.cloud.pubsublite.proto.PublishResponse> getPublishMethod;
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.PublishRequest,
+          com.google.cloud.pubsublite.proto.PublishResponse>
+      getPublishMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.PublishRequest,
+            com.google.cloud.pubsublite.proto.PublishResponse>
+        getPublishMethod;
     if ((getPublishMethod = PublisherServiceGrpc.getPublishMethod) == null) {
       synchronized (PublisherServiceGrpc.class) {
         if ((getPublishMethod = PublisherServiceGrpc.getPublishMethod) == null) {
-          PublisherServiceGrpc.getPublishMethod = getPublishMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.PublishRequest, com.google.cloud.pubsublite.proto.PublishResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Publish"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.PublishRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.PublishResponse.getDefaultInstance()))
-              .setSchemaDescriptor(new PublisherServiceMethodDescriptorSupplier("Publish"))
-              .build();
+          PublisherServiceGrpc.getPublishMethod =
+              getPublishMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.PublishRequest,
+                          com.google.cloud.pubsublite.proto.PublishResponse>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Publish"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.PublishRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.PublishResponse
+                                  .getDefaultInstance()))
+                      .setSchemaDescriptor(new PublisherServiceMethodDescriptorSupplier("Publish"))
+                      .build();
         }
       }
     }
     return getPublishMethod;
   }
 
-  /**
-   * Creates a new async stub that supports all call types for the service
-   */
+  /** Creates a new async stub that supports all call types for the service */
   public static PublisherServiceStub newStub(io.grpc.Channel channel) {
     io.grpc.stub.AbstractStub.StubFactory<PublisherServiceStub> factory =
-      new io.grpc.stub.AbstractStub.StubFactory<PublisherServiceStub>() {
-        @java.lang.Override
-        public PublisherServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-          return new PublisherServiceStub(channel, callOptions);
-        }
-      };
+        new io.grpc.stub.AbstractStub.StubFactory<PublisherServiceStub>() {
+          @java.lang.Override
+          public PublisherServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new PublisherServiceStub(channel, callOptions);
+          }
+        };
     return PublisherServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
-  public static PublisherServiceBlockingStub newBlockingStub(
-      io.grpc.Channel channel) {
+  public static PublisherServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
     io.grpc.stub.AbstractStub.StubFactory<PublisherServiceBlockingStub> factory =
-      new io.grpc.stub.AbstractStub.StubFactory<PublisherServiceBlockingStub>() {
-        @java.lang.Override
-        public PublisherServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-          return new PublisherServiceBlockingStub(channel, callOptions);
-        }
-      };
+        new io.grpc.stub.AbstractStub.StubFactory<PublisherServiceBlockingStub>() {
+          @java.lang.Override
+          public PublisherServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new PublisherServiceBlockingStub(channel, callOptions);
+          }
+        };
     return PublisherServiceBlockingStub.newStub(factory, channel);
   }
 
-  /**
-   * Creates a new ListenableFuture-style stub that supports unary calls on the service
-   */
-  public static PublisherServiceFutureStub newFutureStub(
-      io.grpc.Channel channel) {
+  /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
+  public static PublisherServiceFutureStub newFutureStub(io.grpc.Channel channel) {
     io.grpc.stub.AbstractStub.StubFactory<PublisherServiceFutureStub> factory =
-      new io.grpc.stub.AbstractStub.StubFactory<PublisherServiceFutureStub>() {
-        @java.lang.Override
-        public PublisherServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-          return new PublisherServiceFutureStub(channel, callOptions);
-        }
-      };
+        new io.grpc.stub.AbstractStub.StubFactory<PublisherServiceFutureStub>() {
+          @java.lang.Override
+          public PublisherServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new PublisherServiceFutureStub(channel, callOptions);
+          }
+        };
     return PublisherServiceFutureStub.newStub(factory, channel);
   }
 
   /**
+   *
+   *
    * <pre>
    * The service that a publisher client application uses to publish messages to
    * topics. Published messages are retained by the service for the duration of
@@ -116,9 +122,11 @@ public final class PublisherServiceGrpc {
    * to subscriber clients upon request (via the `SubscriberService`).
    * </pre>
    */
-  public static abstract class PublisherServiceImplBase implements io.grpc.BindableService {
+  public abstract static class PublisherServiceImplBase implements io.grpc.BindableService {
 
     /**
+     *
+     *
      * <pre>
      * Establishes a stream with the server for publishing messages. Once the
      * stream is initialized, the client publishes messages by sending publish
@@ -130,24 +138,27 @@ public final class PublisherServiceGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.PublishRequest> publish(
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.PublishResponse> responseObserver) {
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.PublishResponse>
+            responseObserver) {
       return asyncUnimplementedStreamingCall(getPublishMethod(), responseObserver);
     }
 
-    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+    @java.lang.Override
+    public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getPublishMethod(),
-            asyncBidiStreamingCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.PublishRequest,
-                com.google.cloud.pubsublite.proto.PublishResponse>(
-                  this, METHODID_PUBLISH)))
+              getPublishMethod(),
+              asyncBidiStreamingCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.PublishRequest,
+                      com.google.cloud.pubsublite.proto.PublishResponse>(this, METHODID_PUBLISH)))
           .build();
     }
   }
 
   /**
+   *
+   *
    * <pre>
    * The service that a publisher client application uses to publish messages to
    * topics. Published messages are retained by the service for the duration of
@@ -155,19 +166,20 @@ public final class PublisherServiceGrpc {
    * to subscriber clients upon request (via the `SubscriberService`).
    * </pre>
    */
-  public static final class PublisherServiceStub extends io.grpc.stub.AbstractAsyncStub<PublisherServiceStub> {
-    private PublisherServiceStub(
-        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+  public static final class PublisherServiceStub
+      extends io.grpc.stub.AbstractAsyncStub<PublisherServiceStub> {
+    private PublisherServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
     @java.lang.Override
-    protected PublisherServiceStub build(
-        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+    protected PublisherServiceStub build(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new PublisherServiceStub(channel, callOptions);
     }
 
     /**
+     *
+     *
      * <pre>
      * Establishes a stream with the server for publishing messages. Once the
      * stream is initialized, the client publishes messages by sending publish
@@ -179,13 +191,16 @@ public final class PublisherServiceGrpc {
      * </pre>
      */
     public io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.PublishRequest> publish(
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.PublishResponse> responseObserver) {
+        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.PublishResponse>
+            responseObserver) {
       return asyncBidiStreamingCall(
           getChannel().newCall(getPublishMethod(), getCallOptions()), responseObserver);
     }
   }
 
   /**
+   *
+   *
    * <pre>
    * The service that a publisher client application uses to publish messages to
    * topics. Published messages are retained by the service for the duration of
@@ -193,9 +208,9 @@ public final class PublisherServiceGrpc {
    * to subscriber clients upon request (via the `SubscriberService`).
    * </pre>
    */
-  public static final class PublisherServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<PublisherServiceBlockingStub> {
-    private PublisherServiceBlockingStub(
-        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+  public static final class PublisherServiceBlockingStub
+      extends io.grpc.stub.AbstractBlockingStub<PublisherServiceBlockingStub> {
+    private PublisherServiceBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
@@ -207,6 +222,8 @@ public final class PublisherServiceGrpc {
   }
 
   /**
+   *
+   *
    * <pre>
    * The service that a publisher client application uses to publish messages to
    * topics. Published messages are retained by the service for the duration of
@@ -214,9 +231,9 @@ public final class PublisherServiceGrpc {
    * to subscriber clients upon request (via the `SubscriberService`).
    * </pre>
    */
-  public static final class PublisherServiceFutureStub extends io.grpc.stub.AbstractFutureStub<PublisherServiceFutureStub> {
-    private PublisherServiceFutureStub(
-        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+  public static final class PublisherServiceFutureStub
+      extends io.grpc.stub.AbstractFutureStub<PublisherServiceFutureStub> {
+    private PublisherServiceFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
@@ -229,11 +246,11 @@ public final class PublisherServiceGrpc {
 
   private static final int METHODID_PUBLISH = 0;
 
-  private static final class MethodHandlers<Req, Resp> implements
-      io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
-      io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
-      io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
-      io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
+  private static final class MethodHandlers<Req, Resp>
+      implements io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
+          io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
+          io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
+          io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
     private final PublisherServiceImplBase serviceImpl;
     private final int methodId;
 
@@ -257,16 +274,19 @@ public final class PublisherServiceGrpc {
         io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
         case METHODID_PUBLISH:
-          return (io.grpc.stub.StreamObserver<Req>) serviceImpl.publish(
-              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.PublishResponse>) responseObserver);
+          return (io.grpc.stub.StreamObserver<Req>)
+              serviceImpl.publish(
+                  (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.PublishResponse>)
+                      responseObserver);
         default:
           throw new AssertionError();
       }
     }
   }
 
-  private static abstract class PublisherServiceBaseDescriptorSupplier
-      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private abstract static class PublisherServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier,
+          io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     PublisherServiceBaseDescriptorSupplier() {}
 
     @java.lang.Override
@@ -308,10 +328,12 @@ public final class PublisherServiceGrpc {
       synchronized (PublisherServiceGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
-          serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new PublisherServiceFileDescriptorSupplier())
-              .addMethod(getPublishMethod())
-              .build();
+          serviceDescriptor =
+              result =
+                  io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
+                      .setSchemaDescriptor(new PublisherServiceFileDescriptorSupplier())
+                      .addMethod(getPublishMethod())
+                      .build();
         }
       }
     }

--- a/grpc-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SubscriberServiceGrpc.java
+++ b/grpc-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SubscriberServiceGrpc.java
@@ -2,20 +2,12 @@ package com.google.cloud.pubsublite.proto;
 
 import static io.grpc.MethodDescriptor.generateFullMethodName;
 import static io.grpc.stub.ClientCalls.asyncBidiStreamingCall;
-import static io.grpc.stub.ClientCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
-import static io.grpc.stub.ClientCalls.asyncUnaryCall;
-import static io.grpc.stub.ClientCalls.blockingServerStreamingCall;
-import static io.grpc.stub.ClientCalls.blockingUnaryCall;
-import static io.grpc.stub.ClientCalls.futureUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncBidiStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncClientStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncServerStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncUnaryCall;
 import static io.grpc.stub.ServerCalls.asyncUnimplementedStreamingCall;
-import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
 
 /**
+ *
+ *
  * <pre>
  * The service that a subscriber client application uses to receive messages
  * from subscriptions.
@@ -31,121 +23,143 @@ public final class SubscriberServiceGrpc {
   public static final String SERVICE_NAME = "google.cloud.pubsublite.v1.SubscriberService";
 
   // Static method descriptors that strictly reflect the proto.
-  private static volatile io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.SubscribeRequest,
-      com.google.cloud.pubsublite.proto.SubscribeResponse> getSubscribeMethod;
+  private static volatile io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.SubscribeRequest,
+          com.google.cloud.pubsublite.proto.SubscribeResponse>
+      getSubscribeMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "Subscribe",
       requestType = com.google.cloud.pubsublite.proto.SubscribeRequest.class,
       responseType = com.google.cloud.pubsublite.proto.SubscribeResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-  public static io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.SubscribeRequest,
-      com.google.cloud.pubsublite.proto.SubscribeResponse> getSubscribeMethod() {
-    io.grpc.MethodDescriptor<com.google.cloud.pubsublite.proto.SubscribeRequest, com.google.cloud.pubsublite.proto.SubscribeResponse> getSubscribeMethod;
+  public static io.grpc.MethodDescriptor<
+          com.google.cloud.pubsublite.proto.SubscribeRequest,
+          com.google.cloud.pubsublite.proto.SubscribeResponse>
+      getSubscribeMethod() {
+    io.grpc.MethodDescriptor<
+            com.google.cloud.pubsublite.proto.SubscribeRequest,
+            com.google.cloud.pubsublite.proto.SubscribeResponse>
+        getSubscribeMethod;
     if ((getSubscribeMethod = SubscriberServiceGrpc.getSubscribeMethod) == null) {
       synchronized (SubscriberServiceGrpc.class) {
         if ((getSubscribeMethod = SubscriberServiceGrpc.getSubscribeMethod) == null) {
-          SubscriberServiceGrpc.getSubscribeMethod = getSubscribeMethod =
-              io.grpc.MethodDescriptor.<com.google.cloud.pubsublite.proto.SubscribeRequest, com.google.cloud.pubsublite.proto.SubscribeResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Subscribe"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.SubscribeRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  com.google.cloud.pubsublite.proto.SubscribeResponse.getDefaultInstance()))
-              .setSchemaDescriptor(new SubscriberServiceMethodDescriptorSupplier("Subscribe"))
-              .build();
+          SubscriberServiceGrpc.getSubscribeMethod =
+              getSubscribeMethod =
+                  io.grpc.MethodDescriptor
+                      .<com.google.cloud.pubsublite.proto.SubscribeRequest,
+                          com.google.cloud.pubsublite.proto.SubscribeResponse>
+                          newBuilder()
+                      .setType(io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING)
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Subscribe"))
+                      .setSampledToLocalTracing(true)
+                      .setRequestMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.SubscribeRequest
+                                  .getDefaultInstance()))
+                      .setResponseMarshaller(
+                          io.grpc.protobuf.ProtoUtils.marshaller(
+                              com.google.cloud.pubsublite.proto.SubscribeResponse
+                                  .getDefaultInstance()))
+                      .setSchemaDescriptor(
+                          new SubscriberServiceMethodDescriptorSupplier("Subscribe"))
+                      .build();
         }
       }
     }
     return getSubscribeMethod;
   }
 
-  /**
-   * Creates a new async stub that supports all call types for the service
-   */
+  /** Creates a new async stub that supports all call types for the service */
   public static SubscriberServiceStub newStub(io.grpc.Channel channel) {
     io.grpc.stub.AbstractStub.StubFactory<SubscriberServiceStub> factory =
-      new io.grpc.stub.AbstractStub.StubFactory<SubscriberServiceStub>() {
-        @java.lang.Override
-        public SubscriberServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-          return new SubscriberServiceStub(channel, callOptions);
-        }
-      };
+        new io.grpc.stub.AbstractStub.StubFactory<SubscriberServiceStub>() {
+          @java.lang.Override
+          public SubscriberServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SubscriberServiceStub(channel, callOptions);
+          }
+        };
     return SubscriberServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
-  public static SubscriberServiceBlockingStub newBlockingStub(
-      io.grpc.Channel channel) {
+  public static SubscriberServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
     io.grpc.stub.AbstractStub.StubFactory<SubscriberServiceBlockingStub> factory =
-      new io.grpc.stub.AbstractStub.StubFactory<SubscriberServiceBlockingStub>() {
-        @java.lang.Override
-        public SubscriberServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-          return new SubscriberServiceBlockingStub(channel, callOptions);
-        }
-      };
+        new io.grpc.stub.AbstractStub.StubFactory<SubscriberServiceBlockingStub>() {
+          @java.lang.Override
+          public SubscriberServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SubscriberServiceBlockingStub(channel, callOptions);
+          }
+        };
     return SubscriberServiceBlockingStub.newStub(factory, channel);
   }
 
-  /**
-   * Creates a new ListenableFuture-style stub that supports unary calls on the service
-   */
-  public static SubscriberServiceFutureStub newFutureStub(
-      io.grpc.Channel channel) {
+  /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
+  public static SubscriberServiceFutureStub newFutureStub(io.grpc.Channel channel) {
     io.grpc.stub.AbstractStub.StubFactory<SubscriberServiceFutureStub> factory =
-      new io.grpc.stub.AbstractStub.StubFactory<SubscriberServiceFutureStub>() {
-        @java.lang.Override
-        public SubscriberServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
-          return new SubscriberServiceFutureStub(channel, callOptions);
-        }
-      };
+        new io.grpc.stub.AbstractStub.StubFactory<SubscriberServiceFutureStub>() {
+          @java.lang.Override
+          public SubscriberServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SubscriberServiceFutureStub(channel, callOptions);
+          }
+        };
     return SubscriberServiceFutureStub.newStub(factory, channel);
   }
 
   /**
+   *
+   *
    * <pre>
    * The service that a subscriber client application uses to receive messages
    * from subscriptions.
    * </pre>
    */
-  public static abstract class SubscriberServiceImplBase implements io.grpc.BindableService {
+  public abstract static class SubscriberServiceImplBase implements io.grpc.BindableService {
 
     /**
+     *
+     *
      * <pre>
      * Establishes a stream with the server for receiving messages.
      * </pre>
      */
-    public io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.SubscribeRequest> subscribe(
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.SubscribeResponse> responseObserver) {
+    public io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.SubscribeRequest>
+        subscribe(
+            io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.SubscribeResponse>
+                responseObserver) {
       return asyncUnimplementedStreamingCall(getSubscribeMethod(), responseObserver);
     }
 
-    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
+    @java.lang.Override
+    public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            getSubscribeMethod(),
-            asyncBidiStreamingCall(
-              new MethodHandlers<
-                com.google.cloud.pubsublite.proto.SubscribeRequest,
-                com.google.cloud.pubsublite.proto.SubscribeResponse>(
-                  this, METHODID_SUBSCRIBE)))
+              getSubscribeMethod(),
+              asyncBidiStreamingCall(
+                  new MethodHandlers<
+                      com.google.cloud.pubsublite.proto.SubscribeRequest,
+                      com.google.cloud.pubsublite.proto.SubscribeResponse>(
+                      this, METHODID_SUBSCRIBE)))
           .build();
     }
   }
 
   /**
+   *
+   *
    * <pre>
    * The service that a subscriber client application uses to receive messages
    * from subscriptions.
    * </pre>
    */
-  public static final class SubscriberServiceStub extends io.grpc.stub.AbstractAsyncStub<SubscriberServiceStub> {
-    private SubscriberServiceStub(
-        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+  public static final class SubscriberServiceStub
+      extends io.grpc.stub.AbstractAsyncStub<SubscriberServiceStub> {
+    private SubscriberServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
@@ -156,24 +170,31 @@ public final class SubscriberServiceGrpc {
     }
 
     /**
+     *
+     *
      * <pre>
      * Establishes a stream with the server for receiving messages.
      * </pre>
      */
-    public io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.SubscribeRequest> subscribe(
-        io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.SubscribeResponse> responseObserver) {
+    public io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.SubscribeRequest>
+        subscribe(
+            io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.SubscribeResponse>
+                responseObserver) {
       return asyncBidiStreamingCall(
           getChannel().newCall(getSubscribeMethod(), getCallOptions()), responseObserver);
     }
   }
 
   /**
+   *
+   *
    * <pre>
    * The service that a subscriber client application uses to receive messages
    * from subscriptions.
    * </pre>
    */
-  public static final class SubscriberServiceBlockingStub extends io.grpc.stub.AbstractBlockingStub<SubscriberServiceBlockingStub> {
+  public static final class SubscriberServiceBlockingStub
+      extends io.grpc.stub.AbstractBlockingStub<SubscriberServiceBlockingStub> {
     private SubscriberServiceBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -187,14 +208,16 @@ public final class SubscriberServiceGrpc {
   }
 
   /**
+   *
+   *
    * <pre>
    * The service that a subscriber client application uses to receive messages
    * from subscriptions.
    * </pre>
    */
-  public static final class SubscriberServiceFutureStub extends io.grpc.stub.AbstractFutureStub<SubscriberServiceFutureStub> {
-    private SubscriberServiceFutureStub(
-        io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+  public static final class SubscriberServiceFutureStub
+      extends io.grpc.stub.AbstractFutureStub<SubscriberServiceFutureStub> {
+    private SubscriberServiceFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
 
@@ -207,11 +230,11 @@ public final class SubscriberServiceGrpc {
 
   private static final int METHODID_SUBSCRIBE = 0;
 
-  private static final class MethodHandlers<Req, Resp> implements
-      io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
-      io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
-      io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
-      io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
+  private static final class MethodHandlers<Req, Resp>
+      implements io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
+          io.grpc.stub.ServerCalls.ServerStreamingMethod<Req, Resp>,
+          io.grpc.stub.ServerCalls.ClientStreamingMethod<Req, Resp>,
+          io.grpc.stub.ServerCalls.BidiStreamingMethod<Req, Resp> {
     private final SubscriberServiceImplBase serviceImpl;
     private final int methodId;
 
@@ -235,16 +258,19 @@ public final class SubscriberServiceGrpc {
         io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
         case METHODID_SUBSCRIBE:
-          return (io.grpc.stub.StreamObserver<Req>) serviceImpl.subscribe(
-              (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.SubscribeResponse>) responseObserver);
+          return (io.grpc.stub.StreamObserver<Req>)
+              serviceImpl.subscribe(
+                  (io.grpc.stub.StreamObserver<com.google.cloud.pubsublite.proto.SubscribeResponse>)
+                      responseObserver);
         default:
           throw new AssertionError();
       }
     }
   }
 
-  private static abstract class SubscriberServiceBaseDescriptorSupplier
-      implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
+  private abstract static class SubscriberServiceBaseDescriptorSupplier
+      implements io.grpc.protobuf.ProtoFileDescriptorSupplier,
+          io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     SubscriberServiceBaseDescriptorSupplier() {}
 
     @java.lang.Override
@@ -286,10 +312,12 @@ public final class SubscriberServiceGrpc {
       synchronized (SubscriberServiceGrpc.class) {
         result = serviceDescriptor;
         if (result == null) {
-          serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
-              .setSchemaDescriptor(new SubscriberServiceFileDescriptorSupplier())
-              .addMethod(getSubscribeMethod())
-              .build();
+          serviceDescriptor =
+              result =
+                  io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
+                      .setSchemaDescriptor(new SubscriberServiceFileDescriptorSupplier())
+                      .addMethod(getSubscribeMethod())
+                      .build();
         }
       }
     }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/AdminProto.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/AdminProto.java
@@ -5,332 +5,347 @@ package com.google.cloud.pubsublite.proto;
 
 public final class AdminProto {
   private AdminProto() {}
-  public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistryLite registry) {
+
+  public static void registerAllExtensions(com.google.protobuf.ExtensionRegistryLite registry) {}
+
+  public static void registerAllExtensions(com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions((com.google.protobuf.ExtensionRegistryLite) registry);
   }
 
-  public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
-    registerAllExtensions(
-        (com.google.protobuf.ExtensionRegistryLite) registry);
-  }
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_GetTopicRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_GetTopicRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_GetTopicRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_TopicPartitions_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_TopicPartitions_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_TopicPartitions_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_fieldAccessorTable;
 
-  public static com.google.protobuf.Descriptors.FileDescriptor
-      getDescriptor() {
+  public static com.google.protobuf.Descriptors.FileDescriptor getDescriptor() {
     return descriptor;
   }
-  private static  com.google.protobuf.Descriptors.FileDescriptor
-      descriptor;
+
+  private static com.google.protobuf.Descriptors.FileDescriptor descriptor;
+
   static {
     java.lang.String[] descriptorData = {
-      "\n&google/cloud/pubsublite/v1/admin.proto" +
-      "\022\032google.cloud.pubsublite.v1\032\034google/api" +
-      "/annotations.proto\032\027google/api/client.pr" +
-      "oto\032\037google/api/field_behavior.proto\032\031go" +
-      "ogle/api/resource.proto\032\'google/cloud/pu" +
-      "bsublite/v1/common.proto\032\033google/protobu" +
-      "f/empty.proto\032 google/protobuf/field_mas" +
-      "k.proto\"\235\001\n\022CreateTopicRequest\0229\n\006parent" +
-      "\030\001 \001(\tB)\340A\002\372A#\n!locations.googleapis.com" +
-      "/Location\0225\n\005topic\030\002 \001(\0132!.google.cloud." +
-      "pubsublite.v1.TopicB\003\340A\002\022\025\n\010topic_id\030\003 \001" +
-      "(\tB\003\340A\002\"H\n\017GetTopicRequest\0225\n\004name\030\001 \001(\t" +
-      "B\'\340A\002\372A!\n\037pubsublite.googleapis.com/Topi" +
-      "c\"R\n\031GetTopicPartitionsRequest\0225\n\004name\030\001" +
-      " \001(\tB\'\340A\002\372A!\n\037pubsublite.googleapis.com/" +
-      "Topic\"*\n\017TopicPartitions\022\027\n\017partition_co" +
-      "unt\030\001 \001(\003\"u\n\021ListTopicsRequest\0229\n\006parent" +
-      "\030\001 \001(\tB)\340A\002\372A#\n!locations.googleapis.com" +
-      "/Location\022\021\n\tpage_size\030\002 \001(\005\022\022\n\npage_tok" +
-      "en\030\003 \001(\t\"`\n\022ListTopicsResponse\0221\n\006topics" +
-      "\030\001 \003(\0132!.google.cloud.pubsublite.v1.Topi" +
-      "c\022\027\n\017next_page_token\030\002 \001(\t\"\201\001\n\022UpdateTop" +
-      "icRequest\0225\n\005topic\030\001 \001(\0132!.google.cloud." +
-      "pubsublite.v1.TopicB\003\340A\002\0224\n\013update_mask\030" +
-      "\002 \001(\0132\032.google.protobuf.FieldMaskB\003\340A\002\"K" +
-      "\n\022DeleteTopicRequest\0225\n\004name\030\001 \001(\tB\'\340A\002\372" +
-      "A!\n\037pubsublite.googleapis.com/Topic\"}\n\035L" +
-      "istTopicSubscriptionsRequest\0225\n\004name\030\001 \001" +
-      "(\tB\'\340A\002\372A!\n\037pubsublite.googleapis.com/To" +
-      "pic\022\021\n\tpage_size\030\002 \001(\005\022\022\n\npage_token\030\003 \001" +
-      "(\t\"P\n\036ListTopicSubscriptionsResponse\022\025\n\r" +
-      "subscriptions\030\001 \003(\t\022\027\n\017next_page_token\030\002" +
-      " \001(\t\"\271\001\n\031CreateSubscriptionRequest\0229\n\006pa" +
-      "rent\030\001 \001(\tB)\340A\002\372A#\n!locations.googleapis" +
-      ".com/Location\022C\n\014subscription\030\002 \001(\0132(.go" +
-      "ogle.cloud.pubsublite.v1.SubscriptionB\003\340" +
-      "A\002\022\034\n\017subscription_id\030\003 \001(\tB\003\340A\002\"V\n\026GetS" +
-      "ubscriptionRequest\022<\n\004name\030\001 \001(\tB.\340A\002\372A(" +
-      "\n&pubsublite.googleapis.com/Subscription" +
-      "\"|\n\030ListSubscriptionsRequest\0229\n\006parent\030\001" +
-      " \001(\tB)\340A\002\372A#\n!locations.googleapis.com/L" +
-      "ocation\022\021\n\tpage_size\030\002 \001(\005\022\022\n\npage_token" +
-      "\030\003 \001(\t\"u\n\031ListSubscriptionsResponse\022?\n\rs" +
-      "ubscriptions\030\001 \003(\0132(.google.cloud.pubsub" +
-      "lite.v1.Subscription\022\027\n\017next_page_token\030" +
-      "\002 \001(\t\"\226\001\n\031UpdateSubscriptionRequest\022C\n\014s" +
-      "ubscription\030\001 \001(\0132(.google.cloud.pubsubl" +
-      "ite.v1.SubscriptionB\003\340A\002\0224\n\013update_mask\030" +
-      "\002 \001(\0132\032.google.protobuf.FieldMaskB\003\340A\002\"Y" +
-      "\n\031DeleteSubscriptionRequest\022<\n\004name\030\001 \001(" +
-      "\tB.\340A\002\372A(\n&pubsublite.googleapis.com/Sub" +
-      "scription2\251\022\n\014AdminService\022\271\001\n\013CreateTop" +
-      "ic\022..google.cloud.pubsublite.v1.CreateTo" +
-      "picRequest\032!.google.cloud.pubsublite.v1." +
-      "Topic\"W\202\323\344\223\0029\"0/v1/admin/{parent=project" +
-      "s/*/locations/*}/topics:\005topic\332A\025parent," +
-      "topic,topic_id\022\233\001\n\010GetTopic\022+.google.clo" +
-      "ud.pubsublite.v1.GetTopicRequest\032!.googl" +
-      "e.cloud.pubsublite.v1.Topic\"?\202\323\344\223\0022\0220/v1" +
-      "/admin/{name=projects/*/locations/*/topi" +
-      "cs/*}\332A\004name\022\304\001\n\022GetTopicPartitions\0225.go" +
-      "ogle.cloud.pubsublite.v1.GetTopicPartiti" +
-      "onsRequest\032+.google.cloud.pubsublite.v1." +
-      "TopicPartitions\"J\202\323\344\223\002=\022;/v1/admin/{name" +
-      "=projects/*/locations/*/topics/*}/partit" +
-      "ions\332A\004name\022\256\001\n\nListTopics\022-.google.clou" +
-      "d.pubsublite.v1.ListTopicsRequest\032..goog" +
-      "le.cloud.pubsublite.v1.ListTopicsRespons" +
-      "e\"A\202\323\344\223\0022\0220/v1/admin/{parent=projects/*/" +
-      "locations/*}/topics\332A\006parent\022\273\001\n\013UpdateT" +
-      "opic\022..google.cloud.pubsublite.v1.Update" +
-      "TopicRequest\032!.google.cloud.pubsublite.v" +
-      "1.Topic\"Y\202\323\344\223\002?26/v1/admin/{topic.name=p" +
-      "rojects/*/locations/*/topics/*}:\005topic\332A" +
-      "\021topic,update_mask\022\226\001\n\013DeleteTopic\022..goo" +
-      "gle.cloud.pubsublite.v1.DeleteTopicReque" +
-      "st\032\026.google.protobuf.Empty\"?\202\323\344\223\0022*0/v1/" +
-      "admin/{name=projects/*/locations/*/topic" +
-      "s/*}\332A\004name\022\336\001\n\026ListTopicSubscriptions\0229" +
-      ".google.cloud.pubsublite.v1.ListTopicSub" +
-      "scriptionsRequest\032:.google.cloud.pubsubl" +
-      "ite.v1.ListTopicSubscriptionsResponse\"M\202" +
-      "\323\344\223\002@\022>/v1/admin/{name=projects/*/locati" +
-      "ons/*/topics/*}/subscriptions\332A\004name\022\352\001\n" +
-      "\022CreateSubscription\0225.google.cloud.pubsu" +
-      "blite.v1.CreateSubscriptionRequest\032(.goo" +
-      "gle.cloud.pubsublite.v1.Subscription\"s\202\323" +
-      "\344\223\002G\"7/v1/admin/{parent=projects/*/locat" +
-      "ions/*}/subscriptions:\014subscription\332A#pa" +
-      "rent,subscription,subscription_id\022\267\001\n\017Ge" +
-      "tSubscription\0222.google.cloud.pubsublite." +
-      "v1.GetSubscriptionRequest\032(.google.cloud" +
-      ".pubsublite.v1.Subscription\"F\202\323\344\223\0029\0227/v1" +
-      "/admin/{name=projects/*/locations/*/subs" +
-      "criptions/*}\332A\004name\022\312\001\n\021ListSubscription" +
-      "s\0224.google.cloud.pubsublite.v1.ListSubsc" +
-      "riptionsRequest\0325.google.cloud.pubsublit" +
-      "e.v1.ListSubscriptionsResponse\"H\202\323\344\223\0029\0227" +
-      "/v1/admin/{parent=projects/*/locations/*" +
-      "}/subscriptions\332A\006parent\022\354\001\n\022UpdateSubsc" +
-      "ription\0225.google.cloud.pubsublite.v1.Upd" +
-      "ateSubscriptionRequest\032(.google.cloud.pu" +
-      "bsublite.v1.Subscription\"u\202\323\344\223\002T2D/v1/ad" +
-      "min/{subscription.name=projects/*/locati" +
-      "ons/*/subscriptions/*}:\014subscription\332A\030s" +
-      "ubscription,update_mask\022\253\001\n\022DeleteSubscr" +
-      "iption\0225.google.cloud.pubsublite.v1.Dele" +
-      "teSubscriptionRequest\032\026.google.protobuf." +
-      "Empty\"F\202\323\344\223\0029*7/v1/admin/{name=projects/" +
-      "*/locations/*/subscriptions/*}\332A\004nameB1\n" +
-      "!com.google.cloud.pubsublite.protoB\nAdmi" +
-      "nProtoP\001b\006proto3"
+      "\n&google/cloud/pubsublite/v1/admin.proto"
+          + "\022\032google.cloud.pubsublite.v1\032\034google/api"
+          + "/annotations.proto\032\027google/api/client.pr"
+          + "oto\032\037google/api/field_behavior.proto\032\031go"
+          + "ogle/api/resource.proto\032\'google/cloud/pu"
+          + "bsublite/v1/common.proto\032\033google/protobu"
+          + "f/empty.proto\032 google/protobuf/field_mas"
+          + "k.proto\"\235\001\n\022CreateTopicRequest\0229\n\006parent"
+          + "\030\001 \001(\tB)\340A\002\372A#\n!locations.googleapis.com"
+          + "/Location\0225\n\005topic\030\002 \001(\0132!.google.cloud."
+          + "pubsublite.v1.TopicB\003\340A\002\022\025\n\010topic_id\030\003 \001"
+          + "(\tB\003\340A\002\"H\n\017GetTopicRequest\0225\n\004name\030\001 \001(\t"
+          + "B\'\340A\002\372A!\n\037pubsublite.googleapis.com/Topi"
+          + "c\"R\n\031GetTopicPartitionsRequest\0225\n\004name\030\001"
+          + " \001(\tB\'\340A\002\372A!\n\037pubsublite.googleapis.com/"
+          + "Topic\"*\n\017TopicPartitions\022\027\n\017partition_co"
+          + "unt\030\001 \001(\003\"u\n\021ListTopicsRequest\0229\n\006parent"
+          + "\030\001 \001(\tB)\340A\002\372A#\n!locations.googleapis.com"
+          + "/Location\022\021\n\tpage_size\030\002 \001(\005\022\022\n\npage_tok"
+          + "en\030\003 \001(\t\"`\n\022ListTopicsResponse\0221\n\006topics"
+          + "\030\001 \003(\0132!.google.cloud.pubsublite.v1.Topi"
+          + "c\022\027\n\017next_page_token\030\002 \001(\t\"\201\001\n\022UpdateTop"
+          + "icRequest\0225\n\005topic\030\001 \001(\0132!.google.cloud."
+          + "pubsublite.v1.TopicB\003\340A\002\0224\n\013update_mask\030"
+          + "\002 \001(\0132\032.google.protobuf.FieldMaskB\003\340A\002\"K"
+          + "\n\022DeleteTopicRequest\0225\n\004name\030\001 \001(\tB\'\340A\002\372"
+          + "A!\n\037pubsublite.googleapis.com/Topic\"}\n\035L"
+          + "istTopicSubscriptionsRequest\0225\n\004name\030\001 \001"
+          + "(\tB\'\340A\002\372A!\n\037pubsublite.googleapis.com/To"
+          + "pic\022\021\n\tpage_size\030\002 \001(\005\022\022\n\npage_token\030\003 \001"
+          + "(\t\"P\n\036ListTopicSubscriptionsResponse\022\025\n\r"
+          + "subscriptions\030\001 \003(\t\022\027\n\017next_page_token\030\002"
+          + " \001(\t\"\271\001\n\031CreateSubscriptionRequest\0229\n\006pa"
+          + "rent\030\001 \001(\tB)\340A\002\372A#\n!locations.googleapis"
+          + ".com/Location\022C\n\014subscription\030\002 \001(\0132(.go"
+          + "ogle.cloud.pubsublite.v1.SubscriptionB\003\340"
+          + "A\002\022\034\n\017subscription_id\030\003 \001(\tB\003\340A\002\"V\n\026GetS"
+          + "ubscriptionRequest\022<\n\004name\030\001 \001(\tB.\340A\002\372A("
+          + "\n&pubsublite.googleapis.com/Subscription"
+          + "\"|\n\030ListSubscriptionsRequest\0229\n\006parent\030\001"
+          + " \001(\tB)\340A\002\372A#\n!locations.googleapis.com/L"
+          + "ocation\022\021\n\tpage_size\030\002 \001(\005\022\022\n\npage_token"
+          + "\030\003 \001(\t\"u\n\031ListSubscriptionsResponse\022?\n\rs"
+          + "ubscriptions\030\001 \003(\0132(.google.cloud.pubsub"
+          + "lite.v1.Subscription\022\027\n\017next_page_token\030"
+          + "\002 \001(\t\"\226\001\n\031UpdateSubscriptionRequest\022C\n\014s"
+          + "ubscription\030\001 \001(\0132(.google.cloud.pubsubl"
+          + "ite.v1.SubscriptionB\003\340A\002\0224\n\013update_mask\030"
+          + "\002 \001(\0132\032.google.protobuf.FieldMaskB\003\340A\002\"Y"
+          + "\n\031DeleteSubscriptionRequest\022<\n\004name\030\001 \001("
+          + "\tB.\340A\002\372A(\n&pubsublite.googleapis.com/Sub"
+          + "scription2\251\022\n\014AdminService\022\271\001\n\013CreateTop"
+          + "ic\022..google.cloud.pubsublite.v1.CreateTo"
+          + "picRequest\032!.google.cloud.pubsublite.v1."
+          + "Topic\"W\202\323\344\223\0029\"0/v1/admin/{parent=project"
+          + "s/*/locations/*}/topics:\005topic\332A\025parent,"
+          + "topic,topic_id\022\233\001\n\010GetTopic\022+.google.clo"
+          + "ud.pubsublite.v1.GetTopicRequest\032!.googl"
+          + "e.cloud.pubsublite.v1.Topic\"?\202\323\344\223\0022\0220/v1"
+          + "/admin/{name=projects/*/locations/*/topi"
+          + "cs/*}\332A\004name\022\304\001\n\022GetTopicPartitions\0225.go"
+          + "ogle.cloud.pubsublite.v1.GetTopicPartiti"
+          + "onsRequest\032+.google.cloud.pubsublite.v1."
+          + "TopicPartitions\"J\202\323\344\223\002=\022;/v1/admin/{name"
+          + "=projects/*/locations/*/topics/*}/partit"
+          + "ions\332A\004name\022\256\001\n\nListTopics\022-.google.clou"
+          + "d.pubsublite.v1.ListTopicsRequest\032..goog"
+          + "le.cloud.pubsublite.v1.ListTopicsRespons"
+          + "e\"A\202\323\344\223\0022\0220/v1/admin/{parent=projects/*/"
+          + "locations/*}/topics\332A\006parent\022\273\001\n\013UpdateT"
+          + "opic\022..google.cloud.pubsublite.v1.Update"
+          + "TopicRequest\032!.google.cloud.pubsublite.v"
+          + "1.Topic\"Y\202\323\344\223\002?26/v1/admin/{topic.name=p"
+          + "rojects/*/locations/*/topics/*}:\005topic\332A"
+          + "\021topic,update_mask\022\226\001\n\013DeleteTopic\022..goo"
+          + "gle.cloud.pubsublite.v1.DeleteTopicReque"
+          + "st\032\026.google.protobuf.Empty\"?\202\323\344\223\0022*0/v1/"
+          + "admin/{name=projects/*/locations/*/topic"
+          + "s/*}\332A\004name\022\336\001\n\026ListTopicSubscriptions\0229"
+          + ".google.cloud.pubsublite.v1.ListTopicSub"
+          + "scriptionsRequest\032:.google.cloud.pubsubl"
+          + "ite.v1.ListTopicSubscriptionsResponse\"M\202"
+          + "\323\344\223\002@\022>/v1/admin/{name=projects/*/locati"
+          + "ons/*/topics/*}/subscriptions\332A\004name\022\352\001\n"
+          + "\022CreateSubscription\0225.google.cloud.pubsu"
+          + "blite.v1.CreateSubscriptionRequest\032(.goo"
+          + "gle.cloud.pubsublite.v1.Subscription\"s\202\323"
+          + "\344\223\002G\"7/v1/admin/{parent=projects/*/locat"
+          + "ions/*}/subscriptions:\014subscription\332A#pa"
+          + "rent,subscription,subscription_id\022\267\001\n\017Ge"
+          + "tSubscription\0222.google.cloud.pubsublite."
+          + "v1.GetSubscriptionRequest\032(.google.cloud"
+          + ".pubsublite.v1.Subscription\"F\202\323\344\223\0029\0227/v1"
+          + "/admin/{name=projects/*/locations/*/subs"
+          + "criptions/*}\332A\004name\022\312\001\n\021ListSubscription"
+          + "s\0224.google.cloud.pubsublite.v1.ListSubsc"
+          + "riptionsRequest\0325.google.cloud.pubsublit"
+          + "e.v1.ListSubscriptionsResponse\"H\202\323\344\223\0029\0227"
+          + "/v1/admin/{parent=projects/*/locations/*"
+          + "}/subscriptions\332A\006parent\022\354\001\n\022UpdateSubsc"
+          + "ription\0225.google.cloud.pubsublite.v1.Upd"
+          + "ateSubscriptionRequest\032(.google.cloud.pu"
+          + "bsublite.v1.Subscription\"u\202\323\344\223\002T2D/v1/ad"
+          + "min/{subscription.name=projects/*/locati"
+          + "ons/*/subscriptions/*}:\014subscription\332A\030s"
+          + "ubscription,update_mask\022\253\001\n\022DeleteSubscr"
+          + "iption\0225.google.cloud.pubsublite.v1.Dele"
+          + "teSubscriptionRequest\032\026.google.protobuf."
+          + "Empty\"F\202\323\344\223\0029*7/v1/admin/{name=projects/"
+          + "*/locations/*/subscriptions/*}\332A\004nameB1\n"
+          + "!com.google.cloud.pubsublite.protoB\nAdmi"
+          + "nProtoP\001b\006proto3"
     };
-    descriptor = com.google.protobuf.Descriptors.FileDescriptor
-      .internalBuildGeneratedFileFrom(descriptorData,
-        new com.google.protobuf.Descriptors.FileDescriptor[] {
-          com.google.api.AnnotationsProto.getDescriptor(),
-          com.google.api.ClientProto.getDescriptor(),
-          com.google.api.FieldBehaviorProto.getDescriptor(),
-          com.google.api.ResourceProto.getDescriptor(),
-          com.google.cloud.pubsublite.proto.CommonProto.getDescriptor(),
-          com.google.protobuf.EmptyProto.getDescriptor(),
-          com.google.protobuf.FieldMaskProto.getDescriptor(),
-        });
+    descriptor =
+        com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
+            descriptorData,
+            new com.google.protobuf.Descriptors.FileDescriptor[] {
+              com.google.api.AnnotationsProto.getDescriptor(),
+              com.google.api.ClientProto.getDescriptor(),
+              com.google.api.FieldBehaviorProto.getDescriptor(),
+              com.google.api.ResourceProto.getDescriptor(),
+              com.google.cloud.pubsublite.proto.CommonProto.getDescriptor(),
+              com.google.protobuf.EmptyProto.getDescriptor(),
+              com.google.protobuf.FieldMaskProto.getDescriptor(),
+            });
     internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_descriptor =
-      getDescriptor().getMessageTypes().get(0);
-    internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_descriptor,
-        new java.lang.String[] { "Parent", "Topic", "TopicId", });
+        getDescriptor().getMessageTypes().get(0);
+    internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_descriptor,
+            new java.lang.String[] {
+              "Parent", "Topic", "TopicId",
+            });
     internal_static_google_cloud_pubsublite_v1_GetTopicRequest_descriptor =
-      getDescriptor().getMessageTypes().get(1);
-    internal_static_google_cloud_pubsublite_v1_GetTopicRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_GetTopicRequest_descriptor,
-        new java.lang.String[] { "Name", });
+        getDescriptor().getMessageTypes().get(1);
+    internal_static_google_cloud_pubsublite_v1_GetTopicRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_GetTopicRequest_descriptor,
+            new java.lang.String[] {
+              "Name",
+            });
     internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_descriptor =
-      getDescriptor().getMessageTypes().get(2);
-    internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_descriptor,
-        new java.lang.String[] { "Name", });
+        getDescriptor().getMessageTypes().get(2);
+    internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_descriptor,
+            new java.lang.String[] {
+              "Name",
+            });
     internal_static_google_cloud_pubsublite_v1_TopicPartitions_descriptor =
-      getDescriptor().getMessageTypes().get(3);
-    internal_static_google_cloud_pubsublite_v1_TopicPartitions_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_TopicPartitions_descriptor,
-        new java.lang.String[] { "PartitionCount", });
+        getDescriptor().getMessageTypes().get(3);
+    internal_static_google_cloud_pubsublite_v1_TopicPartitions_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_TopicPartitions_descriptor,
+            new java.lang.String[] {
+              "PartitionCount",
+            });
     internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_descriptor =
-      getDescriptor().getMessageTypes().get(4);
-    internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_descriptor,
-        new java.lang.String[] { "Parent", "PageSize", "PageToken", });
+        getDescriptor().getMessageTypes().get(4);
+    internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_descriptor,
+            new java.lang.String[] {
+              "Parent", "PageSize", "PageToken",
+            });
     internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_descriptor =
-      getDescriptor().getMessageTypes().get(5);
-    internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_descriptor,
-        new java.lang.String[] { "Topics", "NextPageToken", });
+        getDescriptor().getMessageTypes().get(5);
+    internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_descriptor,
+            new java.lang.String[] {
+              "Topics", "NextPageToken",
+            });
     internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_descriptor =
-      getDescriptor().getMessageTypes().get(6);
-    internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_descriptor,
-        new java.lang.String[] { "Topic", "UpdateMask", });
+        getDescriptor().getMessageTypes().get(6);
+    internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_descriptor,
+            new java.lang.String[] {
+              "Topic", "UpdateMask",
+            });
     internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_descriptor =
-      getDescriptor().getMessageTypes().get(7);
-    internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_descriptor,
-        new java.lang.String[] { "Name", });
+        getDescriptor().getMessageTypes().get(7);
+    internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_descriptor,
+            new java.lang.String[] {
+              "Name",
+            });
     internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_descriptor =
-      getDescriptor().getMessageTypes().get(8);
-    internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_descriptor,
-        new java.lang.String[] { "Name", "PageSize", "PageToken", });
+        getDescriptor().getMessageTypes().get(8);
+    internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_descriptor,
+            new java.lang.String[] {
+              "Name", "PageSize", "PageToken",
+            });
     internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_descriptor =
-      getDescriptor().getMessageTypes().get(9);
-    internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_descriptor,
-        new java.lang.String[] { "Subscriptions", "NextPageToken", });
+        getDescriptor().getMessageTypes().get(9);
+    internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_descriptor,
+            new java.lang.String[] {
+              "Subscriptions", "NextPageToken",
+            });
     internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_descriptor =
-      getDescriptor().getMessageTypes().get(10);
-    internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_descriptor,
-        new java.lang.String[] { "Parent", "Subscription", "SubscriptionId", });
+        getDescriptor().getMessageTypes().get(10);
+    internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_descriptor,
+            new java.lang.String[] {
+              "Parent", "Subscription", "SubscriptionId",
+            });
     internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_descriptor =
-      getDescriptor().getMessageTypes().get(11);
-    internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_descriptor,
-        new java.lang.String[] { "Name", });
+        getDescriptor().getMessageTypes().get(11);
+    internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_descriptor,
+            new java.lang.String[] {
+              "Name",
+            });
     internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_descriptor =
-      getDescriptor().getMessageTypes().get(12);
-    internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_descriptor,
-        new java.lang.String[] { "Parent", "PageSize", "PageToken", });
+        getDescriptor().getMessageTypes().get(12);
+    internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_descriptor,
+            new java.lang.String[] {
+              "Parent", "PageSize", "PageToken",
+            });
     internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_descriptor =
-      getDescriptor().getMessageTypes().get(13);
-    internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_descriptor,
-        new java.lang.String[] { "Subscriptions", "NextPageToken", });
+        getDescriptor().getMessageTypes().get(13);
+    internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_descriptor,
+            new java.lang.String[] {
+              "Subscriptions", "NextPageToken",
+            });
     internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_descriptor =
-      getDescriptor().getMessageTypes().get(14);
-    internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_descriptor,
-        new java.lang.String[] { "Subscription", "UpdateMask", });
+        getDescriptor().getMessageTypes().get(14);
+    internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_descriptor,
+            new java.lang.String[] {
+              "Subscription", "UpdateMask",
+            });
     internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_descriptor =
-      getDescriptor().getMessageTypes().get(15);
-    internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_descriptor,
-        new java.lang.String[] { "Name", });
+        getDescriptor().getMessageTypes().get(15);
+    internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_descriptor,
+            new java.lang.String[] {
+              "Name",
+            });
     com.google.protobuf.ExtensionRegistry registry =
         com.google.protobuf.ExtensionRegistry.newInstance();
     registry.add(com.google.api.FieldBehaviorProto.fieldBehavior);
     registry.add(com.google.api.AnnotationsProto.http);
     registry.add(com.google.api.ClientProto.methodSignature);
     registry.add(com.google.api.ResourceProto.resourceReference);
-    com.google.protobuf.Descriptors.FileDescriptor
-        .internalUpdateFileDescriptor(descriptor, registry);
+    com.google.protobuf.Descriptors.FileDescriptor.internalUpdateFileDescriptor(
+        descriptor, registry);
     com.google.api.AnnotationsProto.getDescriptor();
     com.google.api.ClientProto.getDescriptor();
     com.google.api.FieldBehaviorProto.getDescriptor();

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/AttributeValues.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/AttributeValues.java
@@ -4,37 +4,39 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * The values associated with a key of an attribute.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.AttributeValues}
  */
-public  final class AttributeValues extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class AttributeValues extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.AttributeValues)
     AttributeValuesOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use AttributeValues.newBuilder() to construct.
   private AttributeValues(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private AttributeValues() {
     values_ = java.util.Collections.emptyList();
   }
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new AttributeValues();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private AttributeValues(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -54,28 +56,28 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-              values_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
-              mutable_bitField0_ |= 0x00000001;
+          case 10:
+            {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                values_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              values_.add(input.readBytes());
+              break;
             }
-            values_.add(input.readBytes());
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
             }
-            break;
-          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       if (((mutable_bitField0_ & 0x00000001) != 0)) {
         values_ = java.util.Collections.unmodifiableList(values_); // C
@@ -84,50 +86,61 @@ private static final long serialVersionUID = 0L;
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_AttributeValues_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CommonProto
+        .internal_static_google_cloud_pubsublite_v1_AttributeValues_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_AttributeValues_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CommonProto
+        .internal_static_google_cloud_pubsublite_v1_AttributeValues_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.AttributeValues.class, com.google.cloud.pubsublite.proto.AttributeValues.Builder.class);
+            com.google.cloud.pubsublite.proto.AttributeValues.class,
+            com.google.cloud.pubsublite.proto.AttributeValues.Builder.class);
   }
 
   public static final int VALUES_FIELD_NUMBER = 1;
   private java.util.List<com.google.protobuf.ByteString> values_;
   /**
+   *
+   *
    * <pre>
    * The list of values associated with a key.
    * </pre>
    *
    * <code>repeated bytes values = 1;</code>
+   *
    * @return A list containing the values.
    */
-  public java.util.List<com.google.protobuf.ByteString>
-      getValuesList() {
+  public java.util.List<com.google.protobuf.ByteString> getValuesList() {
     return values_;
   }
   /**
+   *
+   *
    * <pre>
    * The list of values associated with a key.
    * </pre>
    *
    * <code>repeated bytes values = 1;</code>
+   *
    * @return The count of values.
    */
   public int getValuesCount() {
     return values_.size();
   }
   /**
+   *
+   *
    * <pre>
    * The list of values associated with a key.
    * </pre>
    *
    * <code>repeated bytes values = 1;</code>
+   *
    * @param index The index of the element to return.
    * @return The values at the given index.
    */
@@ -136,6 +149,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -147,8 +161,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     for (int i = 0; i < values_.size(); i++) {
       output.writeBytes(1, values_.get(i));
     }
@@ -164,8 +177,7 @@ private static final long serialVersionUID = 0L;
     {
       int dataSize = 0;
       for (int i = 0; i < values_.size(); i++) {
-        dataSize += com.google.protobuf.CodedOutputStream
-          .computeBytesSizeNoTag(values_.get(i));
+        dataSize += com.google.protobuf.CodedOutputStream.computeBytesSizeNoTag(values_.get(i));
       }
       size += dataSize;
       size += 1 * getValuesList().size();
@@ -178,15 +190,15 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.AttributeValues)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.AttributeValues other = (com.google.cloud.pubsublite.proto.AttributeValues) obj;
+    com.google.cloud.pubsublite.proto.AttributeValues other =
+        (com.google.cloud.pubsublite.proto.AttributeValues) obj;
 
-    if (!getValuesList()
-        .equals(other.getValuesList())) return false;
+    if (!getValuesList().equals(other.getValuesList())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -208,117 +220,126 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.AttributeValues parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.AttributeValues parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.AttributeValues parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.AttributeValues parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.AttributeValues parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.AttributeValues parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.AttributeValues parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.AttributeValues parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.AttributeValues parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.AttributeValues parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.AttributeValues parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.AttributeValues parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.AttributeValues parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.AttributeValues parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.AttributeValues prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * The values associated with a key of an attribute.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.AttributeValues}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.AttributeValues)
       com.google.cloud.pubsublite.proto.AttributeValuesOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_AttributeValues_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_AttributeValues_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_AttributeValues_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_AttributeValues_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.AttributeValues.class, com.google.cloud.pubsublite.proto.AttributeValues.Builder.class);
+              com.google.cloud.pubsublite.proto.AttributeValues.class,
+              com.google.cloud.pubsublite.proto.AttributeValues.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.AttributeValues.newBuilder()
@@ -326,16 +347,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -345,9 +365,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_AttributeValues_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_AttributeValues_descriptor;
     }
 
     @java.lang.Override
@@ -366,7 +386,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.AttributeValues buildPartial() {
-      com.google.cloud.pubsublite.proto.AttributeValues result = new com.google.cloud.pubsublite.proto.AttributeValues(this);
+      com.google.cloud.pubsublite.proto.AttributeValues result =
+          new com.google.cloud.pubsublite.proto.AttributeValues(this);
       int from_bitField0_ = bitField0_;
       if (((bitField0_ & 0x00000001) != 0)) {
         values_ = java.util.Collections.unmodifiableList(values_);
@@ -381,38 +402,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.AttributeValues) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.AttributeValues)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.AttributeValues) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -420,7 +442,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.AttributeValues other) {
-      if (other == com.google.cloud.pubsublite.proto.AttributeValues.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.AttributeValues.getDefaultInstance())
+        return this;
       if (!other.values_.isEmpty()) {
         if (values_.isEmpty()) {
           values_ = other.values_;
@@ -450,7 +473,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.AttributeValues) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.AttributeValues) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -459,45 +483,57 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     private int bitField0_;
 
-    private java.util.List<com.google.protobuf.ByteString> values_ = java.util.Collections.emptyList();
+    private java.util.List<com.google.protobuf.ByteString> values_ =
+        java.util.Collections.emptyList();
+
     private void ensureValuesIsMutable() {
       if (!((bitField0_ & 0x00000001) != 0)) {
         values_ = new java.util.ArrayList<com.google.protobuf.ByteString>(values_);
         bitField0_ |= 0x00000001;
-       }
+      }
     }
     /**
+     *
+     *
      * <pre>
      * The list of values associated with a key.
      * </pre>
      *
      * <code>repeated bytes values = 1;</code>
+     *
      * @return A list containing the values.
      */
-    public java.util.List<com.google.protobuf.ByteString>
-        getValuesList() {
-      return ((bitField0_ & 0x00000001) != 0) ?
-               java.util.Collections.unmodifiableList(values_) : values_;
+    public java.util.List<com.google.protobuf.ByteString> getValuesList() {
+      return ((bitField0_ & 0x00000001) != 0)
+          ? java.util.Collections.unmodifiableList(values_)
+          : values_;
     }
     /**
+     *
+     *
      * <pre>
      * The list of values associated with a key.
      * </pre>
      *
      * <code>repeated bytes values = 1;</code>
+     *
      * @return The count of values.
      */
     public int getValuesCount() {
       return values_.size();
     }
     /**
+     *
+     *
      * <pre>
      * The list of values associated with a key.
      * </pre>
      *
      * <code>repeated bytes values = 1;</code>
+     *
      * @param index The index of the element to return.
      * @return The values at the given index.
      */
@@ -505,66 +541,76 @@ private static final long serialVersionUID = 0L;
       return values_.get(index);
     }
     /**
+     *
+     *
      * <pre>
      * The list of values associated with a key.
      * </pre>
      *
      * <code>repeated bytes values = 1;</code>
+     *
      * @param index The index to set the value at.
      * @param value The values to set.
      * @return This builder for chaining.
      */
-    public Builder setValues(
-        int index, com.google.protobuf.ByteString value) {
+    public Builder setValues(int index, com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureValuesIsMutable();
+        throw new NullPointerException();
+      }
+      ensureValuesIsMutable();
       values_.set(index, value);
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of values associated with a key.
      * </pre>
      *
      * <code>repeated bytes values = 1;</code>
+     *
      * @param value The values to add.
      * @return This builder for chaining.
      */
     public Builder addValues(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureValuesIsMutable();
+        throw new NullPointerException();
+      }
+      ensureValuesIsMutable();
       values_.add(value);
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of values associated with a key.
      * </pre>
      *
      * <code>repeated bytes values = 1;</code>
+     *
      * @param values The values to add.
      * @return This builder for chaining.
      */
     public Builder addAllValues(
         java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
       ensureValuesIsMutable();
-      com.google.protobuf.AbstractMessageLite.Builder.addAll(
-          values, values_);
+      com.google.protobuf.AbstractMessageLite.Builder.addAll(values, values_);
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of values associated with a key.
      * </pre>
      *
      * <code>repeated bytes values = 1;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearValues() {
@@ -573,9 +619,9 @@ private static final long serialVersionUID = 0L;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -585,12 +631,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.AttributeValues)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.AttributeValues)
   private static final com.google.cloud.pubsublite.proto.AttributeValues DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.AttributeValues();
   }
@@ -599,16 +645,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<AttributeValues>
-      PARSER = new com.google.protobuf.AbstractParser<AttributeValues>() {
-    @java.lang.Override
-    public AttributeValues parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new AttributeValues(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<AttributeValues> PARSER =
+      new com.google.protobuf.AbstractParser<AttributeValues>() {
+        @java.lang.Override
+        public AttributeValues parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new AttributeValues(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<AttributeValues> parser() {
     return PARSER;
@@ -623,6 +669,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.AttributeValues getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/AttributeValuesOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/AttributeValuesOrBuilder.java
@@ -3,34 +3,44 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface AttributeValuesOrBuilder extends
+public interface AttributeValuesOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.AttributeValues)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The list of values associated with a key.
    * </pre>
    *
    * <code>repeated bytes values = 1;</code>
+   *
    * @return A list containing the values.
    */
   java.util.List<com.google.protobuf.ByteString> getValuesList();
   /**
+   *
+   *
    * <pre>
    * The list of values associated with a key.
    * </pre>
    *
    * <code>repeated bytes values = 1;</code>
+   *
    * @return The count of values.
    */
   int getValuesCount();
   /**
+   *
+   *
    * <pre>
    * The list of values associated with a key.
    * </pre>
    *
    * <code>repeated bytes values = 1;</code>
+   *
    * @param index The index of the element to return.
    * @return The values at the given index.
    */

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CommitCursorRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CommitCursorRequest.java
@@ -4,37 +4,39 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request for CommitCursor.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.CommitCursorRequest}
  */
-public  final class CommitCursorRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class CommitCursorRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.CommitCursorRequest)
     CommitCursorRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use CommitCursorRequest.newBuilder() to construct.
   private CommitCursorRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private CommitCursorRequest() {
     subscription_ = "";
   }
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new CommitCursorRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private CommitCursorRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -53,70 +55,79 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            subscription_ = s;
-            break;
-          }
-          case 16: {
+              subscription_ = s;
+              break;
+            }
+          case 16:
+            {
+              partition_ = input.readInt64();
+              break;
+            }
+          case 26:
+            {
+              com.google.cloud.pubsublite.proto.Cursor.Builder subBuilder = null;
+              if (cursor_ != null) {
+                subBuilder = cursor_.toBuilder();
+              }
+              cursor_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Cursor.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(cursor_);
+                cursor_ = subBuilder.buildPartial();
+              }
 
-            partition_ = input.readInt64();
-            break;
-          }
-          case 26: {
-            com.google.cloud.pubsublite.proto.Cursor.Builder subBuilder = null;
-            if (cursor_ != null) {
-              subBuilder = cursor_.toBuilder();
+              break;
             }
-            cursor_ = input.readMessage(com.google.cloud.pubsublite.proto.Cursor.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(cursor_);
-              cursor_ = subBuilder.buildPartial();
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
             }
-
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.CommitCursorRequest.class, com.google.cloud.pubsublite.proto.CommitCursorRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.CommitCursorRequest.class,
+            com.google.cloud.pubsublite.proto.CommitCursorRequest.Builder.class);
   }
 
   public static final int SUBSCRIPTION_FIELD_NUMBER = 1;
   private volatile java.lang.Object subscription_;
   /**
+   *
+   *
    * <pre>
    * The subscription for which to update the cursor.
    * </pre>
    *
    * <code>string subscription = 1;</code>
+   *
    * @return The subscription.
    */
   public java.lang.String getSubscription() {
@@ -124,28 +135,28 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       subscription_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The subscription for which to update the cursor.
    * </pre>
    *
    * <code>string subscription = 1;</code>
+   *
    * @return The bytes for subscription.
    */
-  public com.google.protobuf.ByteString
-      getSubscriptionBytes() {
+  public com.google.protobuf.ByteString getSubscriptionBytes() {
     java.lang.Object ref = subscription_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       subscription_ = b;
       return b;
     } else {
@@ -156,12 +167,15 @@ private static final long serialVersionUID = 0L;
   public static final int PARTITION_FIELD_NUMBER = 2;
   private long partition_;
   /**
+   *
+   *
    * <pre>
    * The partition for which to update the cursor. Partitions are zero indexed,
    * so `partition` must be in the range [0, topic.num_partitions).
    * </pre>
    *
    * <code>int64 partition = 2;</code>
+   *
    * @return The partition.
    */
   public long getPartition() {
@@ -171,28 +185,38 @@ private static final long serialVersionUID = 0L;
   public static final int CURSOR_FIELD_NUMBER = 3;
   private com.google.cloud.pubsublite.proto.Cursor cursor_;
   /**
+   *
+   *
    * <pre>
    * The new value for the committed cursor.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 3;</code>
+   *
    * @return Whether the cursor field is set.
    */
   public boolean hasCursor() {
     return cursor_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * The new value for the committed cursor.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 3;</code>
+   *
    * @return The cursor.
    */
   public com.google.cloud.pubsublite.proto.Cursor getCursor() {
-    return cursor_ == null ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+    return cursor_ == null
+        ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+        : cursor_;
   }
   /**
+   *
+   *
    * <pre>
    * The new value for the committed cursor.
    * </pre>
@@ -204,6 +228,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -215,8 +240,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getSubscriptionBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, subscription_);
     }
@@ -239,12 +263,10 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, subscription_);
     }
     if (partition_ != 0L) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeInt64Size(2, partition_);
+      size += com.google.protobuf.CodedOutputStream.computeInt64Size(2, partition_);
     }
     if (cursor_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(3, getCursor());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(3, getCursor());
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -254,21 +276,19 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.CommitCursorRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.CommitCursorRequest other = (com.google.cloud.pubsublite.proto.CommitCursorRequest) obj;
+    com.google.cloud.pubsublite.proto.CommitCursorRequest other =
+        (com.google.cloud.pubsublite.proto.CommitCursorRequest) obj;
 
-    if (!getSubscription()
-        .equals(other.getSubscription())) return false;
-    if (getPartition()
-        != other.getPartition()) return false;
+    if (!getSubscription().equals(other.getSubscription())) return false;
+    if (getPartition() != other.getPartition()) return false;
     if (hasCursor() != other.hasCursor()) return false;
     if (hasCursor()) {
-      if (!getCursor()
-          .equals(other.getCursor())) return false;
+      if (!getCursor().equals(other.getCursor())) return false;
     }
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
@@ -284,8 +304,7 @@ private static final long serialVersionUID = 0L;
     hash = (37 * hash) + SUBSCRIPTION_FIELD_NUMBER;
     hash = (53 * hash) + getSubscription().hashCode();
     hash = (37 * hash) + PARTITION_FIELD_NUMBER;
-    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-        getPartition());
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(getPartition());
     if (hasCursor()) {
       hash = (37 * hash) + CURSOR_FIELD_NUMBER;
       hash = (53 * hash) + getCursor().hashCode();
@@ -296,117 +315,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.CommitCursorRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.CommitCursorRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.CommitCursorRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.CommitCursorRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.CommitCursorRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.CommitCursorRequest prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.CommitCursorRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request for CommitCursor.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.CommitCursorRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.CommitCursorRequest)
       com.google.cloud.pubsublite.proto.CommitCursorRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.CommitCursorRequest.class, com.google.cloud.pubsublite.proto.CommitCursorRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.CommitCursorRequest.class,
+              com.google.cloud.pubsublite.proto.CommitCursorRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.CommitCursorRequest.newBuilder()
@@ -414,16 +443,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -441,9 +469,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_descriptor;
     }
 
     @java.lang.Override
@@ -462,7 +490,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.CommitCursorRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.CommitCursorRequest result = new com.google.cloud.pubsublite.proto.CommitCursorRequest(this);
+      com.google.cloud.pubsublite.proto.CommitCursorRequest result =
+          new com.google.cloud.pubsublite.proto.CommitCursorRequest(this);
       result.subscription_ = subscription_;
       result.partition_ = partition_;
       if (cursorBuilder_ == null) {
@@ -478,38 +507,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.CommitCursorRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.CommitCursorRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.CommitCursorRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -517,7 +547,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.CommitCursorRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.CommitCursorRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.CommitCursorRequest.getDefaultInstance())
+        return this;
       if (!other.getSubscription().isEmpty()) {
         subscription_ = other.subscription_;
         onChanged();
@@ -547,7 +578,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.CommitCursorRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.CommitCursorRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -559,18 +591,20 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object subscription_ = "";
     /**
+     *
+     *
      * <pre>
      * The subscription for which to update the cursor.
      * </pre>
      *
      * <code>string subscription = 1;</code>
+     *
      * @return The subscription.
      */
     public java.lang.String getSubscription() {
       java.lang.Object ref = subscription_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         subscription_ = s;
         return s;
@@ -579,20 +613,21 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The subscription for which to update the cursor.
      * </pre>
      *
      * <code>string subscription = 1;</code>
+     *
      * @return The bytes for subscription.
      */
-    public com.google.protobuf.ByteString
-        getSubscriptionBytes() {
+    public com.google.protobuf.ByteString getSubscriptionBytes() {
       java.lang.Object ref = subscription_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         subscription_ = b;
         return b;
       } else {
@@ -600,99 +635,115 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The subscription for which to update the cursor.
      * </pre>
      *
      * <code>string subscription = 1;</code>
+     *
      * @param value The subscription to set.
      * @return This builder for chaining.
      */
-    public Builder setSubscription(
-        java.lang.String value) {
+    public Builder setSubscription(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       subscription_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The subscription for which to update the cursor.
      * </pre>
      *
      * <code>string subscription = 1;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearSubscription() {
-      
+
       subscription_ = getDefaultInstance().getSubscription();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The subscription for which to update the cursor.
      * </pre>
      *
      * <code>string subscription = 1;</code>
+     *
      * @param value The bytes for subscription to set.
      * @return This builder for chaining.
      */
-    public Builder setSubscriptionBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setSubscriptionBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       subscription_ = value;
       onChanged();
       return this;
     }
 
-    private long partition_ ;
+    private long partition_;
     /**
+     *
+     *
      * <pre>
      * The partition for which to update the cursor. Partitions are zero indexed,
      * so `partition` must be in the range [0, topic.num_partitions).
      * </pre>
      *
      * <code>int64 partition = 2;</code>
+     *
      * @return The partition.
      */
     public long getPartition() {
       return partition_;
     }
     /**
+     *
+     *
      * <pre>
      * The partition for which to update the cursor. Partitions are zero indexed,
      * so `partition` must be in the range [0, topic.num_partitions).
      * </pre>
      *
      * <code>int64 partition = 2;</code>
+     *
      * @param value The partition to set.
      * @return This builder for chaining.
      */
     public Builder setPartition(long value) {
-      
+
       partition_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The partition for which to update the cursor. Partitions are zero indexed,
      * so `partition` must be in the range [0, topic.num_partitions).
      * </pre>
      *
      * <code>int64 partition = 2;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearPartition() {
-      
+
       partition_ = 0L;
       onChanged();
       return this;
@@ -700,34 +751,47 @@ private static final long serialVersionUID = 0L;
 
     private com.google.cloud.pubsublite.proto.Cursor cursor_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder> cursorBuilder_;
+            com.google.cloud.pubsublite.proto.Cursor,
+            com.google.cloud.pubsublite.proto.Cursor.Builder,
+            com.google.cloud.pubsublite.proto.CursorOrBuilder>
+        cursorBuilder_;
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 3;</code>
+     *
      * @return Whether the cursor field is set.
      */
     public boolean hasCursor() {
       return cursorBuilder_ != null || cursor_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 3;</code>
+     *
      * @return The cursor.
      */
     public com.google.cloud.pubsublite.proto.Cursor getCursor() {
       if (cursorBuilder_ == null) {
-        return cursor_ == null ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+        return cursor_ == null
+            ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+            : cursor_;
       } else {
         return cursorBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
@@ -748,14 +812,15 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 3;</code>
      */
-    public Builder setCursor(
-        com.google.cloud.pubsublite.proto.Cursor.Builder builderForValue) {
+    public Builder setCursor(com.google.cloud.pubsublite.proto.Cursor.Builder builderForValue) {
       if (cursorBuilder_ == null) {
         cursor_ = builderForValue.build();
         onChanged();
@@ -766,6 +831,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
@@ -776,7 +843,9 @@ private static final long serialVersionUID = 0L;
       if (cursorBuilder_ == null) {
         if (cursor_ != null) {
           cursor_ =
-            com.google.cloud.pubsublite.proto.Cursor.newBuilder(cursor_).mergeFrom(value).buildPartial();
+              com.google.cloud.pubsublite.proto.Cursor.newBuilder(cursor_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           cursor_ = value;
         }
@@ -788,6 +857,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
@@ -806,6 +877,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
@@ -813,11 +886,13 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 3;</code>
      */
     public com.google.cloud.pubsublite.proto.Cursor.Builder getCursorBuilder() {
-      
+
       onChanged();
       return getCursorFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
@@ -828,11 +903,14 @@ private static final long serialVersionUID = 0L;
       if (cursorBuilder_ != null) {
         return cursorBuilder_.getMessageOrBuilder();
       } else {
-        return cursor_ == null ?
-            com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+        return cursor_ == null
+            ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+            : cursor_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
@@ -840,21 +918,24 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder> 
+            com.google.cloud.pubsublite.proto.Cursor,
+            com.google.cloud.pubsublite.proto.Cursor.Builder,
+            com.google.cloud.pubsublite.proto.CursorOrBuilder>
         getCursorFieldBuilder() {
       if (cursorBuilder_ == null) {
-        cursorBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder>(
-                getCursor(),
-                getParentForChildren(),
-                isClean());
+        cursorBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Cursor,
+                com.google.cloud.pubsublite.proto.Cursor.Builder,
+                com.google.cloud.pubsublite.proto.CursorOrBuilder>(
+                getCursor(), getParentForChildren(), isClean());
         cursor_ = null;
       }
       return cursorBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -864,12 +945,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.CommitCursorRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.CommitCursorRequest)
   private static final com.google.cloud.pubsublite.proto.CommitCursorRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.CommitCursorRequest();
   }
@@ -878,16 +959,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<CommitCursorRequest>
-      PARSER = new com.google.protobuf.AbstractParser<CommitCursorRequest>() {
-    @java.lang.Override
-    public CommitCursorRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new CommitCursorRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<CommitCursorRequest> PARSER =
+      new com.google.protobuf.AbstractParser<CommitCursorRequest>() {
+        @java.lang.Override
+        public CommitCursorRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new CommitCursorRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<CommitCursorRequest> parser() {
     return PARSER;
@@ -902,6 +983,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.CommitCursorRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CommitCursorRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CommitCursorRequestOrBuilder.java
@@ -3,60 +3,77 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface CommitCursorRequestOrBuilder extends
+public interface CommitCursorRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.CommitCursorRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The subscription for which to update the cursor.
    * </pre>
    *
    * <code>string subscription = 1;</code>
+   *
    * @return The subscription.
    */
   java.lang.String getSubscription();
   /**
+   *
+   *
    * <pre>
    * The subscription for which to update the cursor.
    * </pre>
    *
    * <code>string subscription = 1;</code>
+   *
    * @return The bytes for subscription.
    */
-  com.google.protobuf.ByteString
-      getSubscriptionBytes();
+  com.google.protobuf.ByteString getSubscriptionBytes();
 
   /**
+   *
+   *
    * <pre>
    * The partition for which to update the cursor. Partitions are zero indexed,
    * so `partition` must be in the range [0, topic.num_partitions).
    * </pre>
    *
    * <code>int64 partition = 2;</code>
+   *
    * @return The partition.
    */
   long getPartition();
 
   /**
+   *
+   *
    * <pre>
    * The new value for the committed cursor.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 3;</code>
+   *
    * @return Whether the cursor field is set.
    */
   boolean hasCursor();
   /**
+   *
+   *
    * <pre>
    * The new value for the committed cursor.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 3;</code>
+   *
    * @return The cursor.
    */
   com.google.cloud.pubsublite.proto.Cursor getCursor();
   /**
+   *
+   *
    * <pre>
    * The new value for the committed cursor.
    * </pre>

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CommitCursorResponse.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CommitCursorResponse.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Response for CommitCursor.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.CommitCursorResponse}
  */
-public  final class CommitCursorResponse extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class CommitCursorResponse extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.CommitCursorResponse)
     CommitCursorResponseOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use CommitCursorResponse.newBuilder() to construct.
   private CommitCursorResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private CommitCursorResponse() {
-  }
+
+  private CommitCursorResponse() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new CommitCursorResponse();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private CommitCursorResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,39 +53,42 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
             }
-            break;
-          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.CommitCursorResponse.class, com.google.cloud.pubsublite.proto.CommitCursorResponse.Builder.class);
+            com.google.cloud.pubsublite.proto.CommitCursorResponse.class,
+            com.google.cloud.pubsublite.proto.CommitCursorResponse.Builder.class);
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -96,8 +100,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     unknownFields.writeTo(output);
   }
 
@@ -115,12 +118,13 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.CommitCursorResponse)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.CommitCursorResponse other = (com.google.cloud.pubsublite.proto.CommitCursorResponse) obj;
+    com.google.cloud.pubsublite.proto.CommitCursorResponse other =
+        (com.google.cloud.pubsublite.proto.CommitCursorResponse) obj;
 
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
@@ -139,117 +143,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.CommitCursorResponse parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorResponse parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorResponse parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorResponse parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorResponse parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.CommitCursorResponse parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorResponse parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.CommitCursorResponse parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.CommitCursorResponse parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorResponse parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.CommitCursorResponse parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorResponse parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.CommitCursorResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.CommitCursorResponse prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.CommitCursorResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Response for CommitCursor.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.CommitCursorResponse}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.CommitCursorResponse)
       com.google.cloud.pubsublite.proto.CommitCursorResponseOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.CommitCursorResponse.class, com.google.cloud.pubsublite.proto.CommitCursorResponse.Builder.class);
+              com.google.cloud.pubsublite.proto.CommitCursorResponse.class,
+              com.google.cloud.pubsublite.proto.CommitCursorResponse.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.CommitCursorResponse.newBuilder()
@@ -257,16 +271,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -274,9 +287,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_descriptor;
     }
 
     @java.lang.Override
@@ -295,7 +308,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.CommitCursorResponse buildPartial() {
-      com.google.cloud.pubsublite.proto.CommitCursorResponse result = new com.google.cloud.pubsublite.proto.CommitCursorResponse(this);
+      com.google.cloud.pubsublite.proto.CommitCursorResponse result =
+          new com.google.cloud.pubsublite.proto.CommitCursorResponse(this);
       onBuilt();
       return result;
     }
@@ -304,38 +318,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.CommitCursorResponse) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.CommitCursorResponse)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.CommitCursorResponse) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -343,7 +358,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.CommitCursorResponse other) {
-      if (other == com.google.cloud.pubsublite.proto.CommitCursorResponse.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.CommitCursorResponse.getDefaultInstance())
+        return this;
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
@@ -363,7 +379,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.CommitCursorResponse) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.CommitCursorResponse) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -372,9 +389,9 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -384,12 +401,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.CommitCursorResponse)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.CommitCursorResponse)
   private static final com.google.cloud.pubsublite.proto.CommitCursorResponse DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.CommitCursorResponse();
   }
@@ -398,16 +415,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<CommitCursorResponse>
-      PARSER = new com.google.protobuf.AbstractParser<CommitCursorResponse>() {
-    @java.lang.Override
-    public CommitCursorResponse parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new CommitCursorResponse(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<CommitCursorResponse> PARSER =
+      new com.google.protobuf.AbstractParser<CommitCursorResponse>() {
+        @java.lang.Override
+        public CommitCursorResponse parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new CommitCursorResponse(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<CommitCursorResponse> parser() {
     return PARSER;
@@ -422,6 +439,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.CommitCursorResponse getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CommitCursorResponseOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CommitCursorResponseOrBuilder.java
@@ -3,7 +3,7 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface CommitCursorResponseOrBuilder extends
+public interface CommitCursorResponseOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.CommitCursorResponse)
-    com.google.protobuf.MessageOrBuilder {
-}
+    com.google.protobuf.MessageOrBuilder {}

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CommonProto.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CommonProto.java
@@ -5,191 +5,200 @@ package com.google.cloud.pubsublite.proto;
 
 public final class CommonProto {
   private CommonProto() {}
-  public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistryLite registry) {
+
+  public static void registerAllExtensions(com.google.protobuf.ExtensionRegistryLite registry) {}
+
+  public static void registerAllExtensions(com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions((com.google.protobuf.ExtensionRegistryLite) registry);
   }
 
-  public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
-    registerAllExtensions(
-        (com.google.protobuf.ExtensionRegistryLite) registry);
-  }
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_AttributeValues_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_AttributeValues_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_AttributeValues_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_PubSubMessage_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_PubSubMessage_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_PubSubMessage_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_PubSubMessage_AttributesEntry_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_PubSubMessage_AttributesEntry_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_PubSubMessage_AttributesEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_Cursor_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_Cursor_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_Cursor_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_SequencedMessage_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_SequencedMessage_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_SequencedMessage_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_Topic_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_Topic_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_Topic_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_Subscription_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_Subscription_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_Subscription_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_fieldAccessorTable;
 
-  public static com.google.protobuf.Descriptors.FileDescriptor
-      getDescriptor() {
+  public static com.google.protobuf.Descriptors.FileDescriptor getDescriptor() {
     return descriptor;
   }
-  private static  com.google.protobuf.Descriptors.FileDescriptor
-      descriptor;
+
+  private static com.google.protobuf.Descriptors.FileDescriptor descriptor;
+
   static {
     java.lang.String[] descriptorData = {
-      "\n\'google/cloud/pubsublite/v1/common.prot" +
-      "o\022\032google.cloud.pubsublite.v1\032\031google/ap" +
-      "i/resource.proto\032\036google/protobuf/durati" +
-      "on.proto\032\037google/protobuf/timestamp.prot" +
-      "o\"!\n\017AttributeValues\022\016\n\006values\030\001 \003(\014\"\211\002\n" +
-      "\rPubSubMessage\022\013\n\003key\030\001 \001(\014\022\014\n\004data\030\002 \001(" +
-      "\014\022M\n\nattributes\030\003 \003(\01329.google.cloud.pub" +
-      "sublite.v1.PubSubMessage.AttributesEntry" +
-      "\022.\n\nevent_time\030\004 \001(\0132\032.google.protobuf.T" +
-      "imestamp\032^\n\017AttributesEntry\022\013\n\003key\030\001 \001(\t" +
-      "\022:\n\005value\030\002 \001(\0132+.google.cloud.pubsublit" +
-      "e.v1.AttributeValues:\0028\001\"\030\n\006Cursor\022\016\n\006of" +
-      "fset\030\001 \001(\003\"\310\001\n\020SequencedMessage\0222\n\006curso" +
-      "r\030\001 \001(\0132\".google.cloud.pubsublite.v1.Cur" +
-      "sor\0220\n\014publish_time\030\002 \001(\0132\032.google.proto" +
-      "buf.Timestamp\022:\n\007message\030\003 \001(\0132).google." +
-      "cloud.pubsublite.v1.PubSubMessage\022\022\n\nsiz" +
-      "e_bytes\030\004 \001(\003\"\231\003\n\005Topic\022\014\n\004name\030\001 \001(\t\022K\n" +
-      "\020partition_config\030\002 \001(\01321.google.cloud.p" +
-      "ubsublite.v1.Topic.PartitionConfig\022K\n\020re" +
-      "tention_config\030\003 \001(\01321.google.cloud.pubs" +
-      "ublite.v1.Topic.RetentionConfig\032/\n\017Parti" +
-      "tionConfig\022\r\n\005count\030\001 \001(\003\022\r\n\005scale\030\002 \001(\005" +
-      "\032Y\n\017RetentionConfig\022\033\n\023per_partition_byt" +
-      "es\030\001 \001(\003\022)\n\006period\030\002 \001(\0132\031.google.protob" +
-      "uf.Duration:\\\352AY\n\037pubsublite.googleapis." +
-      "com/Topic\0226projects/{project}/locations/" +
-      "{location}/topics/{topic}\"\220\004\n\014Subscripti" +
-      "on\022\014\n\004name\030\001 \001(\t\0223\n\005topic\030\002 \001(\tB$\372A!\n\037pu" +
-      "bsublite.googleapis.com/Topic\022P\n\017deliver" +
-      "y_config\030\003 \001(\01327.google.cloud.pubsublite" +
-      ".v1.Subscription.DeliveryConfig\032\367\001\n\016Deli" +
-      "veryConfig\022i\n\024delivery_requirement\030\003 \001(\016" +
-      "2K.google.cloud.pubsublite.v1.Subscripti" +
-      "on.DeliveryConfig.DeliveryRequirement\"n\n" +
-      "\023DeliveryRequirement\022$\n DELIVERY_REQUIRE" +
-      "MENT_UNSPECIFIED\020\000\022\027\n\023DELIVER_IMMEDIATEL" +
-      "Y\020\001\022\030\n\024DELIVER_AFTER_STORED\020\002J\004\010\001\020\002J\004\010\002\020" +
-      "\003:q\352An\n&pubsublite.googleapis.com/Subscr" +
-      "iption\022Dprojects/{project}/locations/{lo" +
-      "cation}/subscriptions/{subscription}B5\n!" +
-      "com.google.cloud.pubsublite.protoB\013Commo" +
-      "nProtoP\001\370\001\001b\006proto3"
+      "\n\'google/cloud/pubsublite/v1/common.prot"
+          + "o\022\032google.cloud.pubsublite.v1\032\031google/ap"
+          + "i/resource.proto\032\036google/protobuf/durati"
+          + "on.proto\032\037google/protobuf/timestamp.prot"
+          + "o\"!\n\017AttributeValues\022\016\n\006values\030\001 \003(\014\"\211\002\n"
+          + "\rPubSubMessage\022\013\n\003key\030\001 \001(\014\022\014\n\004data\030\002 \001("
+          + "\014\022M\n\nattributes\030\003 \003(\01329.google.cloud.pub"
+          + "sublite.v1.PubSubMessage.AttributesEntry"
+          + "\022.\n\nevent_time\030\004 \001(\0132\032.google.protobuf.T"
+          + "imestamp\032^\n\017AttributesEntry\022\013\n\003key\030\001 \001(\t"
+          + "\022:\n\005value\030\002 \001(\0132+.google.cloud.pubsublit"
+          + "e.v1.AttributeValues:\0028\001\"\030\n\006Cursor\022\016\n\006of"
+          + "fset\030\001 \001(\003\"\310\001\n\020SequencedMessage\0222\n\006curso"
+          + "r\030\001 \001(\0132\".google.cloud.pubsublite.v1.Cur"
+          + "sor\0220\n\014publish_time\030\002 \001(\0132\032.google.proto"
+          + "buf.Timestamp\022:\n\007message\030\003 \001(\0132).google."
+          + "cloud.pubsublite.v1.PubSubMessage\022\022\n\nsiz"
+          + "e_bytes\030\004 \001(\003\"\231\003\n\005Topic\022\014\n\004name\030\001 \001(\t\022K\n"
+          + "\020partition_config\030\002 \001(\01321.google.cloud.p"
+          + "ubsublite.v1.Topic.PartitionConfig\022K\n\020re"
+          + "tention_config\030\003 \001(\01321.google.cloud.pubs"
+          + "ublite.v1.Topic.RetentionConfig\032/\n\017Parti"
+          + "tionConfig\022\r\n\005count\030\001 \001(\003\022\r\n\005scale\030\002 \001(\005"
+          + "\032Y\n\017RetentionConfig\022\033\n\023per_partition_byt"
+          + "es\030\001 \001(\003\022)\n\006period\030\002 \001(\0132\031.google.protob"
+          + "uf.Duration:\\\352AY\n\037pubsublite.googleapis."
+          + "com/Topic\0226projects/{project}/locations/"
+          + "{location}/topics/{topic}\"\220\004\n\014Subscripti"
+          + "on\022\014\n\004name\030\001 \001(\t\0223\n\005topic\030\002 \001(\tB$\372A!\n\037pu"
+          + "bsublite.googleapis.com/Topic\022P\n\017deliver"
+          + "y_config\030\003 \001(\01327.google.cloud.pubsublite"
+          + ".v1.Subscription.DeliveryConfig\032\367\001\n\016Deli"
+          + "veryConfig\022i\n\024delivery_requirement\030\003 \001(\016"
+          + "2K.google.cloud.pubsublite.v1.Subscripti"
+          + "on.DeliveryConfig.DeliveryRequirement\"n\n"
+          + "\023DeliveryRequirement\022$\n DELIVERY_REQUIRE"
+          + "MENT_UNSPECIFIED\020\000\022\027\n\023DELIVER_IMMEDIATEL"
+          + "Y\020\001\022\030\n\024DELIVER_AFTER_STORED\020\002J\004\010\001\020\002J\004\010\002\020"
+          + "\003:q\352An\n&pubsublite.googleapis.com/Subscr"
+          + "iption\022Dprojects/{project}/locations/{lo"
+          + "cation}/subscriptions/{subscription}B5\n!"
+          + "com.google.cloud.pubsublite.protoB\013Commo"
+          + "nProtoP\001\370\001\001b\006proto3"
     };
-    descriptor = com.google.protobuf.Descriptors.FileDescriptor
-      .internalBuildGeneratedFileFrom(descriptorData,
-        new com.google.protobuf.Descriptors.FileDescriptor[] {
-          com.google.api.ResourceProto.getDescriptor(),
-          com.google.protobuf.DurationProto.getDescriptor(),
-          com.google.protobuf.TimestampProto.getDescriptor(),
-        });
+    descriptor =
+        com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
+            descriptorData,
+            new com.google.protobuf.Descriptors.FileDescriptor[] {
+              com.google.api.ResourceProto.getDescriptor(),
+              com.google.protobuf.DurationProto.getDescriptor(),
+              com.google.protobuf.TimestampProto.getDescriptor(),
+            });
     internal_static_google_cloud_pubsublite_v1_AttributeValues_descriptor =
-      getDescriptor().getMessageTypes().get(0);
-    internal_static_google_cloud_pubsublite_v1_AttributeValues_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_AttributeValues_descriptor,
-        new java.lang.String[] { "Values", });
+        getDescriptor().getMessageTypes().get(0);
+    internal_static_google_cloud_pubsublite_v1_AttributeValues_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_AttributeValues_descriptor,
+            new java.lang.String[] {
+              "Values",
+            });
     internal_static_google_cloud_pubsublite_v1_PubSubMessage_descriptor =
-      getDescriptor().getMessageTypes().get(1);
-    internal_static_google_cloud_pubsublite_v1_PubSubMessage_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_PubSubMessage_descriptor,
-        new java.lang.String[] { "Key", "Data", "Attributes", "EventTime", });
+        getDescriptor().getMessageTypes().get(1);
+    internal_static_google_cloud_pubsublite_v1_PubSubMessage_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_PubSubMessage_descriptor,
+            new java.lang.String[] {
+              "Key", "Data", "Attributes", "EventTime",
+            });
     internal_static_google_cloud_pubsublite_v1_PubSubMessage_AttributesEntry_descriptor =
-      internal_static_google_cloud_pubsublite_v1_PubSubMessage_descriptor.getNestedTypes().get(0);
-    internal_static_google_cloud_pubsublite_v1_PubSubMessage_AttributesEntry_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_PubSubMessage_AttributesEntry_descriptor,
-        new java.lang.String[] { "Key", "Value", });
+        internal_static_google_cloud_pubsublite_v1_PubSubMessage_descriptor.getNestedTypes().get(0);
+    internal_static_google_cloud_pubsublite_v1_PubSubMessage_AttributesEntry_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_PubSubMessage_AttributesEntry_descriptor,
+            new java.lang.String[] {
+              "Key", "Value",
+            });
     internal_static_google_cloud_pubsublite_v1_Cursor_descriptor =
-      getDescriptor().getMessageTypes().get(2);
-    internal_static_google_cloud_pubsublite_v1_Cursor_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_Cursor_descriptor,
-        new java.lang.String[] { "Offset", });
+        getDescriptor().getMessageTypes().get(2);
+    internal_static_google_cloud_pubsublite_v1_Cursor_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_Cursor_descriptor,
+            new java.lang.String[] {
+              "Offset",
+            });
     internal_static_google_cloud_pubsublite_v1_SequencedMessage_descriptor =
-      getDescriptor().getMessageTypes().get(3);
-    internal_static_google_cloud_pubsublite_v1_SequencedMessage_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_SequencedMessage_descriptor,
-        new java.lang.String[] { "Cursor", "PublishTime", "Message", "SizeBytes", });
+        getDescriptor().getMessageTypes().get(3);
+    internal_static_google_cloud_pubsublite_v1_SequencedMessage_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_SequencedMessage_descriptor,
+            new java.lang.String[] {
+              "Cursor", "PublishTime", "Message", "SizeBytes",
+            });
     internal_static_google_cloud_pubsublite_v1_Topic_descriptor =
-      getDescriptor().getMessageTypes().get(4);
-    internal_static_google_cloud_pubsublite_v1_Topic_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_Topic_descriptor,
-        new java.lang.String[] { "Name", "PartitionConfig", "RetentionConfig", });
+        getDescriptor().getMessageTypes().get(4);
+    internal_static_google_cloud_pubsublite_v1_Topic_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_Topic_descriptor,
+            new java.lang.String[] {
+              "Name", "PartitionConfig", "RetentionConfig",
+            });
     internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_descriptor =
-      internal_static_google_cloud_pubsublite_v1_Topic_descriptor.getNestedTypes().get(0);
-    internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_descriptor,
-        new java.lang.String[] { "Count", "Scale", });
+        internal_static_google_cloud_pubsublite_v1_Topic_descriptor.getNestedTypes().get(0);
+    internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_descriptor,
+            new java.lang.String[] {
+              "Count", "Scale",
+            });
     internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_descriptor =
-      internal_static_google_cloud_pubsublite_v1_Topic_descriptor.getNestedTypes().get(1);
-    internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_descriptor,
-        new java.lang.String[] { "PerPartitionBytes", "Period", });
+        internal_static_google_cloud_pubsublite_v1_Topic_descriptor.getNestedTypes().get(1);
+    internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_descriptor,
+            new java.lang.String[] {
+              "PerPartitionBytes", "Period",
+            });
     internal_static_google_cloud_pubsublite_v1_Subscription_descriptor =
-      getDescriptor().getMessageTypes().get(5);
-    internal_static_google_cloud_pubsublite_v1_Subscription_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_Subscription_descriptor,
-        new java.lang.String[] { "Name", "Topic", "DeliveryConfig", });
+        getDescriptor().getMessageTypes().get(5);
+    internal_static_google_cloud_pubsublite_v1_Subscription_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_Subscription_descriptor,
+            new java.lang.String[] {
+              "Name", "Topic", "DeliveryConfig",
+            });
     internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_descriptor =
-      internal_static_google_cloud_pubsublite_v1_Subscription_descriptor.getNestedTypes().get(0);
-    internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_descriptor,
-        new java.lang.String[] { "DeliveryRequirement", });
+        internal_static_google_cloud_pubsublite_v1_Subscription_descriptor.getNestedTypes().get(0);
+    internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_descriptor,
+            new java.lang.String[] {
+              "DeliveryRequirement",
+            });
     com.google.protobuf.ExtensionRegistry registry =
         com.google.protobuf.ExtensionRegistry.newInstance();
     registry.add(com.google.api.ResourceProto.resource);
     registry.add(com.google.api.ResourceProto.resourceReference);
-    com.google.protobuf.Descriptors.FileDescriptor
-        .internalUpdateFileDescriptor(descriptor, registry);
+    com.google.protobuf.Descriptors.FileDescriptor.internalUpdateFileDescriptor(
+        descriptor, registry);
     com.google.api.ResourceProto.getDescriptor();
     com.google.protobuf.DurationProto.getDescriptor();
     com.google.protobuf.TimestampProto.getDescriptor();

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CreateSubscriptionRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CreateSubscriptionRequest.java
@@ -4,21 +4,24 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request for CreateSubscription.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.CreateSubscriptionRequest}
  */
-public  final class CreateSubscriptionRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class CreateSubscriptionRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.CreateSubscriptionRequest)
     CreateSubscriptionRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use CreateSubscriptionRequest.newBuilder() to construct.
   private CreateSubscriptionRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private CreateSubscriptionRequest() {
     parent_ = "";
     subscriptionId_ = "";
@@ -26,16 +29,15 @@ private static final long serialVersionUID = 0L;
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new CreateSubscriptionRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private CreateSubscriptionRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -54,72 +56,84 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            parent_ = s;
-            break;
-          }
-          case 18: {
-            com.google.cloud.pubsublite.proto.Subscription.Builder subBuilder = null;
-            if (subscription_ != null) {
-              subBuilder = subscription_.toBuilder();
+              parent_ = s;
+              break;
             }
-            subscription_ = input.readMessage(com.google.cloud.pubsublite.proto.Subscription.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(subscription_);
-              subscription_ = subBuilder.buildPartial();
-            }
+          case 18:
+            {
+              com.google.cloud.pubsublite.proto.Subscription.Builder subBuilder = null;
+              if (subscription_ != null) {
+                subBuilder = subscription_.toBuilder();
+              }
+              subscription_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Subscription.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(subscription_);
+                subscription_ = subBuilder.buildPartial();
+              }
 
-            break;
-          }
-          case 26: {
-            java.lang.String s = input.readStringRequireUtf8();
-
-            subscriptionId_ = s;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              break;
             }
-            break;
-          }
+          case 26:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              subscriptionId_ = s;
+              break;
+            }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.CreateSubscriptionRequest.class, com.google.cloud.pubsublite.proto.CreateSubscriptionRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.CreateSubscriptionRequest.class,
+            com.google.cloud.pubsublite.proto.CreateSubscriptionRequest.Builder.class);
   }
 
   public static final int PARENT_FIELD_NUMBER = 1;
   private volatile java.lang.Object parent_;
   /**
+   *
+   *
    * <pre>
    * The parent location in which to create the subscription.
    * Structured like `projects/{project_number}/locations/{location}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The parent.
    */
   public java.lang.String getParent() {
@@ -127,29 +141,31 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       parent_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The parent location in which to create the subscription.
    * Structured like `projects/{project_number}/locations/{location}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for parent.
    */
-  public com.google.protobuf.ByteString
-      getParentBytes() {
+  public com.google.protobuf.ByteString getParentBytes() {
     java.lang.Object ref = parent_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       parent_ = b;
       return b;
     } else {
@@ -160,33 +176,49 @@ private static final long serialVersionUID = 0L;
   public static final int SUBSCRIPTION_FIELD_NUMBER = 2;
   private com.google.cloud.pubsublite.proto.Subscription subscription_;
   /**
+   *
+   *
    * <pre>
    * Configuration of the subscription to create. Its `name` field is ignored.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>
+   * .google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return Whether the subscription field is set.
    */
   public boolean hasSubscription() {
     return subscription_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * Configuration of the subscription to create. Its `name` field is ignored.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>
+   * .google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return The subscription.
    */
   public com.google.cloud.pubsublite.proto.Subscription getSubscription() {
-    return subscription_ == null ? com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance() : subscription_;
+    return subscription_ == null
+        ? com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance()
+        : subscription_;
   }
   /**
+   *
+   *
    * <pre>
    * Configuration of the subscription to create. Its `name` field is ignored.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>
+   * .google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
    */
   public com.google.cloud.pubsublite.proto.SubscriptionOrBuilder getSubscriptionOrBuilder() {
     return getSubscription();
@@ -195,6 +227,8 @@ private static final long serialVersionUID = 0L;
   public static final int SUBSCRIPTION_ID_FIELD_NUMBER = 3;
   private volatile java.lang.Object subscriptionId_;
   /**
+   *
+   *
    * <pre>
    * The ID to use for the subscription, which will become the final component
    * of the subscription's name.
@@ -202,6 +236,7 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string subscription_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+   *
    * @return The subscriptionId.
    */
   public java.lang.String getSubscriptionId() {
@@ -209,14 +244,15 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       subscriptionId_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The ID to use for the subscription, which will become the final component
    * of the subscription's name.
@@ -224,15 +260,14 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string subscription_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+   *
    * @return The bytes for subscriptionId.
    */
-  public com.google.protobuf.ByteString
-      getSubscriptionIdBytes() {
+  public com.google.protobuf.ByteString getSubscriptionIdBytes() {
     java.lang.Object ref = subscriptionId_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       subscriptionId_ = b;
       return b;
     } else {
@@ -241,6 +276,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -252,8 +288,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getParentBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, parent_);
     }
@@ -276,8 +311,7 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, parent_);
     }
     if (subscription_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, getSubscription());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(2, getSubscription());
     }
     if (!getSubscriptionIdBytes().isEmpty()) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, subscriptionId_);
@@ -290,22 +324,20 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.CreateSubscriptionRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.CreateSubscriptionRequest other = (com.google.cloud.pubsublite.proto.CreateSubscriptionRequest) obj;
+    com.google.cloud.pubsublite.proto.CreateSubscriptionRequest other =
+        (com.google.cloud.pubsublite.proto.CreateSubscriptionRequest) obj;
 
-    if (!getParent()
-        .equals(other.getParent())) return false;
+    if (!getParent().equals(other.getParent())) return false;
     if (hasSubscription() != other.hasSubscription()) return false;
     if (hasSubscription()) {
-      if (!getSubscription()
-          .equals(other.getSubscription())) return false;
+      if (!getSubscription().equals(other.getSubscription())) return false;
     }
-    if (!getSubscriptionId()
-        .equals(other.getSubscriptionId())) return false;
+    if (!getSubscriptionId().equals(other.getSubscriptionId())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -331,117 +363,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.CreateSubscriptionRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.CreateSubscriptionRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.CreateSubscriptionRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.CreateSubscriptionRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.CreateSubscriptionRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.CreateSubscriptionRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.CreateSubscriptionRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.CreateSubscriptionRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.CreateSubscriptionRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.CreateSubscriptionRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.CreateSubscriptionRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.CreateSubscriptionRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.CreateSubscriptionRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.CreateSubscriptionRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.CreateSubscriptionRequest prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.CreateSubscriptionRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request for CreateSubscription.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.CreateSubscriptionRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.CreateSubscriptionRequest)
       com.google.cloud.pubsublite.proto.CreateSubscriptionRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.CreateSubscriptionRequest.class, com.google.cloud.pubsublite.proto.CreateSubscriptionRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.CreateSubscriptionRequest.class,
+              com.google.cloud.pubsublite.proto.CreateSubscriptionRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.CreateSubscriptionRequest.newBuilder()
@@ -449,16 +491,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -476,9 +517,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_CreateSubscriptionRequest_descriptor;
     }
 
     @java.lang.Override
@@ -497,7 +538,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.CreateSubscriptionRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.CreateSubscriptionRequest result = new com.google.cloud.pubsublite.proto.CreateSubscriptionRequest(this);
+      com.google.cloud.pubsublite.proto.CreateSubscriptionRequest result =
+          new com.google.cloud.pubsublite.proto.CreateSubscriptionRequest(this);
       result.parent_ = parent_;
       if (subscriptionBuilder_ == null) {
         result.subscription_ = subscription_;
@@ -513,38 +555,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.CreateSubscriptionRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.CreateSubscriptionRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.CreateSubscriptionRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -552,7 +595,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.CreateSubscriptionRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.CreateSubscriptionRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.CreateSubscriptionRequest.getDefaultInstance())
+        return this;
       if (!other.getParent().isEmpty()) {
         parent_ = other.parent_;
         onChanged();
@@ -583,7 +627,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.CreateSubscriptionRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.CreateSubscriptionRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -595,19 +640,23 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object parent_ = "";
     /**
+     *
+     *
      * <pre>
      * The parent location in which to create the subscription.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The parent.
      */
     public java.lang.String getParent() {
       java.lang.Object ref = parent_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         parent_ = s;
         return s;
@@ -616,21 +665,24 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The parent location in which to create the subscription.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The bytes for parent.
      */
-    public com.google.protobuf.ByteString
-        getParentBytes() {
+    public com.google.protobuf.ByteString getParentBytes() {
       java.lang.Object ref = parent_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         parent_ = b;
         return b;
       } else {
@@ -638,57 +690,70 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The parent location in which to create the subscription.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The parent to set.
      * @return This builder for chaining.
      */
-    public Builder setParent(
-        java.lang.String value) {
+    public Builder setParent(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       parent_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The parent location in which to create the subscription.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearParent() {
-      
+
       parent_ = getDefaultInstance().getParent();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The parent location in which to create the subscription.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The bytes for parent to set.
      * @return This builder for chaining.
      */
-    public Builder setParentBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setParentBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       parent_ = value;
       onChanged();
       return this;
@@ -696,39 +761,58 @@ private static final long serialVersionUID = 0L;
 
     private com.google.cloud.pubsublite.proto.Subscription subscription_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Subscription, com.google.cloud.pubsublite.proto.Subscription.Builder, com.google.cloud.pubsublite.proto.SubscriptionOrBuilder> subscriptionBuilder_;
+            com.google.cloud.pubsublite.proto.Subscription,
+            com.google.cloud.pubsublite.proto.Subscription.Builder,
+            com.google.cloud.pubsublite.proto.SubscriptionOrBuilder>
+        subscriptionBuilder_;
     /**
+     *
+     *
      * <pre>
      * Configuration of the subscription to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
+     *
      * @return Whether the subscription field is set.
      */
     public boolean hasSubscription() {
       return subscriptionBuilder_ != null || subscription_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * Configuration of the subscription to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
+     *
      * @return The subscription.
      */
     public com.google.cloud.pubsublite.proto.Subscription getSubscription() {
       if (subscriptionBuilder_ == null) {
-        return subscription_ == null ? com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance() : subscription_;
+        return subscription_ == null
+            ? com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance()
+            : subscription_;
       } else {
         return subscriptionBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * Configuration of the subscription to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder setSubscription(com.google.cloud.pubsublite.proto.Subscription value) {
       if (subscriptionBuilder_ == null) {
@@ -744,11 +828,15 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Configuration of the subscription to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder setSubscription(
         com.google.cloud.pubsublite.proto.Subscription.Builder builderForValue) {
@@ -762,17 +850,23 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Configuration of the subscription to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder mergeSubscription(com.google.cloud.pubsublite.proto.Subscription value) {
       if (subscriptionBuilder_ == null) {
         if (subscription_ != null) {
           subscription_ =
-            com.google.cloud.pubsublite.proto.Subscription.newBuilder(subscription_).mergeFrom(value).buildPartial();
+              com.google.cloud.pubsublite.proto.Subscription.newBuilder(subscription_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           subscription_ = value;
         }
@@ -784,11 +878,15 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Configuration of the subscription to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder clearSubscription() {
       if (subscriptionBuilder_ == null) {
@@ -802,48 +900,64 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Configuration of the subscription to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public com.google.cloud.pubsublite.proto.Subscription.Builder getSubscriptionBuilder() {
-      
+
       onChanged();
       return getSubscriptionFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * Configuration of the subscription to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public com.google.cloud.pubsublite.proto.SubscriptionOrBuilder getSubscriptionOrBuilder() {
       if (subscriptionBuilder_ != null) {
         return subscriptionBuilder_.getMessageOrBuilder();
       } else {
-        return subscription_ == null ?
-            com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance() : subscription_;
+        return subscription_ == null
+            ? com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance()
+            : subscription_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Configuration of the subscription to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Subscription, com.google.cloud.pubsublite.proto.Subscription.Builder, com.google.cloud.pubsublite.proto.SubscriptionOrBuilder> 
+            com.google.cloud.pubsublite.proto.Subscription,
+            com.google.cloud.pubsublite.proto.Subscription.Builder,
+            com.google.cloud.pubsublite.proto.SubscriptionOrBuilder>
         getSubscriptionFieldBuilder() {
       if (subscriptionBuilder_ == null) {
-        subscriptionBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Subscription, com.google.cloud.pubsublite.proto.Subscription.Builder, com.google.cloud.pubsublite.proto.SubscriptionOrBuilder>(
-                getSubscription(),
-                getParentForChildren(),
-                isClean());
+        subscriptionBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Subscription,
+                com.google.cloud.pubsublite.proto.Subscription.Builder,
+                com.google.cloud.pubsublite.proto.SubscriptionOrBuilder>(
+                getSubscription(), getParentForChildren(), isClean());
         subscription_ = null;
       }
       return subscriptionBuilder_;
@@ -851,6 +965,8 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object subscriptionId_ = "";
     /**
+     *
+     *
      * <pre>
      * The ID to use for the subscription, which will become the final component
      * of the subscription's name.
@@ -858,13 +974,13 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string subscription_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+     *
      * @return The subscriptionId.
      */
     public java.lang.String getSubscriptionId() {
       java.lang.Object ref = subscriptionId_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         subscriptionId_ = s;
         return s;
@@ -873,6 +989,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The ID to use for the subscription, which will become the final component
      * of the subscription's name.
@@ -880,15 +998,14 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string subscription_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+     *
      * @return The bytes for subscriptionId.
      */
-    public com.google.protobuf.ByteString
-        getSubscriptionIdBytes() {
+    public com.google.protobuf.ByteString getSubscriptionIdBytes() {
       java.lang.Object ref = subscriptionId_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         subscriptionId_ = b;
         return b;
       } else {
@@ -896,6 +1013,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The ID to use for the subscription, which will become the final component
      * of the subscription's name.
@@ -903,20 +1022,22 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string subscription_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+     *
      * @param value The subscriptionId to set.
      * @return This builder for chaining.
      */
-    public Builder setSubscriptionId(
-        java.lang.String value) {
+    public Builder setSubscriptionId(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       subscriptionId_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The ID to use for the subscription, which will become the final component
      * of the subscription's name.
@@ -924,15 +1045,18 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string subscription_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearSubscriptionId() {
-      
+
       subscriptionId_ = getDefaultInstance().getSubscriptionId();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The ID to use for the subscription, which will become the final component
      * of the subscription's name.
@@ -940,23 +1064,23 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string subscription_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+     *
      * @param value The bytes for subscriptionId to set.
      * @return This builder for chaining.
      */
-    public Builder setSubscriptionIdBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setSubscriptionIdBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       subscriptionId_ = value;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -966,12 +1090,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.CreateSubscriptionRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.CreateSubscriptionRequest)
   private static final com.google.cloud.pubsublite.proto.CreateSubscriptionRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.CreateSubscriptionRequest();
   }
@@ -980,16 +1104,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<CreateSubscriptionRequest>
-      PARSER = new com.google.protobuf.AbstractParser<CreateSubscriptionRequest>() {
-    @java.lang.Override
-    public CreateSubscriptionRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new CreateSubscriptionRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<CreateSubscriptionRequest> PARSER =
+      new com.google.protobuf.AbstractParser<CreateSubscriptionRequest>() {
+        @java.lang.Override
+        public CreateSubscriptionRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new CreateSubscriptionRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<CreateSubscriptionRequest> parser() {
     return PARSER;
@@ -1004,6 +1128,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.CreateSubscriptionRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CreateSubscriptionRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CreateSubscriptionRequestOrBuilder.java
@@ -3,60 +3,86 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface CreateSubscriptionRequestOrBuilder extends
+public interface CreateSubscriptionRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.CreateSubscriptionRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The parent location in which to create the subscription.
    * Structured like `projects/{project_number}/locations/{location}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The parent.
    */
   java.lang.String getParent();
   /**
+   *
+   *
    * <pre>
    * The parent location in which to create the subscription.
    * Structured like `projects/{project_number}/locations/{location}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for parent.
    */
-  com.google.protobuf.ByteString
-      getParentBytes();
+  com.google.protobuf.ByteString getParentBytes();
 
   /**
+   *
+   *
    * <pre>
    * Configuration of the subscription to create. Its `name` field is ignored.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>
+   * .google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return Whether the subscription field is set.
    */
   boolean hasSubscription();
   /**
+   *
+   *
    * <pre>
    * Configuration of the subscription to create. Its `name` field is ignored.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>
+   * .google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return The subscription.
    */
   com.google.cloud.pubsublite.proto.Subscription getSubscription();
   /**
+   *
+   *
    * <pre>
    * Configuration of the subscription to create. Its `name` field is ignored.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>
+   * .google.cloud.pubsublite.v1.Subscription subscription = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
    */
   com.google.cloud.pubsublite.proto.SubscriptionOrBuilder getSubscriptionOrBuilder();
 
   /**
+   *
+   *
    * <pre>
    * The ID to use for the subscription, which will become the final component
    * of the subscription's name.
@@ -64,10 +90,13 @@ public interface CreateSubscriptionRequestOrBuilder extends
    * </pre>
    *
    * <code>string subscription_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+   *
    * @return The subscriptionId.
    */
   java.lang.String getSubscriptionId();
   /**
+   *
+   *
    * <pre>
    * The ID to use for the subscription, which will become the final component
    * of the subscription's name.
@@ -75,8 +104,8 @@ public interface CreateSubscriptionRequestOrBuilder extends
    * </pre>
    *
    * <code>string subscription_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+   *
    * @return The bytes for subscriptionId.
    */
-  com.google.protobuf.ByteString
-      getSubscriptionIdBytes();
+  com.google.protobuf.ByteString getSubscriptionIdBytes();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CreateTopicRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CreateTopicRequest.java
@@ -4,21 +4,24 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request for CreateTopic.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.CreateTopicRequest}
  */
-public  final class CreateTopicRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class CreateTopicRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.CreateTopicRequest)
     CreateTopicRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use CreateTopicRequest.newBuilder() to construct.
   private CreateTopicRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private CreateTopicRequest() {
     parent_ = "";
     topicId_ = "";
@@ -26,16 +29,15 @@ private static final long serialVersionUID = 0L;
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new CreateTopicRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private CreateTopicRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -54,72 +56,84 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            parent_ = s;
-            break;
-          }
-          case 18: {
-            com.google.cloud.pubsublite.proto.Topic.Builder subBuilder = null;
-            if (topic_ != null) {
-              subBuilder = topic_.toBuilder();
+              parent_ = s;
+              break;
             }
-            topic_ = input.readMessage(com.google.cloud.pubsublite.proto.Topic.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(topic_);
-              topic_ = subBuilder.buildPartial();
-            }
+          case 18:
+            {
+              com.google.cloud.pubsublite.proto.Topic.Builder subBuilder = null;
+              if (topic_ != null) {
+                subBuilder = topic_.toBuilder();
+              }
+              topic_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Topic.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(topic_);
+                topic_ = subBuilder.buildPartial();
+              }
 
-            break;
-          }
-          case 26: {
-            java.lang.String s = input.readStringRequireUtf8();
-
-            topicId_ = s;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              break;
             }
-            break;
-          }
+          case 26:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              topicId_ = s;
+              break;
+            }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.CreateTopicRequest.class, com.google.cloud.pubsublite.proto.CreateTopicRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.CreateTopicRequest.class,
+            com.google.cloud.pubsublite.proto.CreateTopicRequest.Builder.class);
   }
 
   public static final int PARENT_FIELD_NUMBER = 1;
   private volatile java.lang.Object parent_;
   /**
+   *
+   *
    * <pre>
    * The parent location in which to create the topic.
    * Structured like `projects/{project_number}/locations/{location}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The parent.
    */
   public java.lang.String getParent() {
@@ -127,29 +141,31 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       parent_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The parent location in which to create the topic.
    * Structured like `projects/{project_number}/locations/{location}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for parent.
    */
-  public com.google.protobuf.ByteString
-      getParentBytes() {
+  public com.google.protobuf.ByteString getParentBytes() {
     java.lang.Object ref = parent_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       parent_ = b;
       return b;
     } else {
@@ -160,33 +176,44 @@ private static final long serialVersionUID = 0L;
   public static final int TOPIC_FIELD_NUMBER = 2;
   private com.google.cloud.pubsublite.proto.Topic topic_;
   /**
+   *
+   *
    * <pre>
    * Configuration of the topic to create. Its `name` field is ignored.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return Whether the topic field is set.
    */
   public boolean hasTopic() {
     return topic_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * Configuration of the topic to create. Its `name` field is ignored.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return The topic.
    */
   public com.google.cloud.pubsublite.proto.Topic getTopic() {
     return topic_ == null ? com.google.cloud.pubsublite.proto.Topic.getDefaultInstance() : topic_;
   }
   /**
+   *
+   *
    * <pre>
    * Configuration of the topic to create. Its `name` field is ignored.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
    */
   public com.google.cloud.pubsublite.proto.TopicOrBuilder getTopicOrBuilder() {
     return getTopic();
@@ -195,6 +222,8 @@ private static final long serialVersionUID = 0L;
   public static final int TOPIC_ID_FIELD_NUMBER = 3;
   private volatile java.lang.Object topicId_;
   /**
+   *
+   *
    * <pre>
    * The ID to use for the topic, which will become the final component of
    * the topic's name.
@@ -202,6 +231,7 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string topic_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+   *
    * @return The topicId.
    */
   public java.lang.String getTopicId() {
@@ -209,14 +239,15 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       topicId_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The ID to use for the topic, which will become the final component of
    * the topic's name.
@@ -224,15 +255,14 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string topic_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+   *
    * @return The bytes for topicId.
    */
-  public com.google.protobuf.ByteString
-      getTopicIdBytes() {
+  public com.google.protobuf.ByteString getTopicIdBytes() {
     java.lang.Object ref = topicId_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       topicId_ = b;
       return b;
     } else {
@@ -241,6 +271,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -252,8 +283,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getParentBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, parent_);
     }
@@ -276,8 +306,7 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, parent_);
     }
     if (topic_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, getTopic());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(2, getTopic());
     }
     if (!getTopicIdBytes().isEmpty()) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, topicId_);
@@ -290,22 +319,20 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.CreateTopicRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.CreateTopicRequest other = (com.google.cloud.pubsublite.proto.CreateTopicRequest) obj;
+    com.google.cloud.pubsublite.proto.CreateTopicRequest other =
+        (com.google.cloud.pubsublite.proto.CreateTopicRequest) obj;
 
-    if (!getParent()
-        .equals(other.getParent())) return false;
+    if (!getParent().equals(other.getParent())) return false;
     if (hasTopic() != other.hasTopic()) return false;
     if (hasTopic()) {
-      if (!getTopic()
-          .equals(other.getTopic())) return false;
+      if (!getTopic().equals(other.getTopic())) return false;
     }
-    if (!getTopicId()
-        .equals(other.getTopicId())) return false;
+    if (!getTopicId().equals(other.getTopicId())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -331,117 +358,126 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.CreateTopicRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.CreateTopicRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.CreateTopicRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.CreateTopicRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.CreateTopicRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.CreateTopicRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.CreateTopicRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.CreateTopicRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.CreateTopicRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.CreateTopicRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.CreateTopicRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.CreateTopicRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.CreateTopicRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.CreateTopicRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.CreateTopicRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request for CreateTopic.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.CreateTopicRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.CreateTopicRequest)
       com.google.cloud.pubsublite.proto.CreateTopicRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.CreateTopicRequest.class, com.google.cloud.pubsublite.proto.CreateTopicRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.CreateTopicRequest.class,
+              com.google.cloud.pubsublite.proto.CreateTopicRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.CreateTopicRequest.newBuilder()
@@ -449,16 +485,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -476,9 +511,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_CreateTopicRequest_descriptor;
     }
 
     @java.lang.Override
@@ -497,7 +532,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.CreateTopicRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.CreateTopicRequest result = new com.google.cloud.pubsublite.proto.CreateTopicRequest(this);
+      com.google.cloud.pubsublite.proto.CreateTopicRequest result =
+          new com.google.cloud.pubsublite.proto.CreateTopicRequest(this);
       result.parent_ = parent_;
       if (topicBuilder_ == null) {
         result.topic_ = topic_;
@@ -513,38 +549,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.CreateTopicRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.CreateTopicRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.CreateTopicRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -552,7 +589,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.CreateTopicRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.CreateTopicRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.CreateTopicRequest.getDefaultInstance())
+        return this;
       if (!other.getParent().isEmpty()) {
         parent_ = other.parent_;
         onChanged();
@@ -583,7 +621,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.CreateTopicRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.CreateTopicRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -595,19 +634,23 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object parent_ = "";
     /**
+     *
+     *
      * <pre>
      * The parent location in which to create the topic.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The parent.
      */
     public java.lang.String getParent() {
       java.lang.Object ref = parent_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         parent_ = s;
         return s;
@@ -616,21 +659,24 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The parent location in which to create the topic.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The bytes for parent.
      */
-    public com.google.protobuf.ByteString
-        getParentBytes() {
+    public com.google.protobuf.ByteString getParentBytes() {
       java.lang.Object ref = parent_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         parent_ = b;
         return b;
       } else {
@@ -638,57 +684,70 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The parent location in which to create the topic.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The parent to set.
      * @return This builder for chaining.
      */
-    public Builder setParent(
-        java.lang.String value) {
+    public Builder setParent(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       parent_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The parent location in which to create the topic.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearParent() {
-      
+
       parent_ = getDefaultInstance().getParent();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The parent location in which to create the topic.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The bytes for parent to set.
      * @return This builder for chaining.
      */
-    public Builder setParentBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setParentBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       parent_ = value;
       onChanged();
       return this;
@@ -696,39 +755,55 @@ private static final long serialVersionUID = 0L;
 
     private com.google.cloud.pubsublite.proto.Topic topic_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Topic, com.google.cloud.pubsublite.proto.Topic.Builder, com.google.cloud.pubsublite.proto.TopicOrBuilder> topicBuilder_;
+            com.google.cloud.pubsublite.proto.Topic,
+            com.google.cloud.pubsublite.proto.Topic.Builder,
+            com.google.cloud.pubsublite.proto.TopicOrBuilder>
+        topicBuilder_;
     /**
+     *
+     *
      * <pre>
      * Configuration of the topic to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
+     *
      * @return Whether the topic field is set.
      */
     public boolean hasTopic() {
       return topicBuilder_ != null || topic_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * Configuration of the topic to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
+     *
      * @return The topic.
      */
     public com.google.cloud.pubsublite.proto.Topic getTopic() {
       if (topicBuilder_ == null) {
-        return topic_ == null ? com.google.cloud.pubsublite.proto.Topic.getDefaultInstance() : topic_;
+        return topic_ == null
+            ? com.google.cloud.pubsublite.proto.Topic.getDefaultInstance()
+            : topic_;
       } else {
         return topicBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * Configuration of the topic to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder setTopic(com.google.cloud.pubsublite.proto.Topic value) {
       if (topicBuilder_ == null) {
@@ -744,14 +819,16 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Configuration of the topic to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
-    public Builder setTopic(
-        com.google.cloud.pubsublite.proto.Topic.Builder builderForValue) {
+    public Builder setTopic(com.google.cloud.pubsublite.proto.Topic.Builder builderForValue) {
       if (topicBuilder_ == null) {
         topic_ = builderForValue.build();
         onChanged();
@@ -762,17 +839,22 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Configuration of the topic to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder mergeTopic(com.google.cloud.pubsublite.proto.Topic value) {
       if (topicBuilder_ == null) {
         if (topic_ != null) {
           topic_ =
-            com.google.cloud.pubsublite.proto.Topic.newBuilder(topic_).mergeFrom(value).buildPartial();
+              com.google.cloud.pubsublite.proto.Topic.newBuilder(topic_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           topic_ = value;
         }
@@ -784,11 +866,14 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Configuration of the topic to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder clearTopic() {
       if (topicBuilder_ == null) {
@@ -802,48 +887,61 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Configuration of the topic to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public com.google.cloud.pubsublite.proto.Topic.Builder getTopicBuilder() {
-      
+
       onChanged();
       return getTopicFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * Configuration of the topic to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public com.google.cloud.pubsublite.proto.TopicOrBuilder getTopicOrBuilder() {
       if (topicBuilder_ != null) {
         return topicBuilder_.getMessageOrBuilder();
       } else {
-        return topic_ == null ?
-            com.google.cloud.pubsublite.proto.Topic.getDefaultInstance() : topic_;
+        return topic_ == null
+            ? com.google.cloud.pubsublite.proto.Topic.getDefaultInstance()
+            : topic_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Configuration of the topic to create. Its `name` field is ignored.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Topic, com.google.cloud.pubsublite.proto.Topic.Builder, com.google.cloud.pubsublite.proto.TopicOrBuilder> 
+            com.google.cloud.pubsublite.proto.Topic,
+            com.google.cloud.pubsublite.proto.Topic.Builder,
+            com.google.cloud.pubsublite.proto.TopicOrBuilder>
         getTopicFieldBuilder() {
       if (topicBuilder_ == null) {
-        topicBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Topic, com.google.cloud.pubsublite.proto.Topic.Builder, com.google.cloud.pubsublite.proto.TopicOrBuilder>(
-                getTopic(),
-                getParentForChildren(),
-                isClean());
+        topicBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Topic,
+                com.google.cloud.pubsublite.proto.Topic.Builder,
+                com.google.cloud.pubsublite.proto.TopicOrBuilder>(
+                getTopic(), getParentForChildren(), isClean());
         topic_ = null;
       }
       return topicBuilder_;
@@ -851,6 +949,8 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object topicId_ = "";
     /**
+     *
+     *
      * <pre>
      * The ID to use for the topic, which will become the final component of
      * the topic's name.
@@ -858,13 +958,13 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string topic_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+     *
      * @return The topicId.
      */
     public java.lang.String getTopicId() {
       java.lang.Object ref = topicId_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         topicId_ = s;
         return s;
@@ -873,6 +973,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The ID to use for the topic, which will become the final component of
      * the topic's name.
@@ -880,15 +982,14 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string topic_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+     *
      * @return The bytes for topicId.
      */
-    public com.google.protobuf.ByteString
-        getTopicIdBytes() {
+    public com.google.protobuf.ByteString getTopicIdBytes() {
       java.lang.Object ref = topicId_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         topicId_ = b;
         return b;
       } else {
@@ -896,6 +997,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The ID to use for the topic, which will become the final component of
      * the topic's name.
@@ -903,20 +1006,22 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string topic_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+     *
      * @param value The topicId to set.
      * @return This builder for chaining.
      */
-    public Builder setTopicId(
-        java.lang.String value) {
+    public Builder setTopicId(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       topicId_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The ID to use for the topic, which will become the final component of
      * the topic's name.
@@ -924,15 +1029,18 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string topic_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearTopicId() {
-      
+
       topicId_ = getDefaultInstance().getTopicId();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The ID to use for the topic, which will become the final component of
      * the topic's name.
@@ -940,23 +1048,23 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string topic_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+     *
      * @param value The bytes for topicId to set.
      * @return This builder for chaining.
      */
-    public Builder setTopicIdBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setTopicIdBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       topicId_ = value;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -966,12 +1074,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.CreateTopicRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.CreateTopicRequest)
   private static final com.google.cloud.pubsublite.proto.CreateTopicRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.CreateTopicRequest();
   }
@@ -980,16 +1088,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<CreateTopicRequest>
-      PARSER = new com.google.protobuf.AbstractParser<CreateTopicRequest>() {
-    @java.lang.Override
-    public CreateTopicRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new CreateTopicRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<CreateTopicRequest> PARSER =
+      new com.google.protobuf.AbstractParser<CreateTopicRequest>() {
+        @java.lang.Override
+        public CreateTopicRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new CreateTopicRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<CreateTopicRequest> parser() {
     return PARSER;
@@ -1004,6 +1112,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.CreateTopicRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CreateTopicRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CreateTopicRequestOrBuilder.java
@@ -3,60 +3,83 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface CreateTopicRequestOrBuilder extends
+public interface CreateTopicRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.CreateTopicRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The parent location in which to create the topic.
    * Structured like `projects/{project_number}/locations/{location}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The parent.
    */
   java.lang.String getParent();
   /**
+   *
+   *
    * <pre>
    * The parent location in which to create the topic.
    * Structured like `projects/{project_number}/locations/{location}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for parent.
    */
-  com.google.protobuf.ByteString
-      getParentBytes();
+  com.google.protobuf.ByteString getParentBytes();
 
   /**
+   *
+   *
    * <pre>
    * Configuration of the topic to create. Its `name` field is ignored.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return Whether the topic field is set.
    */
   boolean hasTopic();
   /**
+   *
+   *
    * <pre>
    * Configuration of the topic to create. Its `name` field is ignored.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return The topic.
    */
   com.google.cloud.pubsublite.proto.Topic getTopic();
   /**
+   *
+   *
    * <pre>
    * Configuration of the topic to create. Its `name` field is ignored.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.cloud.pubsublite.v1.Topic topic = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
    */
   com.google.cloud.pubsublite.proto.TopicOrBuilder getTopicOrBuilder();
 
   /**
+   *
+   *
    * <pre>
    * The ID to use for the topic, which will become the final component of
    * the topic's name.
@@ -64,10 +87,13 @@ public interface CreateTopicRequestOrBuilder extends
    * </pre>
    *
    * <code>string topic_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+   *
    * @return The topicId.
    */
   java.lang.String getTopicId();
   /**
+   *
+   *
    * <pre>
    * The ID to use for the topic, which will become the final component of
    * the topic's name.
@@ -75,8 +101,8 @@ public interface CreateTopicRequestOrBuilder extends
    * </pre>
    *
    * <code>string topic_id = 3 [(.google.api.field_behavior) = REQUIRED];</code>
+   *
    * @return The bytes for topicId.
    */
-  com.google.protobuf.ByteString
-      getTopicIdBytes();
+  com.google.protobuf.ByteString getTopicIdBytes();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/Cursor.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/Cursor.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * A cursor that describes the position of a message within a topic partition.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.Cursor}
  */
-public  final class Cursor extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class Cursor extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.Cursor)
     CursorOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use Cursor.newBuilder() to construct.
   private Cursor(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private Cursor() {
-  }
+
+  private Cursor() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new Cursor();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private Cursor(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,52 +53,57 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 8: {
-
-            offset_ = input.readInt64();
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+          case 8:
+            {
+              offset_ = input.readInt64();
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Cursor_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CommonProto
+        .internal_static_google_cloud_pubsublite_v1_Cursor_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Cursor_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CommonProto
+        .internal_static_google_cloud_pubsublite_v1_Cursor_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.Cursor.class, com.google.cloud.pubsublite.proto.Cursor.Builder.class);
+            com.google.cloud.pubsublite.proto.Cursor.class,
+            com.google.cloud.pubsublite.proto.Cursor.Builder.class);
   }
 
   public static final int OFFSET_FIELD_NUMBER = 1;
   private long offset_;
   /**
+   *
+   *
    * <pre>
    * The offset of a message within a topic partition. Must be greater than or
    * equal 0.
    * </pre>
    *
    * <code>int64 offset = 1;</code>
+   *
    * @return The offset.
    */
   public long getOffset() {
@@ -105,6 +111,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -116,8 +123,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (offset_ != 0L) {
       output.writeInt64(1, offset_);
     }
@@ -131,8 +137,7 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (offset_ != 0L) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeInt64Size(1, offset_);
+      size += com.google.protobuf.CodedOutputStream.computeInt64Size(1, offset_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -142,15 +147,14 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.Cursor)) {
       return super.equals(obj);
     }
     com.google.cloud.pubsublite.proto.Cursor other = (com.google.cloud.pubsublite.proto.Cursor) obj;
 
-    if (getOffset()
-        != other.getOffset()) return false;
+    if (getOffset() != other.getOffset()) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -163,125 +167,133 @@ private static final long serialVersionUID = 0L;
     int hash = 41;
     hash = (19 * hash) + getDescriptor().hashCode();
     hash = (37 * hash) + OFFSET_FIELD_NUMBER;
-    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-        getOffset());
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(getOffset());
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
   }
 
-  public static com.google.cloud.pubsublite.proto.Cursor parseFrom(
-      java.nio.ByteBuffer data)
+  public static com.google.cloud.pubsublite.proto.Cursor parseFrom(java.nio.ByteBuffer data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.Cursor parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.Cursor parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.Cursor parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.Cursor parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.Cursor parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.Cursor parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.Cursor parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.Cursor parseDelimitedFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.Cursor parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.Cursor parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.Cursor parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.Cursor parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.Cursor prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * A cursor that describes the position of a message within a topic partition.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.Cursor}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.Cursor)
       com.google.cloud.pubsublite.proto.CursorOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Cursor_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_Cursor_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Cursor_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_Cursor_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.Cursor.class, com.google.cloud.pubsublite.proto.Cursor.Builder.class);
+              com.google.cloud.pubsublite.proto.Cursor.class,
+              com.google.cloud.pubsublite.proto.Cursor.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.Cursor.newBuilder()
@@ -289,16 +301,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -308,9 +319,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Cursor_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_Cursor_descriptor;
     }
 
     @java.lang.Override
@@ -329,7 +340,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.Cursor buildPartial() {
-      com.google.cloud.pubsublite.proto.Cursor result = new com.google.cloud.pubsublite.proto.Cursor(this);
+      com.google.cloud.pubsublite.proto.Cursor result =
+          new com.google.cloud.pubsublite.proto.Cursor(this);
       result.offset_ = offset_;
       onBuilt();
       return result;
@@ -339,38 +351,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.Cursor) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.Cursor)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.Cursor) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -411,53 +424,62 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-    private long offset_ ;
+    private long offset_;
     /**
+     *
+     *
      * <pre>
      * The offset of a message within a topic partition. Must be greater than or
      * equal 0.
      * </pre>
      *
      * <code>int64 offset = 1;</code>
+     *
      * @return The offset.
      */
     public long getOffset() {
       return offset_;
     }
     /**
+     *
+     *
      * <pre>
      * The offset of a message within a topic partition. Must be greater than or
      * equal 0.
      * </pre>
      *
      * <code>int64 offset = 1;</code>
+     *
      * @param value The offset to set.
      * @return This builder for chaining.
      */
     public Builder setOffset(long value) {
-      
+
       offset_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The offset of a message within a topic partition. Must be greater than or
      * equal 0.
      * </pre>
      *
      * <code>int64 offset = 1;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearOffset() {
-      
+
       offset_ = 0L;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -467,12 +489,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.Cursor)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.Cursor)
   private static final com.google.cloud.pubsublite.proto.Cursor DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.Cursor();
   }
@@ -481,16 +503,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<Cursor>
-      PARSER = new com.google.protobuf.AbstractParser<Cursor>() {
-    @java.lang.Override
-    public Cursor parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new Cursor(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<Cursor> PARSER =
+      new com.google.protobuf.AbstractParser<Cursor>() {
+        @java.lang.Override
+        public Cursor parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new Cursor(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<Cursor> parser() {
     return PARSER;
@@ -505,6 +527,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.Cursor getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CursorOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CursorOrBuilder.java
@@ -3,17 +3,21 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface CursorOrBuilder extends
+public interface CursorOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.Cursor)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The offset of a message within a topic partition. Must be greater than or
    * equal 0.
    * </pre>
    *
    * <code>int64 offset = 1;</code>
+   *
    * @return The offset.
    */
   long getOffset();

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CursorProto.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/CursorProto.java
@@ -5,212 +5,218 @@ package com.google.cloud.pubsublite.proto;
 
 public final class CursorProto {
   private CursorProto() {}
-  public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistryLite registry) {
+
+  public static void registerAllExtensions(com.google.protobuf.ExtensionRegistryLite registry) {}
+
+  public static void registerAllExtensions(com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions((com.google.protobuf.ExtensionRegistryLite) registry);
   }
 
-  public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
-    registerAllExtensions(
-        (com.google.protobuf.ExtensionRegistryLite) registry);
-  }
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_PartitionCursor_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_PartitionCursor_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_PartitionCursor_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_fieldAccessorTable;
 
-  public static com.google.protobuf.Descriptors.FileDescriptor
-      getDescriptor() {
+  public static com.google.protobuf.Descriptors.FileDescriptor getDescriptor() {
     return descriptor;
   }
-  private static  com.google.protobuf.Descriptors.FileDescriptor
-      descriptor;
+
+  private static com.google.protobuf.Descriptors.FileDescriptor descriptor;
+
   static {
     java.lang.String[] descriptorData = {
-      "\n\'google/cloud/pubsublite/v1/cursor.prot" +
-      "o\022\032google.cloud.pubsublite.v1\032\034google/ap" +
-      "i/annotations.proto\032\027google/api/client.p" +
-      "roto\032\037google/api/field_behavior.proto\032\031g" +
-      "oogle/api/resource.proto\032\'google/cloud/p" +
-      "ubsublite/v1/common.proto\"E\n\032InitialComm" +
-      "itCursorRequest\022\024\n\014subscription\030\001 \001(\t\022\021\n" +
-      "\tpartition\030\002 \001(\003\"\035\n\033InitialCommitCursorR" +
-      "esponse\"R\n\034SequencedCommitCursorRequest\022" +
-      "2\n\006cursor\030\001 \001(\0132\".google.cloud.pubsublit" +
-      "e.v1.Cursor\"=\n\035SequencedCommitCursorResp" +
-      "onse\022\034\n\024acknowledged_commits\030\001 \001(\003\"\300\001\n\034S" +
-      "treamingCommitCursorRequest\022I\n\007initial\030\001" +
-      " \001(\01326.google.cloud.pubsublite.v1.Initia" +
-      "lCommitCursorRequestH\000\022J\n\006commit\030\002 \001(\01328" +
-      ".google.cloud.pubsublite.v1.SequencedCom" +
-      "mitCursorRequestH\000B\t\n\007request\"\303\001\n\035Stream" +
-      "ingCommitCursorResponse\022J\n\007initial\030\001 \001(\013" +
-      "27.google.cloud.pubsublite.v1.InitialCom" +
-      "mitCursorResponseH\000\022K\n\006commit\030\002 \001(\01329.go" +
-      "ogle.cloud.pubsublite.v1.SequencedCommit" +
-      "CursorResponseH\000B\t\n\007request\"r\n\023CommitCur" +
-      "sorRequest\022\024\n\014subscription\030\001 \001(\t\022\021\n\tpart" +
-      "ition\030\002 \001(\003\0222\n\006cursor\030\003 \001(\0132\".google.clo" +
-      "ud.pubsublite.v1.Cursor\"\026\n\024CommitCursorR" +
-      "esponse\"\204\001\n\033ListPartitionCursorsRequest\022" +
-      ">\n\006parent\030\001 \001(\tB.\340A\002\372A(\n&pubsublite.goog" +
-      "leapis.com/Subscription\022\021\n\tpage_size\030\002 \001" +
-      "(\005\022\022\n\npage_token\030\003 \001(\t\"X\n\017PartitionCurso" +
-      "r\022\021\n\tpartition\030\001 \001(\003\0222\n\006cursor\030\002 \001(\0132\".g" +
-      "oogle.cloud.pubsublite.v1.Cursor\"\177\n\034List" +
-      "PartitionCursorsResponse\022F\n\021partition_cu" +
-      "rsors\030\001 \003(\0132+.google.cloud.pubsublite.v1" +
-      ".PartitionCursor\022\027\n\017next_page_token\030\002 \001(" +
-      "\t2\372\003\n\rCursorService\022\222\001\n\025StreamingCommitC" +
-      "ursor\0228.google.cloud.pubsublite.v1.Strea" +
-      "mingCommitCursorRequest\0329.google.cloud.p" +
-      "ubsublite.v1.StreamingCommitCursorRespon" +
-      "se\"\000(\0010\001\022s\n\014CommitCursor\022/.google.cloud." +
-      "pubsublite.v1.CommitCursorRequest\0320.goog" +
-      "le.cloud.pubsublite.v1.CommitCursorRespo" +
-      "nse\"\000\022\336\001\n\024ListPartitionCursors\0227.google." +
-      "cloud.pubsublite.v1.ListPartitionCursors" +
-      "Request\0328.google.cloud.pubsublite.v1.Lis" +
-      "tPartitionCursorsResponse\"S\202\323\344\223\002D\022B/v1/c" +
-      "ursor/{parent=projects/*/locations/*/sub" +
-      "scriptions/*}/cursors\332A\006parentB5\n!com.go" +
-      "ogle.cloud.pubsublite.protoB\013CursorProto" +
-      "P\001\370\001\001b\006proto3"
+      "\n\'google/cloud/pubsublite/v1/cursor.prot"
+          + "o\022\032google.cloud.pubsublite.v1\032\034google/ap"
+          + "i/annotations.proto\032\027google/api/client.p"
+          + "roto\032\037google/api/field_behavior.proto\032\031g"
+          + "oogle/api/resource.proto\032\'google/cloud/p"
+          + "ubsublite/v1/common.proto\"E\n\032InitialComm"
+          + "itCursorRequest\022\024\n\014subscription\030\001 \001(\t\022\021\n"
+          + "\tpartition\030\002 \001(\003\"\035\n\033InitialCommitCursorR"
+          + "esponse\"R\n\034SequencedCommitCursorRequest\022"
+          + "2\n\006cursor\030\001 \001(\0132\".google.cloud.pubsublit"
+          + "e.v1.Cursor\"=\n\035SequencedCommitCursorResp"
+          + "onse\022\034\n\024acknowledged_commits\030\001 \001(\003\"\300\001\n\034S"
+          + "treamingCommitCursorRequest\022I\n\007initial\030\001"
+          + " \001(\01326.google.cloud.pubsublite.v1.Initia"
+          + "lCommitCursorRequestH\000\022J\n\006commit\030\002 \001(\01328"
+          + ".google.cloud.pubsublite.v1.SequencedCom"
+          + "mitCursorRequestH\000B\t\n\007request\"\303\001\n\035Stream"
+          + "ingCommitCursorResponse\022J\n\007initial\030\001 \001(\013"
+          + "27.google.cloud.pubsublite.v1.InitialCom"
+          + "mitCursorResponseH\000\022K\n\006commit\030\002 \001(\01329.go"
+          + "ogle.cloud.pubsublite.v1.SequencedCommit"
+          + "CursorResponseH\000B\t\n\007request\"r\n\023CommitCur"
+          + "sorRequest\022\024\n\014subscription\030\001 \001(\t\022\021\n\tpart"
+          + "ition\030\002 \001(\003\0222\n\006cursor\030\003 \001(\0132\".google.clo"
+          + "ud.pubsublite.v1.Cursor\"\026\n\024CommitCursorR"
+          + "esponse\"\204\001\n\033ListPartitionCursorsRequest\022"
+          + ">\n\006parent\030\001 \001(\tB.\340A\002\372A(\n&pubsublite.goog"
+          + "leapis.com/Subscription\022\021\n\tpage_size\030\002 \001"
+          + "(\005\022\022\n\npage_token\030\003 \001(\t\"X\n\017PartitionCurso"
+          + "r\022\021\n\tpartition\030\001 \001(\003\0222\n\006cursor\030\002 \001(\0132\".g"
+          + "oogle.cloud.pubsublite.v1.Cursor\"\177\n\034List"
+          + "PartitionCursorsResponse\022F\n\021partition_cu"
+          + "rsors\030\001 \003(\0132+.google.cloud.pubsublite.v1"
+          + ".PartitionCursor\022\027\n\017next_page_token\030\002 \001("
+          + "\t2\372\003\n\rCursorService\022\222\001\n\025StreamingCommitC"
+          + "ursor\0228.google.cloud.pubsublite.v1.Strea"
+          + "mingCommitCursorRequest\0329.google.cloud.p"
+          + "ubsublite.v1.StreamingCommitCursorRespon"
+          + "se\"\000(\0010\001\022s\n\014CommitCursor\022/.google.cloud."
+          + "pubsublite.v1.CommitCursorRequest\0320.goog"
+          + "le.cloud.pubsublite.v1.CommitCursorRespo"
+          + "nse\"\000\022\336\001\n\024ListPartitionCursors\0227.google."
+          + "cloud.pubsublite.v1.ListPartitionCursors"
+          + "Request\0328.google.cloud.pubsublite.v1.Lis"
+          + "tPartitionCursorsResponse\"S\202\323\344\223\002D\022B/v1/c"
+          + "ursor/{parent=projects/*/locations/*/sub"
+          + "scriptions/*}/cursors\332A\006parentB5\n!com.go"
+          + "ogle.cloud.pubsublite.protoB\013CursorProto"
+          + "P\001\370\001\001b\006proto3"
     };
-    descriptor = com.google.protobuf.Descriptors.FileDescriptor
-      .internalBuildGeneratedFileFrom(descriptorData,
-        new com.google.protobuf.Descriptors.FileDescriptor[] {
-          com.google.api.AnnotationsProto.getDescriptor(),
-          com.google.api.ClientProto.getDescriptor(),
-          com.google.api.FieldBehaviorProto.getDescriptor(),
-          com.google.api.ResourceProto.getDescriptor(),
-          com.google.cloud.pubsublite.proto.CommonProto.getDescriptor(),
-        });
+    descriptor =
+        com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
+            descriptorData,
+            new com.google.protobuf.Descriptors.FileDescriptor[] {
+              com.google.api.AnnotationsProto.getDescriptor(),
+              com.google.api.ClientProto.getDescriptor(),
+              com.google.api.FieldBehaviorProto.getDescriptor(),
+              com.google.api.ResourceProto.getDescriptor(),
+              com.google.cloud.pubsublite.proto.CommonProto.getDescriptor(),
+            });
     internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_descriptor =
-      getDescriptor().getMessageTypes().get(0);
-    internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_descriptor,
-        new java.lang.String[] { "Subscription", "Partition", });
+        getDescriptor().getMessageTypes().get(0);
+    internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_descriptor,
+            new java.lang.String[] {
+              "Subscription", "Partition",
+            });
     internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_descriptor =
-      getDescriptor().getMessageTypes().get(1);
-    internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_descriptor,
-        new java.lang.String[] { });
+        getDescriptor().getMessageTypes().get(1);
+    internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_descriptor,
+            new java.lang.String[] {});
     internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_descriptor =
-      getDescriptor().getMessageTypes().get(2);
-    internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_descriptor,
-        new java.lang.String[] { "Cursor", });
+        getDescriptor().getMessageTypes().get(2);
+    internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_descriptor,
+            new java.lang.String[] {
+              "Cursor",
+            });
     internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_descriptor =
-      getDescriptor().getMessageTypes().get(3);
-    internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_descriptor,
-        new java.lang.String[] { "AcknowledgedCommits", });
+        getDescriptor().getMessageTypes().get(3);
+    internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_descriptor,
+            new java.lang.String[] {
+              "AcknowledgedCommits",
+            });
     internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_descriptor =
-      getDescriptor().getMessageTypes().get(4);
-    internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_descriptor,
-        new java.lang.String[] { "Initial", "Commit", "Request", });
+        getDescriptor().getMessageTypes().get(4);
+    internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_descriptor,
+            new java.lang.String[] {
+              "Initial", "Commit", "Request",
+            });
     internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_descriptor =
-      getDescriptor().getMessageTypes().get(5);
-    internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_descriptor,
-        new java.lang.String[] { "Initial", "Commit", "Request", });
+        getDescriptor().getMessageTypes().get(5);
+    internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_descriptor,
+            new java.lang.String[] {
+              "Initial", "Commit", "Request",
+            });
     internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_descriptor =
-      getDescriptor().getMessageTypes().get(6);
-    internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_descriptor,
-        new java.lang.String[] { "Subscription", "Partition", "Cursor", });
+        getDescriptor().getMessageTypes().get(6);
+    internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_CommitCursorRequest_descriptor,
+            new java.lang.String[] {
+              "Subscription", "Partition", "Cursor",
+            });
     internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_descriptor =
-      getDescriptor().getMessageTypes().get(7);
-    internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_descriptor,
-        new java.lang.String[] { });
+        getDescriptor().getMessageTypes().get(7);
+    internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_CommitCursorResponse_descriptor,
+            new java.lang.String[] {});
     internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_descriptor =
-      getDescriptor().getMessageTypes().get(8);
-    internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_descriptor,
-        new java.lang.String[] { "Parent", "PageSize", "PageToken", });
+        getDescriptor().getMessageTypes().get(8);
+    internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_descriptor,
+            new java.lang.String[] {
+              "Parent", "PageSize", "PageToken",
+            });
     internal_static_google_cloud_pubsublite_v1_PartitionCursor_descriptor =
-      getDescriptor().getMessageTypes().get(9);
-    internal_static_google_cloud_pubsublite_v1_PartitionCursor_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_PartitionCursor_descriptor,
-        new java.lang.String[] { "Partition", "Cursor", });
+        getDescriptor().getMessageTypes().get(9);
+    internal_static_google_cloud_pubsublite_v1_PartitionCursor_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_PartitionCursor_descriptor,
+            new java.lang.String[] {
+              "Partition", "Cursor",
+            });
     internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_descriptor =
-      getDescriptor().getMessageTypes().get(10);
-    internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_descriptor,
-        new java.lang.String[] { "PartitionCursors", "NextPageToken", });
+        getDescriptor().getMessageTypes().get(10);
+    internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_descriptor,
+            new java.lang.String[] {
+              "PartitionCursors", "NextPageToken",
+            });
     com.google.protobuf.ExtensionRegistry registry =
         com.google.protobuf.ExtensionRegistry.newInstance();
     registry.add(com.google.api.FieldBehaviorProto.fieldBehavior);
     registry.add(com.google.api.AnnotationsProto.http);
     registry.add(com.google.api.ClientProto.methodSignature);
     registry.add(com.google.api.ResourceProto.resourceReference);
-    com.google.protobuf.Descriptors.FileDescriptor
-        .internalUpdateFileDescriptor(descriptor, registry);
+    com.google.protobuf.Descriptors.FileDescriptor.internalUpdateFileDescriptor(
+        descriptor, registry);
     com.google.api.AnnotationsProto.getDescriptor();
     com.google.api.ClientProto.getDescriptor();
     com.google.api.FieldBehaviorProto.getDescriptor();

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/DeleteSubscriptionRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/DeleteSubscriptionRequest.java
@@ -4,37 +4,39 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request for DeleteSubscription.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.DeleteSubscriptionRequest}
  */
-public  final class DeleteSubscriptionRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class DeleteSubscriptionRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.DeleteSubscriptionRequest)
     DeleteSubscriptionRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use DeleteSubscriptionRequest.newBuilder() to construct.
   private DeleteSubscriptionRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private DeleteSubscriptionRequest() {
     name_ = "";
   }
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new DeleteSubscriptionRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private DeleteSubscriptionRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -53,52 +55,60 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            name_ = s;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              name_ = s;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest.class, com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest.class,
+            com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest.Builder.class);
   }
 
   public static final int NAME_FIELD_NUMBER = 1;
   private volatile java.lang.Object name_;
   /**
+   *
+   *
    * <pre>
    * The name of the subscription to delete.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The name.
    */
   public java.lang.String getName() {
@@ -106,28 +116,30 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       name_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The name of the subscription to delete.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for name.
    */
-  public com.google.protobuf.ByteString
-      getNameBytes() {
+  public com.google.protobuf.ByteString getNameBytes() {
     java.lang.Object ref = name_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       name_ = b;
       return b;
     } else {
@@ -136,6 +148,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -147,8 +160,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
@@ -172,15 +184,15 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest other = (com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest) obj;
+    com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest other =
+        (com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest) obj;
 
-    if (!getName()
-        .equals(other.getName())) return false;
+    if (!getName().equals(other.getName())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -200,117 +212,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request for DeleteSubscription.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.DeleteSubscriptionRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.DeleteSubscriptionRequest)
       com.google.cloud.pubsublite.proto.DeleteSubscriptionRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest.class, com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest.class,
+              com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest.newBuilder()
@@ -318,16 +340,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -337,9 +358,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_DeleteSubscriptionRequest_descriptor;
     }
 
     @java.lang.Override
@@ -358,7 +379,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest result = new com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest(this);
+      com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest result =
+          new com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest(this);
       result.name_ = name_;
       onBuilt();
       return result;
@@ -368,38 +390,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -407,7 +430,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest.getDefaultInstance())
+        return this;
       if (!other.getName().isEmpty()) {
         name_ = other.name_;
         onChanged();
@@ -431,7 +455,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -443,18 +468,22 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object name_ = "";
     /**
+     *
+     *
      * <pre>
      * The name of the subscription to delete.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The name.
      */
     public java.lang.String getName() {
       java.lang.Object ref = name_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         name_ = s;
         return s;
@@ -463,20 +492,23 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The name of the subscription to delete.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The bytes for name.
      */
-    public com.google.protobuf.ByteString
-        getNameBytes() {
+    public com.google.protobuf.ByteString getNameBytes() {
       java.lang.Object ref = name_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         name_ = b;
         return b;
       } else {
@@ -484,61 +516,74 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The name of the subscription to delete.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The name to set.
      * @return This builder for chaining.
      */
-    public Builder setName(
-        java.lang.String value) {
+    public Builder setName(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       name_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The name of the subscription to delete.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearName() {
-      
+
       name_ = getDefaultInstance().getName();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The name of the subscription to delete.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The bytes for name to set.
      * @return This builder for chaining.
      */
-    public Builder setNameBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setNameBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       name_ = value;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -548,12 +593,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.DeleteSubscriptionRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.DeleteSubscriptionRequest)
   private static final com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest();
   }
@@ -562,16 +607,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<DeleteSubscriptionRequest>
-      PARSER = new com.google.protobuf.AbstractParser<DeleteSubscriptionRequest>() {
-    @java.lang.Override
-    public DeleteSubscriptionRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new DeleteSubscriptionRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<DeleteSubscriptionRequest> PARSER =
+      new com.google.protobuf.AbstractParser<DeleteSubscriptionRequest>() {
+        @java.lang.Override
+        public DeleteSubscriptionRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new DeleteSubscriptionRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<DeleteSubscriptionRequest> parser() {
     return PARSER;
@@ -586,6 +631,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.DeleteSubscriptionRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/DeleteSubscriptionRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/DeleteSubscriptionRequestOrBuilder.java
@@ -3,27 +3,37 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface DeleteSubscriptionRequestOrBuilder extends
+public interface DeleteSubscriptionRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.DeleteSubscriptionRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The name of the subscription to delete.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The name.
    */
   java.lang.String getName();
   /**
+   *
+   *
    * <pre>
    * The name of the subscription to delete.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for name.
    */
-  com.google.protobuf.ByteString
-      getNameBytes();
+  com.google.protobuf.ByteString getNameBytes();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/DeleteTopicRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/DeleteTopicRequest.java
@@ -4,37 +4,39 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request for DeleteTopic.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.DeleteTopicRequest}
  */
-public  final class DeleteTopicRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class DeleteTopicRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.DeleteTopicRequest)
     DeleteTopicRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use DeleteTopicRequest.newBuilder() to construct.
   private DeleteTopicRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private DeleteTopicRequest() {
     name_ = "";
   }
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new DeleteTopicRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private DeleteTopicRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -53,52 +55,60 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            name_ = s;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              name_ = s;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.DeleteTopicRequest.class, com.google.cloud.pubsublite.proto.DeleteTopicRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.DeleteTopicRequest.class,
+            com.google.cloud.pubsublite.proto.DeleteTopicRequest.Builder.class);
   }
 
   public static final int NAME_FIELD_NUMBER = 1;
   private volatile java.lang.Object name_;
   /**
+   *
+   *
    * <pre>
    * The name of the topic to delete.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The name.
    */
   public java.lang.String getName() {
@@ -106,28 +116,30 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       name_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The name of the topic to delete.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for name.
    */
-  public com.google.protobuf.ByteString
-      getNameBytes() {
+  public com.google.protobuf.ByteString getNameBytes() {
     java.lang.Object ref = name_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       name_ = b;
       return b;
     } else {
@@ -136,6 +148,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -147,8 +160,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
@@ -172,15 +184,15 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.DeleteTopicRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.DeleteTopicRequest other = (com.google.cloud.pubsublite.proto.DeleteTopicRequest) obj;
+    com.google.cloud.pubsublite.proto.DeleteTopicRequest other =
+        (com.google.cloud.pubsublite.proto.DeleteTopicRequest) obj;
 
-    if (!getName()
-        .equals(other.getName())) return false;
+    if (!getName().equals(other.getName())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -200,117 +212,126 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.DeleteTopicRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.DeleteTopicRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.DeleteTopicRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.DeleteTopicRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.DeleteTopicRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.DeleteTopicRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.DeleteTopicRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.DeleteTopicRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.DeleteTopicRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.DeleteTopicRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.DeleteTopicRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.DeleteTopicRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.DeleteTopicRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.DeleteTopicRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.DeleteTopicRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request for DeleteTopic.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.DeleteTopicRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.DeleteTopicRequest)
       com.google.cloud.pubsublite.proto.DeleteTopicRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.DeleteTopicRequest.class, com.google.cloud.pubsublite.proto.DeleteTopicRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.DeleteTopicRequest.class,
+              com.google.cloud.pubsublite.proto.DeleteTopicRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.DeleteTopicRequest.newBuilder()
@@ -318,16 +339,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -337,9 +357,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_DeleteTopicRequest_descriptor;
     }
 
     @java.lang.Override
@@ -358,7 +378,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.DeleteTopicRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.DeleteTopicRequest result = new com.google.cloud.pubsublite.proto.DeleteTopicRequest(this);
+      com.google.cloud.pubsublite.proto.DeleteTopicRequest result =
+          new com.google.cloud.pubsublite.proto.DeleteTopicRequest(this);
       result.name_ = name_;
       onBuilt();
       return result;
@@ -368,38 +389,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.DeleteTopicRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.DeleteTopicRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.DeleteTopicRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -407,7 +429,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.DeleteTopicRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.DeleteTopicRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.DeleteTopicRequest.getDefaultInstance())
+        return this;
       if (!other.getName().isEmpty()) {
         name_ = other.name_;
         onChanged();
@@ -431,7 +454,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.DeleteTopicRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.DeleteTopicRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -443,18 +467,22 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object name_ = "";
     /**
+     *
+     *
      * <pre>
      * The name of the topic to delete.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The name.
      */
     public java.lang.String getName() {
       java.lang.Object ref = name_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         name_ = s;
         return s;
@@ -463,20 +491,23 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic to delete.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The bytes for name.
      */
-    public com.google.protobuf.ByteString
-        getNameBytes() {
+    public com.google.protobuf.ByteString getNameBytes() {
       java.lang.Object ref = name_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         name_ = b;
         return b;
       } else {
@@ -484,61 +515,74 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic to delete.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The name to set.
      * @return This builder for chaining.
      */
-    public Builder setName(
-        java.lang.String value) {
+    public Builder setName(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       name_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic to delete.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearName() {
-      
+
       name_ = getDefaultInstance().getName();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic to delete.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The bytes for name to set.
      * @return This builder for chaining.
      */
-    public Builder setNameBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setNameBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       name_ = value;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -548,12 +592,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.DeleteTopicRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.DeleteTopicRequest)
   private static final com.google.cloud.pubsublite.proto.DeleteTopicRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.DeleteTopicRequest();
   }
@@ -562,16 +606,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<DeleteTopicRequest>
-      PARSER = new com.google.protobuf.AbstractParser<DeleteTopicRequest>() {
-    @java.lang.Override
-    public DeleteTopicRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new DeleteTopicRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<DeleteTopicRequest> PARSER =
+      new com.google.protobuf.AbstractParser<DeleteTopicRequest>() {
+        @java.lang.Override
+        public DeleteTopicRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new DeleteTopicRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<DeleteTopicRequest> parser() {
     return PARSER;
@@ -586,6 +630,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.DeleteTopicRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/DeleteTopicRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/DeleteTopicRequestOrBuilder.java
@@ -3,27 +3,37 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface DeleteTopicRequestOrBuilder extends
+public interface DeleteTopicRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.DeleteTopicRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The name of the topic to delete.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The name.
    */
   java.lang.String getName();
   /**
+   *
+   *
    * <pre>
    * The name of the topic to delete.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for name.
    */
-  com.google.protobuf.ByteString
-      getNameBytes();
+  com.google.protobuf.ByteString getNameBytes();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/FlowControlRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/FlowControlRequest.java
@@ -4,6 +4,8 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request to grant tokens to the server, requesting delivery of messages when
  * they become available.
@@ -11,30 +13,29 @@ package com.google.cloud.pubsublite.proto;
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.FlowControlRequest}
  */
-public  final class FlowControlRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class FlowControlRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.FlowControlRequest)
     FlowControlRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use FlowControlRequest.newBuilder() to construct.
   private FlowControlRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private FlowControlRequest() {
-  }
+
+  private FlowControlRequest() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new FlowControlRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private FlowControlRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -53,56 +54,61 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 8: {
-
-            allowedMessages_ = input.readInt64();
-            break;
-          }
-          case 16: {
-
-            allowedBytes_ = input.readInt64();
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+          case 8:
+            {
+              allowedMessages_ = input.readInt64();
+              break;
             }
-            break;
-          }
+          case 16:
+            {
+              allowedBytes_ = input.readInt64();
+              break;
+            }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_FlowControlRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.SubscriberProto
+        .internal_static_google_cloud_pubsublite_v1_FlowControlRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_FlowControlRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.SubscriberProto
+        .internal_static_google_cloud_pubsublite_v1_FlowControlRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.FlowControlRequest.class, com.google.cloud.pubsublite.proto.FlowControlRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.FlowControlRequest.class,
+            com.google.cloud.pubsublite.proto.FlowControlRequest.Builder.class);
   }
 
   public static final int ALLOWED_MESSAGES_FIELD_NUMBER = 1;
   private long allowedMessages_;
   /**
+   *
+   *
    * <pre>
    * The number of message tokens to grant. Must be greater than or equal to 0.
    * </pre>
    *
    * <code>int64 allowed_messages = 1;</code>
+   *
    * @return The allowedMessages.
    */
   public long getAllowedMessages() {
@@ -112,11 +118,14 @@ private static final long serialVersionUID = 0L;
   public static final int ALLOWED_BYTES_FIELD_NUMBER = 2;
   private long allowedBytes_;
   /**
+   *
+   *
    * <pre>
    * The number of byte tokens to grant. Must be greater than or equal to 0.
    * </pre>
    *
    * <code>int64 allowed_bytes = 2;</code>
+   *
    * @return The allowedBytes.
    */
   public long getAllowedBytes() {
@@ -124,6 +133,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -135,8 +145,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (allowedMessages_ != 0L) {
       output.writeInt64(1, allowedMessages_);
     }
@@ -153,12 +162,10 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (allowedMessages_ != 0L) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeInt64Size(1, allowedMessages_);
+      size += com.google.protobuf.CodedOutputStream.computeInt64Size(1, allowedMessages_);
     }
     if (allowedBytes_ != 0L) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeInt64Size(2, allowedBytes_);
+      size += com.google.protobuf.CodedOutputStream.computeInt64Size(2, allowedBytes_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -168,17 +175,16 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.FlowControlRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.FlowControlRequest other = (com.google.cloud.pubsublite.proto.FlowControlRequest) obj;
+    com.google.cloud.pubsublite.proto.FlowControlRequest other =
+        (com.google.cloud.pubsublite.proto.FlowControlRequest) obj;
 
-    if (getAllowedMessages()
-        != other.getAllowedMessages()) return false;
-    if (getAllowedBytes()
-        != other.getAllowedBytes()) return false;
+    if (getAllowedMessages() != other.getAllowedMessages()) return false;
+    if (getAllowedBytes() != other.getAllowedBytes()) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -191,107 +197,112 @@ private static final long serialVersionUID = 0L;
     int hash = 41;
     hash = (19 * hash) + getDescriptor().hashCode();
     hash = (37 * hash) + ALLOWED_MESSAGES_FIELD_NUMBER;
-    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-        getAllowedMessages());
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(getAllowedMessages());
     hash = (37 * hash) + ALLOWED_BYTES_FIELD_NUMBER;
-    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-        getAllowedBytes());
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(getAllowedBytes());
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
   }
 
   public static com.google.cloud.pubsublite.proto.FlowControlRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.FlowControlRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.FlowControlRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.FlowControlRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.FlowControlRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.FlowControlRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.FlowControlRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.FlowControlRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.FlowControlRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.FlowControlRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.FlowControlRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.FlowControlRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.FlowControlRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.FlowControlRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.FlowControlRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request to grant tokens to the server, requesting delivery of messages when
    * they become available.
@@ -299,21 +310,23 @@ private static final long serialVersionUID = 0L;
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.FlowControlRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.FlowControlRequest)
       com.google.cloud.pubsublite.proto.FlowControlRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_FlowControlRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_FlowControlRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_FlowControlRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_FlowControlRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.FlowControlRequest.class, com.google.cloud.pubsublite.proto.FlowControlRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.FlowControlRequest.class,
+              com.google.cloud.pubsublite.proto.FlowControlRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.FlowControlRequest.newBuilder()
@@ -321,16 +334,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -342,9 +354,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_FlowControlRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_FlowControlRequest_descriptor;
     }
 
     @java.lang.Override
@@ -363,7 +375,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.FlowControlRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.FlowControlRequest result = new com.google.cloud.pubsublite.proto.FlowControlRequest(this);
+      com.google.cloud.pubsublite.proto.FlowControlRequest result =
+          new com.google.cloud.pubsublite.proto.FlowControlRequest(this);
       result.allowedMessages_ = allowedMessages_;
       result.allowedBytes_ = allowedBytes_;
       onBuilt();
@@ -374,38 +387,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.FlowControlRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.FlowControlRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.FlowControlRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -413,7 +427,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.FlowControlRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.FlowControlRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.FlowControlRequest.getDefaultInstance())
+        return this;
       if (other.getAllowedMessages() != 0L) {
         setAllowedMessages(other.getAllowedMessages());
       }
@@ -439,7 +454,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.FlowControlRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.FlowControlRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -449,92 +465,110 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-    private long allowedMessages_ ;
+    private long allowedMessages_;
     /**
+     *
+     *
      * <pre>
      * The number of message tokens to grant. Must be greater than or equal to 0.
      * </pre>
      *
      * <code>int64 allowed_messages = 1;</code>
+     *
      * @return The allowedMessages.
      */
     public long getAllowedMessages() {
       return allowedMessages_;
     }
     /**
+     *
+     *
      * <pre>
      * The number of message tokens to grant. Must be greater than or equal to 0.
      * </pre>
      *
      * <code>int64 allowed_messages = 1;</code>
+     *
      * @param value The allowedMessages to set.
      * @return This builder for chaining.
      */
     public Builder setAllowedMessages(long value) {
-      
+
       allowedMessages_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The number of message tokens to grant. Must be greater than or equal to 0.
      * </pre>
      *
      * <code>int64 allowed_messages = 1;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearAllowedMessages() {
-      
+
       allowedMessages_ = 0L;
       onChanged();
       return this;
     }
 
-    private long allowedBytes_ ;
+    private long allowedBytes_;
     /**
+     *
+     *
      * <pre>
      * The number of byte tokens to grant. Must be greater than or equal to 0.
      * </pre>
      *
      * <code>int64 allowed_bytes = 2;</code>
+     *
      * @return The allowedBytes.
      */
     public long getAllowedBytes() {
       return allowedBytes_;
     }
     /**
+     *
+     *
      * <pre>
      * The number of byte tokens to grant. Must be greater than or equal to 0.
      * </pre>
      *
      * <code>int64 allowed_bytes = 2;</code>
+     *
      * @param value The allowedBytes to set.
      * @return This builder for chaining.
      */
     public Builder setAllowedBytes(long value) {
-      
+
       allowedBytes_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The number of byte tokens to grant. Must be greater than or equal to 0.
      * </pre>
      *
      * <code>int64 allowed_bytes = 2;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearAllowedBytes() {
-      
+
       allowedBytes_ = 0L;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -544,12 +578,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.FlowControlRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.FlowControlRequest)
   private static final com.google.cloud.pubsublite.proto.FlowControlRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.FlowControlRequest();
   }
@@ -558,16 +592,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<FlowControlRequest>
-      PARSER = new com.google.protobuf.AbstractParser<FlowControlRequest>() {
-    @java.lang.Override
-    public FlowControlRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new FlowControlRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<FlowControlRequest> PARSER =
+      new com.google.protobuf.AbstractParser<FlowControlRequest>() {
+        @java.lang.Override
+        public FlowControlRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new FlowControlRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<FlowControlRequest> parser() {
     return PARSER;
@@ -582,6 +616,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.FlowControlRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/FlowControlRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/FlowControlRequestOrBuilder.java
@@ -3,26 +3,33 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface FlowControlRequestOrBuilder extends
+public interface FlowControlRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.FlowControlRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The number of message tokens to grant. Must be greater than or equal to 0.
    * </pre>
    *
    * <code>int64 allowed_messages = 1;</code>
+   *
    * @return The allowedMessages.
    */
   long getAllowedMessages();
 
   /**
+   *
+   *
    * <pre>
    * The number of byte tokens to grant. Must be greater than or equal to 0.
    * </pre>
    *
    * <code>int64 allowed_bytes = 2;</code>
+   *
    * @return The allowedBytes.
    */
   long getAllowedBytes();

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/GetSubscriptionRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/GetSubscriptionRequest.java
@@ -4,37 +4,39 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request for GetSubscription.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.GetSubscriptionRequest}
  */
-public  final class GetSubscriptionRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class GetSubscriptionRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.GetSubscriptionRequest)
     GetSubscriptionRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use GetSubscriptionRequest.newBuilder() to construct.
   private GetSubscriptionRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private GetSubscriptionRequest() {
     name_ = "";
   }
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new GetSubscriptionRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private GetSubscriptionRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -53,52 +55,60 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            name_ = s;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              name_ = s;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.GetSubscriptionRequest.class, com.google.cloud.pubsublite.proto.GetSubscriptionRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.GetSubscriptionRequest.class,
+            com.google.cloud.pubsublite.proto.GetSubscriptionRequest.Builder.class);
   }
 
   public static final int NAME_FIELD_NUMBER = 1;
   private volatile java.lang.Object name_;
   /**
+   *
+   *
    * <pre>
    * The name of the subscription whose configuration to return.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The name.
    */
   public java.lang.String getName() {
@@ -106,28 +116,30 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       name_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The name of the subscription whose configuration to return.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for name.
    */
-  public com.google.protobuf.ByteString
-      getNameBytes() {
+  public com.google.protobuf.ByteString getNameBytes() {
     java.lang.Object ref = name_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       name_ = b;
       return b;
     } else {
@@ -136,6 +148,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -147,8 +160,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
@@ -172,15 +184,15 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.GetSubscriptionRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.GetSubscriptionRequest other = (com.google.cloud.pubsublite.proto.GetSubscriptionRequest) obj;
+    com.google.cloud.pubsublite.proto.GetSubscriptionRequest other =
+        (com.google.cloud.pubsublite.proto.GetSubscriptionRequest) obj;
 
-    if (!getName()
-        .equals(other.getName())) return false;
+    if (!getName().equals(other.getName())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -200,117 +212,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.GetSubscriptionRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.GetSubscriptionRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.GetSubscriptionRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.GetSubscriptionRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.GetSubscriptionRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.GetSubscriptionRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.GetSubscriptionRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.GetSubscriptionRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.GetSubscriptionRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.GetSubscriptionRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.GetSubscriptionRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.GetSubscriptionRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.GetSubscriptionRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.GetSubscriptionRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.GetSubscriptionRequest prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.GetSubscriptionRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request for GetSubscription.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.GetSubscriptionRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.GetSubscriptionRequest)
       com.google.cloud.pubsublite.proto.GetSubscriptionRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.GetSubscriptionRequest.class, com.google.cloud.pubsublite.proto.GetSubscriptionRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.GetSubscriptionRequest.class,
+              com.google.cloud.pubsublite.proto.GetSubscriptionRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.GetSubscriptionRequest.newBuilder()
@@ -318,16 +340,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -337,9 +358,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_GetSubscriptionRequest_descriptor;
     }
 
     @java.lang.Override
@@ -358,7 +379,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.GetSubscriptionRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.GetSubscriptionRequest result = new com.google.cloud.pubsublite.proto.GetSubscriptionRequest(this);
+      com.google.cloud.pubsublite.proto.GetSubscriptionRequest result =
+          new com.google.cloud.pubsublite.proto.GetSubscriptionRequest(this);
       result.name_ = name_;
       onBuilt();
       return result;
@@ -368,38 +390,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.GetSubscriptionRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.GetSubscriptionRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.GetSubscriptionRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -407,7 +430,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.GetSubscriptionRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.GetSubscriptionRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.GetSubscriptionRequest.getDefaultInstance())
+        return this;
       if (!other.getName().isEmpty()) {
         name_ = other.name_;
         onChanged();
@@ -431,7 +455,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.GetSubscriptionRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.GetSubscriptionRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -443,18 +468,22 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object name_ = "";
     /**
+     *
+     *
      * <pre>
      * The name of the subscription whose configuration to return.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The name.
      */
     public java.lang.String getName() {
       java.lang.Object ref = name_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         name_ = s;
         return s;
@@ -463,20 +492,23 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The name of the subscription whose configuration to return.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The bytes for name.
      */
-    public com.google.protobuf.ByteString
-        getNameBytes() {
+    public com.google.protobuf.ByteString getNameBytes() {
       java.lang.Object ref = name_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         name_ = b;
         return b;
       } else {
@@ -484,61 +516,74 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The name of the subscription whose configuration to return.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The name to set.
      * @return This builder for chaining.
      */
-    public Builder setName(
-        java.lang.String value) {
+    public Builder setName(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       name_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The name of the subscription whose configuration to return.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearName() {
-      
+
       name_ = getDefaultInstance().getName();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The name of the subscription whose configuration to return.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The bytes for name to set.
      * @return This builder for chaining.
      */
-    public Builder setNameBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setNameBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       name_ = value;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -548,12 +593,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.GetSubscriptionRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.GetSubscriptionRequest)
   private static final com.google.cloud.pubsublite.proto.GetSubscriptionRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.GetSubscriptionRequest();
   }
@@ -562,16 +607,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<GetSubscriptionRequest>
-      PARSER = new com.google.protobuf.AbstractParser<GetSubscriptionRequest>() {
-    @java.lang.Override
-    public GetSubscriptionRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new GetSubscriptionRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<GetSubscriptionRequest> PARSER =
+      new com.google.protobuf.AbstractParser<GetSubscriptionRequest>() {
+        @java.lang.Override
+        public GetSubscriptionRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new GetSubscriptionRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<GetSubscriptionRequest> parser() {
     return PARSER;
@@ -586,6 +631,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.GetSubscriptionRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/GetSubscriptionRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/GetSubscriptionRequestOrBuilder.java
@@ -3,27 +3,37 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface GetSubscriptionRequestOrBuilder extends
+public interface GetSubscriptionRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.GetSubscriptionRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The name of the subscription whose configuration to return.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The name.
    */
   java.lang.String getName();
   /**
+   *
+   *
    * <pre>
    * The name of the subscription whose configuration to return.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for name.
    */
-  com.google.protobuf.ByteString
-      getNameBytes();
+  com.google.protobuf.ByteString getNameBytes();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/GetTopicPartitionsRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/GetTopicPartitionsRequest.java
@@ -4,37 +4,39 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request for GetTopicPartitions.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.GetTopicPartitionsRequest}
  */
-public  final class GetTopicPartitionsRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class GetTopicPartitionsRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.GetTopicPartitionsRequest)
     GetTopicPartitionsRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use GetTopicPartitionsRequest.newBuilder() to construct.
   private GetTopicPartitionsRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private GetTopicPartitionsRequest() {
     name_ = "";
   }
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new GetTopicPartitionsRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private GetTopicPartitionsRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -53,52 +55,60 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            name_ = s;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              name_ = s;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest.class, com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest.class,
+            com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest.Builder.class);
   }
 
   public static final int NAME_FIELD_NUMBER = 1;
   private volatile java.lang.Object name_;
   /**
+   *
+   *
    * <pre>
    * The topic whose partition information to return.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The name.
    */
   public java.lang.String getName() {
@@ -106,28 +116,30 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       name_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The topic whose partition information to return.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for name.
    */
-  public com.google.protobuf.ByteString
-      getNameBytes() {
+  public com.google.protobuf.ByteString getNameBytes() {
     java.lang.Object ref = name_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       name_ = b;
       return b;
     } else {
@@ -136,6 +148,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -147,8 +160,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
@@ -172,15 +184,15 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest other = (com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest) obj;
+    com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest other =
+        (com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest) obj;
 
-    if (!getName()
-        .equals(other.getName())) return false;
+    if (!getName().equals(other.getName())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -200,117 +212,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request for GetTopicPartitions.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.GetTopicPartitionsRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.GetTopicPartitionsRequest)
       com.google.cloud.pubsublite.proto.GetTopicPartitionsRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest.class, com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest.class,
+              com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest.newBuilder()
@@ -318,16 +340,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -337,9 +358,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_GetTopicPartitionsRequest_descriptor;
     }
 
     @java.lang.Override
@@ -358,7 +379,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest result = new com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest(this);
+      com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest result =
+          new com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest(this);
       result.name_ = name_;
       onBuilt();
       return result;
@@ -368,38 +390,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -407,7 +430,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest.getDefaultInstance())
+        return this;
       if (!other.getName().isEmpty()) {
         name_ = other.name_;
         onChanged();
@@ -431,7 +455,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -443,18 +468,22 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object name_ = "";
     /**
+     *
+     *
      * <pre>
      * The topic whose partition information to return.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The name.
      */
     public java.lang.String getName() {
       java.lang.Object ref = name_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         name_ = s;
         return s;
@@ -463,20 +492,23 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The topic whose partition information to return.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The bytes for name.
      */
-    public com.google.protobuf.ByteString
-        getNameBytes() {
+    public com.google.protobuf.ByteString getNameBytes() {
       java.lang.Object ref = name_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         name_ = b;
         return b;
       } else {
@@ -484,61 +516,74 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The topic whose partition information to return.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The name to set.
      * @return This builder for chaining.
      */
-    public Builder setName(
-        java.lang.String value) {
+    public Builder setName(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       name_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The topic whose partition information to return.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearName() {
-      
+
       name_ = getDefaultInstance().getName();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The topic whose partition information to return.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The bytes for name to set.
      * @return This builder for chaining.
      */
-    public Builder setNameBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setNameBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       name_ = value;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -548,12 +593,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.GetTopicPartitionsRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.GetTopicPartitionsRequest)
   private static final com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest();
   }
@@ -562,16 +607,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<GetTopicPartitionsRequest>
-      PARSER = new com.google.protobuf.AbstractParser<GetTopicPartitionsRequest>() {
-    @java.lang.Override
-    public GetTopicPartitionsRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new GetTopicPartitionsRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<GetTopicPartitionsRequest> PARSER =
+      new com.google.protobuf.AbstractParser<GetTopicPartitionsRequest>() {
+        @java.lang.Override
+        public GetTopicPartitionsRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new GetTopicPartitionsRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<GetTopicPartitionsRequest> parser() {
     return PARSER;
@@ -586,6 +631,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.GetTopicPartitionsRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/GetTopicPartitionsRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/GetTopicPartitionsRequestOrBuilder.java
@@ -3,27 +3,37 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface GetTopicPartitionsRequestOrBuilder extends
+public interface GetTopicPartitionsRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.GetTopicPartitionsRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The topic whose partition information to return.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The name.
    */
   java.lang.String getName();
   /**
+   *
+   *
    * <pre>
    * The topic whose partition information to return.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for name.
    */
-  com.google.protobuf.ByteString
-      getNameBytes();
+  com.google.protobuf.ByteString getNameBytes();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/GetTopicRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/GetTopicRequest.java
@@ -4,37 +4,39 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request for GetTopic.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.GetTopicRequest}
  */
-public  final class GetTopicRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class GetTopicRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.GetTopicRequest)
     GetTopicRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use GetTopicRequest.newBuilder() to construct.
   private GetTopicRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private GetTopicRequest() {
     name_ = "";
   }
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new GetTopicRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private GetTopicRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -53,52 +55,60 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            name_ = s;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              name_ = s;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_GetTopicRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_GetTopicRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_GetTopicRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_GetTopicRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.GetTopicRequest.class, com.google.cloud.pubsublite.proto.GetTopicRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.GetTopicRequest.class,
+            com.google.cloud.pubsublite.proto.GetTopicRequest.Builder.class);
   }
 
   public static final int NAME_FIELD_NUMBER = 1;
   private volatile java.lang.Object name_;
   /**
+   *
+   *
    * <pre>
    * The name of the topic whose configuration to return.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The name.
    */
   public java.lang.String getName() {
@@ -106,28 +116,30 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       name_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The name of the topic whose configuration to return.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for name.
    */
-  public com.google.protobuf.ByteString
-      getNameBytes() {
+  public com.google.protobuf.ByteString getNameBytes() {
     java.lang.Object ref = name_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       name_ = b;
       return b;
     } else {
@@ -136,6 +148,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -147,8 +160,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
@@ -172,15 +184,15 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.GetTopicRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.GetTopicRequest other = (com.google.cloud.pubsublite.proto.GetTopicRequest) obj;
+    com.google.cloud.pubsublite.proto.GetTopicRequest other =
+        (com.google.cloud.pubsublite.proto.GetTopicRequest) obj;
 
-    if (!getName()
-        .equals(other.getName())) return false;
+    if (!getName().equals(other.getName())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -200,117 +212,126 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.GetTopicRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.GetTopicRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.GetTopicRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.GetTopicRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.GetTopicRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.GetTopicRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.GetTopicRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.GetTopicRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.GetTopicRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.GetTopicRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.GetTopicRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.GetTopicRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.GetTopicRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.GetTopicRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.GetTopicRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request for GetTopic.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.GetTopicRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.GetTopicRequest)
       com.google.cloud.pubsublite.proto.GetTopicRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_GetTopicRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_GetTopicRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_GetTopicRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_GetTopicRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.GetTopicRequest.class, com.google.cloud.pubsublite.proto.GetTopicRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.GetTopicRequest.class,
+              com.google.cloud.pubsublite.proto.GetTopicRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.GetTopicRequest.newBuilder()
@@ -318,16 +339,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -337,9 +357,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_GetTopicRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_GetTopicRequest_descriptor;
     }
 
     @java.lang.Override
@@ -358,7 +378,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.GetTopicRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.GetTopicRequest result = new com.google.cloud.pubsublite.proto.GetTopicRequest(this);
+      com.google.cloud.pubsublite.proto.GetTopicRequest result =
+          new com.google.cloud.pubsublite.proto.GetTopicRequest(this);
       result.name_ = name_;
       onBuilt();
       return result;
@@ -368,38 +389,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.GetTopicRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.GetTopicRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.GetTopicRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -407,7 +429,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.GetTopicRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.GetTopicRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.GetTopicRequest.getDefaultInstance())
+        return this;
       if (!other.getName().isEmpty()) {
         name_ = other.name_;
         onChanged();
@@ -431,7 +454,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.GetTopicRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.GetTopicRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -443,18 +467,22 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object name_ = "";
     /**
+     *
+     *
      * <pre>
      * The name of the topic whose configuration to return.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The name.
      */
     public java.lang.String getName() {
       java.lang.Object ref = name_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         name_ = s;
         return s;
@@ -463,20 +491,23 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic whose configuration to return.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The bytes for name.
      */
-    public com.google.protobuf.ByteString
-        getNameBytes() {
+    public com.google.protobuf.ByteString getNameBytes() {
       java.lang.Object ref = name_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         name_ = b;
         return b;
       } else {
@@ -484,61 +515,74 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic whose configuration to return.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The name to set.
      * @return This builder for chaining.
      */
-    public Builder setName(
-        java.lang.String value) {
+    public Builder setName(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       name_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic whose configuration to return.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearName() {
-      
+
       name_ = getDefaultInstance().getName();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic whose configuration to return.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The bytes for name to set.
      * @return This builder for chaining.
      */
-    public Builder setNameBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setNameBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       name_ = value;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -548,12 +592,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.GetTopicRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.GetTopicRequest)
   private static final com.google.cloud.pubsublite.proto.GetTopicRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.GetTopicRequest();
   }
@@ -562,16 +606,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<GetTopicRequest>
-      PARSER = new com.google.protobuf.AbstractParser<GetTopicRequest>() {
-    @java.lang.Override
-    public GetTopicRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new GetTopicRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<GetTopicRequest> PARSER =
+      new com.google.protobuf.AbstractParser<GetTopicRequest>() {
+        @java.lang.Override
+        public GetTopicRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new GetTopicRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<GetTopicRequest> parser() {
     return PARSER;
@@ -586,6 +630,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.GetTopicRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/GetTopicRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/GetTopicRequestOrBuilder.java
@@ -3,27 +3,37 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface GetTopicRequestOrBuilder extends
+public interface GetTopicRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.GetTopicRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The name of the topic whose configuration to return.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The name.
    */
   java.lang.String getName();
   /**
+   *
+   *
    * <pre>
    * The name of the topic whose configuration to return.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for name.
    */
-  com.google.protobuf.ByteString
-      getNameBytes();
+  com.google.protobuf.ByteString getNameBytes();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialCommitCursorRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialCommitCursorRequest.java
@@ -4,6 +4,8 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * The first streaming request that must be sent on a newly-opened stream. The
  * client must wait for the response before sending subsequent requests on the
@@ -12,31 +14,31 @@ package com.google.cloud.pubsublite.proto;
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.InitialCommitCursorRequest}
  */
-public  final class InitialCommitCursorRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class InitialCommitCursorRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.InitialCommitCursorRequest)
     InitialCommitCursorRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use InitialCommitCursorRequest.newBuilder() to construct.
   private InitialCommitCursorRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private InitialCommitCursorRequest() {
     subscription_ = "";
   }
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new InitialCommitCursorRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private InitialCommitCursorRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -55,57 +57,63 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            subscription_ = s;
-            break;
-          }
-          case 16: {
-
-            partition_ = input.readInt64();
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              subscription_ = s;
+              break;
             }
-            break;
-          }
+          case 16:
+            {
+              partition_ = input.readInt64();
+              break;
+            }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.class, com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.class,
+            com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.Builder.class);
   }
 
   public static final int SUBSCRIPTION_FIELD_NUMBER = 1;
   private volatile java.lang.Object subscription_;
   /**
+   *
+   *
    * <pre>
    * The subscription for which to manage committed cursors.
    * </pre>
    *
    * <code>string subscription = 1;</code>
+   *
    * @return The subscription.
    */
   public java.lang.String getSubscription() {
@@ -113,28 +121,28 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       subscription_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The subscription for which to manage committed cursors.
    * </pre>
    *
    * <code>string subscription = 1;</code>
+   *
    * @return The bytes for subscription.
    */
-  public com.google.protobuf.ByteString
-      getSubscriptionBytes() {
+  public com.google.protobuf.ByteString getSubscriptionBytes() {
     java.lang.Object ref = subscription_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       subscription_ = b;
       return b;
     } else {
@@ -145,12 +153,15 @@ private static final long serialVersionUID = 0L;
   public static final int PARTITION_FIELD_NUMBER = 2;
   private long partition_;
   /**
+   *
+   *
    * <pre>
    * The partition for which to manage committed cursors. Partitions are zero
    * indexed, so `partition` must be in the range [0, topic.num_partitions).
    * </pre>
    *
    * <code>int64 partition = 2;</code>
+   *
    * @return The partition.
    */
   public long getPartition() {
@@ -158,6 +169,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -169,8 +181,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getSubscriptionBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, subscription_);
     }
@@ -190,8 +201,7 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, subscription_);
     }
     if (partition_ != 0L) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeInt64Size(2, partition_);
+      size += com.google.protobuf.CodedOutputStream.computeInt64Size(2, partition_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -201,17 +211,16 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.InitialCommitCursorRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.InitialCommitCursorRequest other = (com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) obj;
+    com.google.cloud.pubsublite.proto.InitialCommitCursorRequest other =
+        (com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) obj;
 
-    if (!getSubscription()
-        .equals(other.getSubscription())) return false;
-    if (getPartition()
-        != other.getPartition()) return false;
+    if (!getSubscription().equals(other.getSubscription())) return false;
+    if (getPartition() != other.getPartition()) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -226,104 +235,111 @@ private static final long serialVersionUID = 0L;
     hash = (37 * hash) + SUBSCRIPTION_FIELD_NUMBER;
     hash = (53 * hash) + getSubscription().hashCode();
     hash = (37 * hash) + PARTITION_FIELD_NUMBER;
-    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-        getPartition());
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(getPartition());
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
   }
 
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.InitialCommitCursorRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.InitialCommitCursorRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.InitialCommitCursorRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.InitialCommitCursorRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.InitialCommitCursorRequest prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.InitialCommitCursorRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * The first streaming request that must be sent on a newly-opened stream. The
    * client must wait for the response before sending subsequent requests on the
@@ -332,21 +348,23 @@ private static final long serialVersionUID = 0L;
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.InitialCommitCursorRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.InitialCommitCursorRequest)
       com.google.cloud.pubsublite.proto.InitialCommitCursorRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.class, com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.class,
+              com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.newBuilder()
@@ -354,16 +372,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -375,13 +392,14 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_InitialCommitCursorRequest_descriptor;
     }
 
     @java.lang.Override
-    public com.google.cloud.pubsublite.proto.InitialCommitCursorRequest getDefaultInstanceForType() {
+    public com.google.cloud.pubsublite.proto.InitialCommitCursorRequest
+        getDefaultInstanceForType() {
       return com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.getDefaultInstance();
     }
 
@@ -396,7 +414,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.InitialCommitCursorRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.InitialCommitCursorRequest result = new com.google.cloud.pubsublite.proto.InitialCommitCursorRequest(this);
+      com.google.cloud.pubsublite.proto.InitialCommitCursorRequest result =
+          new com.google.cloud.pubsublite.proto.InitialCommitCursorRequest(this);
       result.subscription_ = subscription_;
       result.partition_ = partition_;
       onBuilt();
@@ -407,38 +426,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.InitialCommitCursorRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -446,7 +466,9 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.InitialCommitCursorRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.getDefaultInstance()) return this;
+      if (other
+          == com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.getDefaultInstance())
+        return this;
       if (!other.getSubscription().isEmpty()) {
         subscription_ = other.subscription_;
         onChanged();
@@ -473,7 +495,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -485,18 +508,20 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object subscription_ = "";
     /**
+     *
+     *
      * <pre>
      * The subscription for which to manage committed cursors.
      * </pre>
      *
      * <code>string subscription = 1;</code>
+     *
      * @return The subscription.
      */
     public java.lang.String getSubscription() {
       java.lang.Object ref = subscription_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         subscription_ = s;
         return s;
@@ -505,20 +530,21 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The subscription for which to manage committed cursors.
      * </pre>
      *
      * <code>string subscription = 1;</code>
+     *
      * @return The bytes for subscription.
      */
-    public com.google.protobuf.ByteString
-        getSubscriptionBytes() {
+    public com.google.protobuf.ByteString getSubscriptionBytes() {
       java.lang.Object ref = subscription_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         subscription_ = b;
         return b;
       } else {
@@ -526,106 +552,122 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The subscription for which to manage committed cursors.
      * </pre>
      *
      * <code>string subscription = 1;</code>
+     *
      * @param value The subscription to set.
      * @return This builder for chaining.
      */
-    public Builder setSubscription(
-        java.lang.String value) {
+    public Builder setSubscription(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       subscription_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The subscription for which to manage committed cursors.
      * </pre>
      *
      * <code>string subscription = 1;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearSubscription() {
-      
+
       subscription_ = getDefaultInstance().getSubscription();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The subscription for which to manage committed cursors.
      * </pre>
      *
      * <code>string subscription = 1;</code>
+     *
      * @param value The bytes for subscription to set.
      * @return This builder for chaining.
      */
-    public Builder setSubscriptionBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setSubscriptionBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       subscription_ = value;
       onChanged();
       return this;
     }
 
-    private long partition_ ;
+    private long partition_;
     /**
+     *
+     *
      * <pre>
      * The partition for which to manage committed cursors. Partitions are zero
      * indexed, so `partition` must be in the range [0, topic.num_partitions).
      * </pre>
      *
      * <code>int64 partition = 2;</code>
+     *
      * @return The partition.
      */
     public long getPartition() {
       return partition_;
     }
     /**
+     *
+     *
      * <pre>
      * The partition for which to manage committed cursors. Partitions are zero
      * indexed, so `partition` must be in the range [0, topic.num_partitions).
      * </pre>
      *
      * <code>int64 partition = 2;</code>
+     *
      * @param value The partition to set.
      * @return This builder for chaining.
      */
     public Builder setPartition(long value) {
-      
+
       partition_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The partition for which to manage committed cursors. Partitions are zero
      * indexed, so `partition` must be in the range [0, topic.num_partitions).
      * </pre>
      *
      * <code>int64 partition = 2;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearPartition() {
-      
+
       partition_ = 0L;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -635,12 +677,13 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.InitialCommitCursorRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.InitialCommitCursorRequest)
-  private static final com.google.cloud.pubsublite.proto.InitialCommitCursorRequest DEFAULT_INSTANCE;
+  private static final com.google.cloud.pubsublite.proto.InitialCommitCursorRequest
+      DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.InitialCommitCursorRequest();
   }
@@ -649,16 +692,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<InitialCommitCursorRequest>
-      PARSER = new com.google.protobuf.AbstractParser<InitialCommitCursorRequest>() {
-    @java.lang.Override
-    public InitialCommitCursorRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new InitialCommitCursorRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<InitialCommitCursorRequest> PARSER =
+      new com.google.protobuf.AbstractParser<InitialCommitCursorRequest>() {
+        @java.lang.Override
+        public InitialCommitCursorRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new InitialCommitCursorRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<InitialCommitCursorRequest> parser() {
     return PARSER;
@@ -673,6 +716,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.InitialCommitCursorRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialCommitCursorRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialCommitCursorRequestOrBuilder.java
@@ -3,37 +3,46 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface InitialCommitCursorRequestOrBuilder extends
+public interface InitialCommitCursorRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.InitialCommitCursorRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The subscription for which to manage committed cursors.
    * </pre>
    *
    * <code>string subscription = 1;</code>
+   *
    * @return The subscription.
    */
   java.lang.String getSubscription();
   /**
+   *
+   *
    * <pre>
    * The subscription for which to manage committed cursors.
    * </pre>
    *
    * <code>string subscription = 1;</code>
+   *
    * @return The bytes for subscription.
    */
-  com.google.protobuf.ByteString
-      getSubscriptionBytes();
+  com.google.protobuf.ByteString getSubscriptionBytes();
 
   /**
+   *
+   *
    * <pre>
    * The partition for which to manage committed cursors. Partitions are zero
    * indexed, so `partition` must be in the range [0, topic.num_partitions).
    * </pre>
    *
    * <code>int64 partition = 2;</code>
+   *
    * @return The partition.
    */
   long getPartition();

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialCommitCursorResponse.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialCommitCursorResponse.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Response to an InitialCommitCursorRequest.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.InitialCommitCursorResponse}
  */
-public  final class InitialCommitCursorResponse extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class InitialCommitCursorResponse extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.InitialCommitCursorResponse)
     InitialCommitCursorResponseOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use InitialCommitCursorResponse.newBuilder() to construct.
   private InitialCommitCursorResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private InitialCommitCursorResponse() {
-  }
+
+  private InitialCommitCursorResponse() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new InitialCommitCursorResponse();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private InitialCommitCursorResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,39 +53,42 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
             }
-            break;
-          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.class, com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.Builder.class);
+            com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.class,
+            com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.Builder.class);
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -96,8 +100,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     unknownFields.writeTo(output);
   }
 
@@ -115,12 +118,13 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.InitialCommitCursorResponse)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.InitialCommitCursorResponse other = (com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) obj;
+    com.google.cloud.pubsublite.proto.InitialCommitCursorResponse other =
+        (com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) obj;
 
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
@@ -139,117 +143,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorResponse parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorResponse parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorResponse parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorResponse parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorResponse parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.InitialCommitCursorResponse parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorResponse parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.InitialCommitCursorResponse parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.InitialCommitCursorResponse parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorResponse parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.InitialCommitCursorResponse parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorResponse parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialCommitCursorResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.InitialCommitCursorResponse prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.InitialCommitCursorResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Response to an InitialCommitCursorRequest.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.InitialCommitCursorResponse}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.InitialCommitCursorResponse)
       com.google.cloud.pubsublite.proto.InitialCommitCursorResponseOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.class, com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.Builder.class);
+              com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.class,
+              com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.newBuilder()
@@ -257,16 +271,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -274,13 +287,14 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_InitialCommitCursorResponse_descriptor;
     }
 
     @java.lang.Override
-    public com.google.cloud.pubsublite.proto.InitialCommitCursorResponse getDefaultInstanceForType() {
+    public com.google.cloud.pubsublite.proto.InitialCommitCursorResponse
+        getDefaultInstanceForType() {
       return com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.getDefaultInstance();
     }
 
@@ -295,7 +309,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.InitialCommitCursorResponse buildPartial() {
-      com.google.cloud.pubsublite.proto.InitialCommitCursorResponse result = new com.google.cloud.pubsublite.proto.InitialCommitCursorResponse(this);
+      com.google.cloud.pubsublite.proto.InitialCommitCursorResponse result =
+          new com.google.cloud.pubsublite.proto.InitialCommitCursorResponse(this);
       onBuilt();
       return result;
     }
@@ -304,38 +319,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.InitialCommitCursorResponse)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -343,7 +359,9 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.InitialCommitCursorResponse other) {
-      if (other == com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.getDefaultInstance()) return this;
+      if (other
+          == com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.getDefaultInstance())
+        return this;
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
@@ -363,7 +381,9 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.InitialCommitCursorResponse)
+                e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -372,9 +392,9 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -384,12 +404,13 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.InitialCommitCursorResponse)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.InitialCommitCursorResponse)
-  private static final com.google.cloud.pubsublite.proto.InitialCommitCursorResponse DEFAULT_INSTANCE;
+  private static final com.google.cloud.pubsublite.proto.InitialCommitCursorResponse
+      DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.InitialCommitCursorResponse();
   }
@@ -398,16 +419,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<InitialCommitCursorResponse>
-      PARSER = new com.google.protobuf.AbstractParser<InitialCommitCursorResponse>() {
-    @java.lang.Override
-    public InitialCommitCursorResponse parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new InitialCommitCursorResponse(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<InitialCommitCursorResponse> PARSER =
+      new com.google.protobuf.AbstractParser<InitialCommitCursorResponse>() {
+        @java.lang.Override
+        public InitialCommitCursorResponse parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new InitialCommitCursorResponse(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<InitialCommitCursorResponse> parser() {
     return PARSER;
@@ -422,6 +443,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.InitialCommitCursorResponse getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialCommitCursorResponseOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialCommitCursorResponseOrBuilder.java
@@ -3,7 +3,7 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface InitialCommitCursorResponseOrBuilder extends
+public interface InitialCommitCursorResponseOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.InitialCommitCursorResponse)
-    com.google.protobuf.MessageOrBuilder {
-}
+    com.google.protobuf.MessageOrBuilder {}

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialPublishRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialPublishRequest.java
@@ -4,37 +4,39 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * The first request that must be sent on a newly-opened stream.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.InitialPublishRequest}
  */
-public  final class InitialPublishRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class InitialPublishRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.InitialPublishRequest)
     InitialPublishRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use InitialPublishRequest.newBuilder() to construct.
   private InitialPublishRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private InitialPublishRequest() {
     topic_ = "";
   }
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new InitialPublishRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private InitialPublishRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -53,57 +55,63 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            topic_ = s;
-            break;
-          }
-          case 16: {
-
-            partition_ = input.readInt64();
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              topic_ = s;
+              break;
             }
-            break;
-          }
+          case 16:
+            {
+              partition_ = input.readInt64();
+              break;
+            }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.PublisherProto
+        .internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.PublisherProto
+        .internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.InitialPublishRequest.class, com.google.cloud.pubsublite.proto.InitialPublishRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.InitialPublishRequest.class,
+            com.google.cloud.pubsublite.proto.InitialPublishRequest.Builder.class);
   }
 
   public static final int TOPIC_FIELD_NUMBER = 1;
   private volatile java.lang.Object topic_;
   /**
+   *
+   *
    * <pre>
    * The topic to which messages will be written.
    * </pre>
    *
    * <code>string topic = 1;</code>
+   *
    * @return The topic.
    */
   public java.lang.String getTopic() {
@@ -111,28 +119,28 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       topic_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The topic to which messages will be written.
    * </pre>
    *
    * <code>string topic = 1;</code>
+   *
    * @return The bytes for topic.
    */
-  public com.google.protobuf.ByteString
-      getTopicBytes() {
+  public com.google.protobuf.ByteString getTopicBytes() {
     java.lang.Object ref = topic_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       topic_ = b;
       return b;
     } else {
@@ -143,6 +151,8 @@ private static final long serialVersionUID = 0L;
   public static final int PARTITION_FIELD_NUMBER = 2;
   private long partition_;
   /**
+   *
+   *
    * <pre>
    * The partition within the topic to which messages will be written.
    * Partitions are zero indexed, so `partition` must be in the range [0,
@@ -150,6 +160,7 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>int64 partition = 2;</code>
+   *
    * @return The partition.
    */
   public long getPartition() {
@@ -157,6 +168,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -168,8 +180,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getTopicBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, topic_);
     }
@@ -189,8 +200,7 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, topic_);
     }
     if (partition_ != 0L) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeInt64Size(2, partition_);
+      size += com.google.protobuf.CodedOutputStream.computeInt64Size(2, partition_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -200,17 +210,16 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.InitialPublishRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.InitialPublishRequest other = (com.google.cloud.pubsublite.proto.InitialPublishRequest) obj;
+    com.google.cloud.pubsublite.proto.InitialPublishRequest other =
+        (com.google.cloud.pubsublite.proto.InitialPublishRequest) obj;
 
-    if (!getTopic()
-        .equals(other.getTopic())) return false;
-    if (getPartition()
-        != other.getPartition()) return false;
+    if (!getTopic().equals(other.getTopic())) return false;
+    if (getPartition() != other.getPartition()) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -225,125 +234,134 @@ private static final long serialVersionUID = 0L;
     hash = (37 * hash) + TOPIC_FIELD_NUMBER;
     hash = (53 * hash) + getTopic().hashCode();
     hash = (37 * hash) + PARTITION_FIELD_NUMBER;
-    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-        getPartition());
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(getPartition());
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
   }
 
   public static com.google.cloud.pubsublite.proto.InitialPublishRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.InitialPublishRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.InitialPublishRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.InitialPublishRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.InitialPublishRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.InitialPublishRequest prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.InitialPublishRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * The first request that must be sent on a newly-opened stream.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.InitialPublishRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.InitialPublishRequest)
       com.google.cloud.pubsublite.proto.InitialPublishRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.InitialPublishRequest.class, com.google.cloud.pubsublite.proto.InitialPublishRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.InitialPublishRequest.class,
+              com.google.cloud.pubsublite.proto.InitialPublishRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.InitialPublishRequest.newBuilder()
@@ -351,16 +369,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -372,9 +389,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_descriptor;
     }
 
     @java.lang.Override
@@ -393,7 +410,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.InitialPublishRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.InitialPublishRequest result = new com.google.cloud.pubsublite.proto.InitialPublishRequest(this);
+      com.google.cloud.pubsublite.proto.InitialPublishRequest result =
+          new com.google.cloud.pubsublite.proto.InitialPublishRequest(this);
       result.topic_ = topic_;
       result.partition_ = partition_;
       onBuilt();
@@ -404,38 +422,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.InitialPublishRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.InitialPublishRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.InitialPublishRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -443,7 +462,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.InitialPublishRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.InitialPublishRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.InitialPublishRequest.getDefaultInstance())
+        return this;
       if (!other.getTopic().isEmpty()) {
         topic_ = other.topic_;
         onChanged();
@@ -470,7 +490,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.InitialPublishRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.InitialPublishRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -482,18 +503,20 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object topic_ = "";
     /**
+     *
+     *
      * <pre>
      * The topic to which messages will be written.
      * </pre>
      *
      * <code>string topic = 1;</code>
+     *
      * @return The topic.
      */
     public java.lang.String getTopic() {
       java.lang.Object ref = topic_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         topic_ = s;
         return s;
@@ -502,20 +525,21 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The topic to which messages will be written.
      * </pre>
      *
      * <code>string topic = 1;</code>
+     *
      * @return The bytes for topic.
      */
-    public com.google.protobuf.ByteString
-        getTopicBytes() {
+    public com.google.protobuf.ByteString getTopicBytes() {
       java.lang.Object ref = topic_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         topic_ = b;
         return b;
       } else {
@@ -523,61 +547,70 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The topic to which messages will be written.
      * </pre>
      *
      * <code>string topic = 1;</code>
+     *
      * @param value The topic to set.
      * @return This builder for chaining.
      */
-    public Builder setTopic(
-        java.lang.String value) {
+    public Builder setTopic(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       topic_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The topic to which messages will be written.
      * </pre>
      *
      * <code>string topic = 1;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearTopic() {
-      
+
       topic_ = getDefaultInstance().getTopic();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The topic to which messages will be written.
      * </pre>
      *
      * <code>string topic = 1;</code>
+     *
      * @param value The bytes for topic to set.
      * @return This builder for chaining.
      */
-    public Builder setTopicBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setTopicBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       topic_ = value;
       onChanged();
       return this;
     }
 
-    private long partition_ ;
+    private long partition_;
     /**
+     *
+     *
      * <pre>
      * The partition within the topic to which messages will be written.
      * Partitions are zero indexed, so `partition` must be in the range [0,
@@ -585,12 +618,15 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int64 partition = 2;</code>
+     *
      * @return The partition.
      */
     public long getPartition() {
       return partition_;
     }
     /**
+     *
+     *
      * <pre>
      * The partition within the topic to which messages will be written.
      * Partitions are zero indexed, so `partition` must be in the range [0,
@@ -598,16 +634,19 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int64 partition = 2;</code>
+     *
      * @param value The partition to set.
      * @return This builder for chaining.
      */
     public Builder setPartition(long value) {
-      
+
       partition_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The partition within the topic to which messages will be written.
      * Partitions are zero indexed, so `partition` must be in the range [0,
@@ -615,17 +654,18 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int64 partition = 2;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearPartition() {
-      
+
       partition_ = 0L;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -635,12 +675,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.InitialPublishRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.InitialPublishRequest)
   private static final com.google.cloud.pubsublite.proto.InitialPublishRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.InitialPublishRequest();
   }
@@ -649,16 +689,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<InitialPublishRequest>
-      PARSER = new com.google.protobuf.AbstractParser<InitialPublishRequest>() {
-    @java.lang.Override
-    public InitialPublishRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new InitialPublishRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<InitialPublishRequest> PARSER =
+      new com.google.protobuf.AbstractParser<InitialPublishRequest>() {
+        @java.lang.Override
+        public InitialPublishRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new InitialPublishRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<InitialPublishRequest> parser() {
     return PARSER;
@@ -673,6 +713,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.InitialPublishRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialPublishRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialPublishRequestOrBuilder.java
@@ -3,31 +3,39 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface InitialPublishRequestOrBuilder extends
+public interface InitialPublishRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.InitialPublishRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The topic to which messages will be written.
    * </pre>
    *
    * <code>string topic = 1;</code>
+   *
    * @return The topic.
    */
   java.lang.String getTopic();
   /**
+   *
+   *
    * <pre>
    * The topic to which messages will be written.
    * </pre>
    *
    * <code>string topic = 1;</code>
+   *
    * @return The bytes for topic.
    */
-  com.google.protobuf.ByteString
-      getTopicBytes();
+  com.google.protobuf.ByteString getTopicBytes();
 
   /**
+   *
+   *
    * <pre>
    * The partition within the topic to which messages will be written.
    * Partitions are zero indexed, so `partition` must be in the range [0,
@@ -35,6 +43,7 @@ public interface InitialPublishRequestOrBuilder extends
    * </pre>
    *
    * <code>int64 partition = 2;</code>
+   *
    * @return The partition.
    */
   long getPartition();

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialPublishResponse.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialPublishResponse.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Response to an InitialPublishRequest.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.InitialPublishResponse}
  */
-public  final class InitialPublishResponse extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class InitialPublishResponse extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.InitialPublishResponse)
     InitialPublishResponseOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use InitialPublishResponse.newBuilder() to construct.
   private InitialPublishResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private InitialPublishResponse() {
-  }
+
+  private InitialPublishResponse() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new InitialPublishResponse();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private InitialPublishResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,39 +53,42 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
             }
-            break;
-          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.PublisherProto
+        .internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.PublisherProto
+        .internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.InitialPublishResponse.class, com.google.cloud.pubsublite.proto.InitialPublishResponse.Builder.class);
+            com.google.cloud.pubsublite.proto.InitialPublishResponse.class,
+            com.google.cloud.pubsublite.proto.InitialPublishResponse.Builder.class);
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -96,8 +100,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     unknownFields.writeTo(output);
   }
 
@@ -115,12 +118,13 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.InitialPublishResponse)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.InitialPublishResponse other = (com.google.cloud.pubsublite.proto.InitialPublishResponse) obj;
+    com.google.cloud.pubsublite.proto.InitialPublishResponse other =
+        (com.google.cloud.pubsublite.proto.InitialPublishResponse) obj;
 
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
@@ -139,117 +143,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.InitialPublishResponse parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishResponse parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishResponse parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishResponse parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishResponse parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.InitialPublishResponse parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishResponse parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.InitialPublishResponse parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.InitialPublishResponse parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishResponse parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.InitialPublishResponse parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishResponse parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialPublishResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.InitialPublishResponse prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.InitialPublishResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Response to an InitialPublishRequest.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.InitialPublishResponse}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.InitialPublishResponse)
       com.google.cloud.pubsublite.proto.InitialPublishResponseOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.InitialPublishResponse.class, com.google.cloud.pubsublite.proto.InitialPublishResponse.Builder.class);
+              com.google.cloud.pubsublite.proto.InitialPublishResponse.class,
+              com.google.cloud.pubsublite.proto.InitialPublishResponse.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.InitialPublishResponse.newBuilder()
@@ -257,16 +271,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -274,9 +287,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_descriptor;
     }
 
     @java.lang.Override
@@ -295,7 +308,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.InitialPublishResponse buildPartial() {
-      com.google.cloud.pubsublite.proto.InitialPublishResponse result = new com.google.cloud.pubsublite.proto.InitialPublishResponse(this);
+      com.google.cloud.pubsublite.proto.InitialPublishResponse result =
+          new com.google.cloud.pubsublite.proto.InitialPublishResponse(this);
       onBuilt();
       return result;
     }
@@ -304,38 +318,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.InitialPublishResponse) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.InitialPublishResponse)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.InitialPublishResponse) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -343,7 +358,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.InitialPublishResponse other) {
-      if (other == com.google.cloud.pubsublite.proto.InitialPublishResponse.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.InitialPublishResponse.getDefaultInstance())
+        return this;
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
@@ -363,7 +379,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.InitialPublishResponse) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.InitialPublishResponse) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -372,9 +389,9 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -384,12 +401,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.InitialPublishResponse)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.InitialPublishResponse)
   private static final com.google.cloud.pubsublite.proto.InitialPublishResponse DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.InitialPublishResponse();
   }
@@ -398,16 +415,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<InitialPublishResponse>
-      PARSER = new com.google.protobuf.AbstractParser<InitialPublishResponse>() {
-    @java.lang.Override
-    public InitialPublishResponse parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new InitialPublishResponse(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<InitialPublishResponse> PARSER =
+      new com.google.protobuf.AbstractParser<InitialPublishResponse>() {
+        @java.lang.Override
+        public InitialPublishResponse parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new InitialPublishResponse(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<InitialPublishResponse> parser() {
     return PARSER;
@@ -422,6 +439,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.InitialPublishResponse getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialPublishResponseOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialPublishResponseOrBuilder.java
@@ -3,7 +3,7 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface InitialPublishResponseOrBuilder extends
+public interface InitialPublishResponseOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.InitialPublishResponse)
-    com.google.protobuf.MessageOrBuilder {
-}
+    com.google.protobuf.MessageOrBuilder {}

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialSubscribeRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialSubscribeRequest.java
@@ -4,6 +4,8 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * The first request that must be sent on a newly-opened stream. The client must
  * wait for the response before sending subsequent requests on the stream.
@@ -11,31 +13,31 @@ package com.google.cloud.pubsublite.proto;
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.InitialSubscribeRequest}
  */
-public  final class InitialSubscribeRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class InitialSubscribeRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.InitialSubscribeRequest)
     InitialSubscribeRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use InitialSubscribeRequest.newBuilder() to construct.
   private InitialSubscribeRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private InitialSubscribeRequest() {
     subscription_ = "";
   }
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new InitialSubscribeRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private InitialSubscribeRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -54,57 +56,63 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            subscription_ = s;
-            break;
-          }
-          case 16: {
-
-            partition_ = input.readInt64();
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              subscription_ = s;
+              break;
             }
-            break;
-          }
+          case 16:
+            {
+              partition_ = input.readInt64();
+              break;
+            }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.SubscriberProto
+        .internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.SubscriberProto
+        .internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.InitialSubscribeRequest.class, com.google.cloud.pubsublite.proto.InitialSubscribeRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.InitialSubscribeRequest.class,
+            com.google.cloud.pubsublite.proto.InitialSubscribeRequest.Builder.class);
   }
 
   public static final int SUBSCRIPTION_FIELD_NUMBER = 1;
   private volatile java.lang.Object subscription_;
   /**
+   *
+   *
    * <pre>
    * The subscription from which to receive messages.
    * </pre>
    *
    * <code>string subscription = 1;</code>
+   *
    * @return The subscription.
    */
   public java.lang.String getSubscription() {
@@ -112,28 +120,28 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       subscription_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The subscription from which to receive messages.
    * </pre>
    *
    * <code>string subscription = 1;</code>
+   *
    * @return The bytes for subscription.
    */
-  public com.google.protobuf.ByteString
-      getSubscriptionBytes() {
+  public com.google.protobuf.ByteString getSubscriptionBytes() {
     java.lang.Object ref = subscription_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       subscription_ = b;
       return b;
     } else {
@@ -144,12 +152,15 @@ private static final long serialVersionUID = 0L;
   public static final int PARTITION_FIELD_NUMBER = 2;
   private long partition_;
   /**
+   *
+   *
    * <pre>
    * The partition from which to receive messages. Partitions are zero indexed,
    * so `partition` must be in the range [0, topic.num_partitions).
    * </pre>
    *
    * <code>int64 partition = 2;</code>
+   *
    * @return The partition.
    */
   public long getPartition() {
@@ -157,6 +168,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -168,8 +180,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getSubscriptionBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, subscription_);
     }
@@ -189,8 +200,7 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, subscription_);
     }
     if (partition_ != 0L) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeInt64Size(2, partition_);
+      size += com.google.protobuf.CodedOutputStream.computeInt64Size(2, partition_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -200,17 +210,16 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.InitialSubscribeRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.InitialSubscribeRequest other = (com.google.cloud.pubsublite.proto.InitialSubscribeRequest) obj;
+    com.google.cloud.pubsublite.proto.InitialSubscribeRequest other =
+        (com.google.cloud.pubsublite.proto.InitialSubscribeRequest) obj;
 
-    if (!getSubscription()
-        .equals(other.getSubscription())) return false;
-    if (getPartition()
-        != other.getPartition()) return false;
+    if (!getSubscription().equals(other.getSubscription())) return false;
+    if (getPartition() != other.getPartition()) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -225,104 +234,111 @@ private static final long serialVersionUID = 0L;
     hash = (37 * hash) + SUBSCRIPTION_FIELD_NUMBER;
     hash = (53 * hash) + getSubscription().hashCode();
     hash = (37 * hash) + PARTITION_FIELD_NUMBER;
-    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-        getPartition());
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(getPartition());
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
   }
 
   public static com.google.cloud.pubsublite.proto.InitialSubscribeRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.InitialSubscribeRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.InitialSubscribeRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.InitialSubscribeRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.InitialSubscribeRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.InitialSubscribeRequest prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.InitialSubscribeRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * The first request that must be sent on a newly-opened stream. The client must
    * wait for the response before sending subsequent requests on the stream.
@@ -330,21 +346,23 @@ private static final long serialVersionUID = 0L;
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.InitialSubscribeRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.InitialSubscribeRequest)
       com.google.cloud.pubsublite.proto.InitialSubscribeRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.InitialSubscribeRequest.class, com.google.cloud.pubsublite.proto.InitialSubscribeRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.InitialSubscribeRequest.class,
+              com.google.cloud.pubsublite.proto.InitialSubscribeRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.InitialSubscribeRequest.newBuilder()
@@ -352,16 +370,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -373,9 +390,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_descriptor;
     }
 
     @java.lang.Override
@@ -394,7 +411,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.InitialSubscribeRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.InitialSubscribeRequest result = new com.google.cloud.pubsublite.proto.InitialSubscribeRequest(this);
+      com.google.cloud.pubsublite.proto.InitialSubscribeRequest result =
+          new com.google.cloud.pubsublite.proto.InitialSubscribeRequest(this);
       result.subscription_ = subscription_;
       result.partition_ = partition_;
       onBuilt();
@@ -405,38 +423,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.InitialSubscribeRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.InitialSubscribeRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.InitialSubscribeRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -444,7 +463,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.InitialSubscribeRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.InitialSubscribeRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.InitialSubscribeRequest.getDefaultInstance())
+        return this;
       if (!other.getSubscription().isEmpty()) {
         subscription_ = other.subscription_;
         onChanged();
@@ -471,7 +491,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.InitialSubscribeRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.InitialSubscribeRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -483,18 +504,20 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object subscription_ = "";
     /**
+     *
+     *
      * <pre>
      * The subscription from which to receive messages.
      * </pre>
      *
      * <code>string subscription = 1;</code>
+     *
      * @return The subscription.
      */
     public java.lang.String getSubscription() {
       java.lang.Object ref = subscription_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         subscription_ = s;
         return s;
@@ -503,20 +526,21 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The subscription from which to receive messages.
      * </pre>
      *
      * <code>string subscription = 1;</code>
+     *
      * @return The bytes for subscription.
      */
-    public com.google.protobuf.ByteString
-        getSubscriptionBytes() {
+    public com.google.protobuf.ByteString getSubscriptionBytes() {
       java.lang.Object ref = subscription_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         subscription_ = b;
         return b;
       } else {
@@ -524,106 +548,122 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The subscription from which to receive messages.
      * </pre>
      *
      * <code>string subscription = 1;</code>
+     *
      * @param value The subscription to set.
      * @return This builder for chaining.
      */
-    public Builder setSubscription(
-        java.lang.String value) {
+    public Builder setSubscription(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       subscription_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The subscription from which to receive messages.
      * </pre>
      *
      * <code>string subscription = 1;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearSubscription() {
-      
+
       subscription_ = getDefaultInstance().getSubscription();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The subscription from which to receive messages.
      * </pre>
      *
      * <code>string subscription = 1;</code>
+     *
      * @param value The bytes for subscription to set.
      * @return This builder for chaining.
      */
-    public Builder setSubscriptionBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setSubscriptionBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       subscription_ = value;
       onChanged();
       return this;
     }
 
-    private long partition_ ;
+    private long partition_;
     /**
+     *
+     *
      * <pre>
      * The partition from which to receive messages. Partitions are zero indexed,
      * so `partition` must be in the range [0, topic.num_partitions).
      * </pre>
      *
      * <code>int64 partition = 2;</code>
+     *
      * @return The partition.
      */
     public long getPartition() {
       return partition_;
     }
     /**
+     *
+     *
      * <pre>
      * The partition from which to receive messages. Partitions are zero indexed,
      * so `partition` must be in the range [0, topic.num_partitions).
      * </pre>
      *
      * <code>int64 partition = 2;</code>
+     *
      * @param value The partition to set.
      * @return This builder for chaining.
      */
     public Builder setPartition(long value) {
-      
+
       partition_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The partition from which to receive messages. Partitions are zero indexed,
      * so `partition` must be in the range [0, topic.num_partitions).
      * </pre>
      *
      * <code>int64 partition = 2;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearPartition() {
-      
+
       partition_ = 0L;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -633,12 +673,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.InitialSubscribeRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.InitialSubscribeRequest)
   private static final com.google.cloud.pubsublite.proto.InitialSubscribeRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.InitialSubscribeRequest();
   }
@@ -647,16 +687,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<InitialSubscribeRequest>
-      PARSER = new com.google.protobuf.AbstractParser<InitialSubscribeRequest>() {
-    @java.lang.Override
-    public InitialSubscribeRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new InitialSubscribeRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<InitialSubscribeRequest> PARSER =
+      new com.google.protobuf.AbstractParser<InitialSubscribeRequest>() {
+        @java.lang.Override
+        public InitialSubscribeRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new InitialSubscribeRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<InitialSubscribeRequest> parser() {
     return PARSER;
@@ -671,6 +711,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.InitialSubscribeRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialSubscribeRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialSubscribeRequestOrBuilder.java
@@ -3,37 +3,46 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface InitialSubscribeRequestOrBuilder extends
+public interface InitialSubscribeRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.InitialSubscribeRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The subscription from which to receive messages.
    * </pre>
    *
    * <code>string subscription = 1;</code>
+   *
    * @return The subscription.
    */
   java.lang.String getSubscription();
   /**
+   *
+   *
    * <pre>
    * The subscription from which to receive messages.
    * </pre>
    *
    * <code>string subscription = 1;</code>
+   *
    * @return The bytes for subscription.
    */
-  com.google.protobuf.ByteString
-      getSubscriptionBytes();
+  com.google.protobuf.ByteString getSubscriptionBytes();
 
   /**
+   *
+   *
    * <pre>
    * The partition from which to receive messages. Partitions are zero indexed,
    * so `partition` must be in the range [0, topic.num_partitions).
    * </pre>
    *
    * <code>int64 partition = 2;</code>
+   *
    * @return The partition.
    */
   long getPartition();

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialSubscribeResponse.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialSubscribeResponse.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Response to an InitialSubscribeRequest.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.InitialSubscribeResponse}
  */
-public  final class InitialSubscribeResponse extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class InitialSubscribeResponse extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.InitialSubscribeResponse)
     InitialSubscribeResponseOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use InitialSubscribeResponse.newBuilder() to construct.
   private InitialSubscribeResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private InitialSubscribeResponse() {
-  }
+
+  private InitialSubscribeResponse() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new InitialSubscribeResponse();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private InitialSubscribeResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,78 +53,93 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            com.google.cloud.pubsublite.proto.Cursor.Builder subBuilder = null;
-            if (cursor_ != null) {
-              subBuilder = cursor_.toBuilder();
-            }
-            cursor_ = input.readMessage(com.google.cloud.pubsublite.proto.Cursor.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(cursor_);
-              cursor_ = subBuilder.buildPartial();
-            }
+          case 10:
+            {
+              com.google.cloud.pubsublite.proto.Cursor.Builder subBuilder = null;
+              if (cursor_ != null) {
+                subBuilder = cursor_.toBuilder();
+              }
+              cursor_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Cursor.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(cursor_);
+                cursor_ = subBuilder.buildPartial();
+              }
 
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.SubscriberProto
+        .internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.SubscriberProto
+        .internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.InitialSubscribeResponse.class, com.google.cloud.pubsublite.proto.InitialSubscribeResponse.Builder.class);
+            com.google.cloud.pubsublite.proto.InitialSubscribeResponse.class,
+            com.google.cloud.pubsublite.proto.InitialSubscribeResponse.Builder.class);
   }
 
   public static final int CURSOR_FIELD_NUMBER = 1;
   private com.google.cloud.pubsublite.proto.Cursor cursor_;
   /**
+   *
+   *
    * <pre>
    * The cursor from which the subscriber will start receiving messages once
    * flow control tokens become available.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+   *
    * @return Whether the cursor field is set.
    */
   public boolean hasCursor() {
     return cursor_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * The cursor from which the subscriber will start receiving messages once
    * flow control tokens become available.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+   *
    * @return The cursor.
    */
   public com.google.cloud.pubsublite.proto.Cursor getCursor() {
-    return cursor_ == null ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+    return cursor_ == null
+        ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+        : cursor_;
   }
   /**
+   *
+   *
    * <pre>
    * The cursor from which the subscriber will start receiving messages once
    * flow control tokens become available.
@@ -136,6 +152,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -147,8 +164,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (cursor_ != null) {
       output.writeMessage(1, getCursor());
     }
@@ -162,8 +178,7 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (cursor_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, getCursor());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(1, getCursor());
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -173,17 +188,17 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.InitialSubscribeResponse)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.InitialSubscribeResponse other = (com.google.cloud.pubsublite.proto.InitialSubscribeResponse) obj;
+    com.google.cloud.pubsublite.proto.InitialSubscribeResponse other =
+        (com.google.cloud.pubsublite.proto.InitialSubscribeResponse) obj;
 
     if (hasCursor() != other.hasCursor()) return false;
     if (hasCursor()) {
-      if (!getCursor()
-          .equals(other.getCursor())) return false;
+      if (!getCursor().equals(other.getCursor())) return false;
     }
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
@@ -206,117 +221,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.InitialSubscribeResponse parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeResponse parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeResponse parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeResponse parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeResponse parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.InitialSubscribeResponse parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeResponse parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.InitialSubscribeResponse parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.InitialSubscribeResponse parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeResponse parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.InitialSubscribeResponse parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeResponse parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.InitialSubscribeResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.InitialSubscribeResponse prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.InitialSubscribeResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Response to an InitialSubscribeRequest.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.InitialSubscribeResponse}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.InitialSubscribeResponse)
       com.google.cloud.pubsublite.proto.InitialSubscribeResponseOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.InitialSubscribeResponse.class, com.google.cloud.pubsublite.proto.InitialSubscribeResponse.Builder.class);
+              com.google.cloud.pubsublite.proto.InitialSubscribeResponse.class,
+              com.google.cloud.pubsublite.proto.InitialSubscribeResponse.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.InitialSubscribeResponse.newBuilder()
@@ -324,16 +349,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -347,9 +371,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_descriptor;
     }
 
     @java.lang.Override
@@ -368,7 +392,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.InitialSubscribeResponse buildPartial() {
-      com.google.cloud.pubsublite.proto.InitialSubscribeResponse result = new com.google.cloud.pubsublite.proto.InitialSubscribeResponse(this);
+      com.google.cloud.pubsublite.proto.InitialSubscribeResponse result =
+          new com.google.cloud.pubsublite.proto.InitialSubscribeResponse(this);
       if (cursorBuilder_ == null) {
         result.cursor_ = cursor_;
       } else {
@@ -382,38 +407,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.InitialSubscribeResponse) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.InitialSubscribeResponse)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.InitialSubscribeResponse) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -421,7 +447,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.InitialSubscribeResponse other) {
-      if (other == com.google.cloud.pubsublite.proto.InitialSubscribeResponse.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.InitialSubscribeResponse.getDefaultInstance())
+        return this;
       if (other.hasCursor()) {
         mergeCursor(other.getCursor());
       }
@@ -444,7 +471,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.InitialSubscribeResponse) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.InitialSubscribeResponse) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -456,36 +484,49 @@ private static final long serialVersionUID = 0L;
 
     private com.google.cloud.pubsublite.proto.Cursor cursor_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder> cursorBuilder_;
+            com.google.cloud.pubsublite.proto.Cursor,
+            com.google.cloud.pubsublite.proto.Cursor.Builder,
+            com.google.cloud.pubsublite.proto.CursorOrBuilder>
+        cursorBuilder_;
     /**
+     *
+     *
      * <pre>
      * The cursor from which the subscriber will start receiving messages once
      * flow control tokens become available.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+     *
      * @return Whether the cursor field is set.
      */
     public boolean hasCursor() {
       return cursorBuilder_ != null || cursor_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * The cursor from which the subscriber will start receiving messages once
      * flow control tokens become available.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+     *
      * @return The cursor.
      */
     public com.google.cloud.pubsublite.proto.Cursor getCursor() {
       if (cursorBuilder_ == null) {
-        return cursor_ == null ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+        return cursor_ == null
+            ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+            : cursor_;
       } else {
         return cursorBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * The cursor from which the subscriber will start receiving messages once
      * flow control tokens become available.
@@ -507,6 +548,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The cursor from which the subscriber will start receiving messages once
      * flow control tokens become available.
@@ -514,8 +557,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
      */
-    public Builder setCursor(
-        com.google.cloud.pubsublite.proto.Cursor.Builder builderForValue) {
+    public Builder setCursor(com.google.cloud.pubsublite.proto.Cursor.Builder builderForValue) {
       if (cursorBuilder_ == null) {
         cursor_ = builderForValue.build();
         onChanged();
@@ -526,6 +568,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The cursor from which the subscriber will start receiving messages once
      * flow control tokens become available.
@@ -537,7 +581,9 @@ private static final long serialVersionUID = 0L;
       if (cursorBuilder_ == null) {
         if (cursor_ != null) {
           cursor_ =
-            com.google.cloud.pubsublite.proto.Cursor.newBuilder(cursor_).mergeFrom(value).buildPartial();
+              com.google.cloud.pubsublite.proto.Cursor.newBuilder(cursor_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           cursor_ = value;
         }
@@ -549,6 +595,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The cursor from which the subscriber will start receiving messages once
      * flow control tokens become available.
@@ -568,6 +616,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The cursor from which the subscriber will start receiving messages once
      * flow control tokens become available.
@@ -576,11 +626,13 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
      */
     public com.google.cloud.pubsublite.proto.Cursor.Builder getCursorBuilder() {
-      
+
       onChanged();
       return getCursorFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * The cursor from which the subscriber will start receiving messages once
      * flow control tokens become available.
@@ -592,11 +644,14 @@ private static final long serialVersionUID = 0L;
       if (cursorBuilder_ != null) {
         return cursorBuilder_.getMessageOrBuilder();
       } else {
-        return cursor_ == null ?
-            com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+        return cursor_ == null
+            ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+            : cursor_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The cursor from which the subscriber will start receiving messages once
      * flow control tokens become available.
@@ -605,21 +660,24 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder> 
+            com.google.cloud.pubsublite.proto.Cursor,
+            com.google.cloud.pubsublite.proto.Cursor.Builder,
+            com.google.cloud.pubsublite.proto.CursorOrBuilder>
         getCursorFieldBuilder() {
       if (cursorBuilder_ == null) {
-        cursorBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder>(
-                getCursor(),
-                getParentForChildren(),
-                isClean());
+        cursorBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Cursor,
+                com.google.cloud.pubsublite.proto.Cursor.Builder,
+                com.google.cloud.pubsublite.proto.CursorOrBuilder>(
+                getCursor(), getParentForChildren(), isClean());
         cursor_ = null;
       }
       return cursorBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -629,12 +687,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.InitialSubscribeResponse)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.InitialSubscribeResponse)
   private static final com.google.cloud.pubsublite.proto.InitialSubscribeResponse DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.InitialSubscribeResponse();
   }
@@ -643,16 +701,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<InitialSubscribeResponse>
-      PARSER = new com.google.protobuf.AbstractParser<InitialSubscribeResponse>() {
-    @java.lang.Override
-    public InitialSubscribeResponse parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new InitialSubscribeResponse(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<InitialSubscribeResponse> PARSER =
+      new com.google.protobuf.AbstractParser<InitialSubscribeResponse>() {
+        @java.lang.Override
+        public InitialSubscribeResponse parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new InitialSubscribeResponse(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<InitialSubscribeResponse> parser() {
     return PARSER;
@@ -667,6 +725,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.InitialSubscribeResponse getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialSubscribeResponseOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/InitialSubscribeResponseOrBuilder.java
@@ -3,31 +3,40 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface InitialSubscribeResponseOrBuilder extends
+public interface InitialSubscribeResponseOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.InitialSubscribeResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The cursor from which the subscriber will start receiving messages once
    * flow control tokens become available.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+   *
    * @return Whether the cursor field is set.
    */
   boolean hasCursor();
   /**
+   *
+   *
    * <pre>
    * The cursor from which the subscriber will start receiving messages once
    * flow control tokens become available.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+   *
    * @return The cursor.
    */
   com.google.cloud.pubsublite.proto.Cursor getCursor();
   /**
+   *
+   *
    * <pre>
    * The cursor from which the subscriber will start receiving messages once
    * flow control tokens become available.

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListPartitionCursorsRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListPartitionCursorsRequest.java
@@ -4,21 +4,24 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request for ListPartitionCursors.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.ListPartitionCursorsRequest}
  */
-public  final class ListPartitionCursorsRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class ListPartitionCursorsRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.ListPartitionCursorsRequest)
     ListPartitionCursorsRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use ListPartitionCursorsRequest.newBuilder() to construct.
   private ListPartitionCursorsRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private ListPartitionCursorsRequest() {
     parent_ = "";
     pageToken_ = "";
@@ -26,16 +29,15 @@ private static final long serialVersionUID = 0L;
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new ListPartitionCursorsRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private ListPartitionCursorsRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -54,65 +56,74 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            parent_ = s;
-            break;
-          }
-          case 16: {
-
-            pageSize_ = input.readInt32();
-            break;
-          }
-          case 26: {
-            java.lang.String s = input.readStringRequireUtf8();
-
-            pageToken_ = s;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              parent_ = s;
+              break;
             }
-            break;
-          }
+          case 16:
+            {
+              pageSize_ = input.readInt32();
+              break;
+            }
+          case 26:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              pageToken_ = s;
+              break;
+            }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest.class, com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest.class,
+            com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest.Builder.class);
   }
 
   public static final int PARENT_FIELD_NUMBER = 1;
   private volatile java.lang.Object parent_;
   /**
+   *
+   *
    * <pre>
    * The subscription for which to retrieve cursors.
    * Structured like
    * `projects/{project_number}/locations/{location}/subscriptions/{subscription_id}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The parent.
    */
   public java.lang.String getParent() {
@@ -120,30 +131,32 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       parent_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The subscription for which to retrieve cursors.
    * Structured like
    * `projects/{project_number}/locations/{location}/subscriptions/{subscription_id}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for parent.
    */
-  public com.google.protobuf.ByteString
-      getParentBytes() {
+  public com.google.protobuf.ByteString getParentBytes() {
     java.lang.Object ref = parent_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       parent_ = b;
       return b;
     } else {
@@ -154,6 +167,8 @@ private static final long serialVersionUID = 0L;
   public static final int PAGE_SIZE_FIELD_NUMBER = 2;
   private int pageSize_;
   /**
+   *
+   *
    * <pre>
    * The maximum number of cursors to return. The service may return fewer than
    * this value.
@@ -161,6 +176,7 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>int32 page_size = 2;</code>
+   *
    * @return The pageSize.
    */
   public int getPageSize() {
@@ -170,6 +186,8 @@ private static final long serialVersionUID = 0L;
   public static final int PAGE_TOKEN_FIELD_NUMBER = 3;
   private volatile java.lang.Object pageToken_;
   /**
+   *
+   *
    * <pre>
    * A page token, received from a previous `ListPartitionCursors` call.
    * Provide this to retrieve the subsequent page.
@@ -178,6 +196,7 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string page_token = 3;</code>
+   *
    * @return The pageToken.
    */
   public java.lang.String getPageToken() {
@@ -185,14 +204,15 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       pageToken_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * A page token, received from a previous `ListPartitionCursors` call.
    * Provide this to retrieve the subsequent page.
@@ -201,15 +221,14 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string page_token = 3;</code>
+   *
    * @return The bytes for pageToken.
    */
-  public com.google.protobuf.ByteString
-      getPageTokenBytes() {
+  public com.google.protobuf.ByteString getPageTokenBytes() {
     java.lang.Object ref = pageToken_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       pageToken_ = b;
       return b;
     } else {
@@ -218,6 +237,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -229,8 +249,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getParentBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, parent_);
     }
@@ -253,8 +272,7 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, parent_);
     }
     if (pageSize_ != 0) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeInt32Size(2, pageSize_);
+      size += com.google.protobuf.CodedOutputStream.computeInt32Size(2, pageSize_);
     }
     if (!getPageTokenBytes().isEmpty()) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, pageToken_);
@@ -267,19 +285,17 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest other = (com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest) obj;
+    com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest other =
+        (com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest) obj;
 
-    if (!getParent()
-        .equals(other.getParent())) return false;
-    if (getPageSize()
-        != other.getPageSize()) return false;
-    if (!getPageToken()
-        .equals(other.getPageToken())) return false;
+    if (!getParent().equals(other.getParent())) return false;
+    if (getPageSize() != other.getPageSize()) return false;
+    if (!getPageToken().equals(other.getPageToken())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -303,117 +319,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request for ListPartitionCursors.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.ListPartitionCursorsRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.ListPartitionCursorsRequest)
       com.google.cloud.pubsublite.proto.ListPartitionCursorsRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest.class, com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest.class,
+              com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest.newBuilder()
@@ -421,16 +447,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -444,13 +469,14 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsRequest_descriptor;
     }
 
     @java.lang.Override
-    public com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest getDefaultInstanceForType() {
+    public com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest
+        getDefaultInstanceForType() {
       return com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest.getDefaultInstance();
     }
 
@@ -465,7 +491,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest result = new com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest(this);
+      com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest result =
+          new com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest(this);
       result.parent_ = parent_;
       result.pageSize_ = pageSize_;
       result.pageToken_ = pageToken_;
@@ -477,38 +504,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -516,7 +544,9 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest.getDefaultInstance()) return this;
+      if (other
+          == com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest.getDefaultInstance())
+        return this;
       if (!other.getParent().isEmpty()) {
         parent_ = other.parent_;
         onChanged();
@@ -547,7 +577,9 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest)
+                e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -559,20 +591,24 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object parent_ = "";
     /**
+     *
+     *
      * <pre>
      * The subscription for which to retrieve cursors.
      * Structured like
      * `projects/{project_number}/locations/{location}/subscriptions/{subscription_id}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The parent.
      */
     public java.lang.String getParent() {
       java.lang.Object ref = parent_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         parent_ = s;
         return s;
@@ -581,22 +617,25 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The subscription for which to retrieve cursors.
      * Structured like
      * `projects/{project_number}/locations/{location}/subscriptions/{subscription_id}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The bytes for parent.
      */
-    public com.google.protobuf.ByteString
-        getParentBytes() {
+    public com.google.protobuf.ByteString getParentBytes() {
       java.lang.Object ref = parent_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         parent_ = b;
         return b;
       } else {
@@ -604,67 +643,82 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The subscription for which to retrieve cursors.
      * Structured like
      * `projects/{project_number}/locations/{location}/subscriptions/{subscription_id}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The parent to set.
      * @return This builder for chaining.
      */
-    public Builder setParent(
-        java.lang.String value) {
+    public Builder setParent(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       parent_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The subscription for which to retrieve cursors.
      * Structured like
      * `projects/{project_number}/locations/{location}/subscriptions/{subscription_id}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearParent() {
-      
+
       parent_ = getDefaultInstance().getParent();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The subscription for which to retrieve cursors.
      * Structured like
      * `projects/{project_number}/locations/{location}/subscriptions/{subscription_id}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The bytes for parent to set.
      * @return This builder for chaining.
      */
-    public Builder setParentBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setParentBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       parent_ = value;
       onChanged();
       return this;
     }
 
-    private int pageSize_ ;
+    private int pageSize_;
     /**
+     *
+     *
      * <pre>
      * The maximum number of cursors to return. The service may return fewer than
      * this value.
@@ -672,12 +726,15 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int32 page_size = 2;</code>
+     *
      * @return The pageSize.
      */
     public int getPageSize() {
       return pageSize_;
     }
     /**
+     *
+     *
      * <pre>
      * The maximum number of cursors to return. The service may return fewer than
      * this value.
@@ -685,16 +742,19 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int32 page_size = 2;</code>
+     *
      * @param value The pageSize to set.
      * @return This builder for chaining.
      */
     public Builder setPageSize(int value) {
-      
+
       pageSize_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The maximum number of cursors to return. The service may return fewer than
      * this value.
@@ -702,10 +762,11 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int32 page_size = 2;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearPageSize() {
-      
+
       pageSize_ = 0;
       onChanged();
       return this;
@@ -713,6 +774,8 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object pageToken_ = "";
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListPartitionCursors` call.
      * Provide this to retrieve the subsequent page.
@@ -721,13 +784,13 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @return The pageToken.
      */
     public java.lang.String getPageToken() {
       java.lang.Object ref = pageToken_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         pageToken_ = s;
         return s;
@@ -736,6 +799,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListPartitionCursors` call.
      * Provide this to retrieve the subsequent page.
@@ -744,15 +809,14 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @return The bytes for pageToken.
      */
-    public com.google.protobuf.ByteString
-        getPageTokenBytes() {
+    public com.google.protobuf.ByteString getPageTokenBytes() {
       java.lang.Object ref = pageToken_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         pageToken_ = b;
         return b;
       } else {
@@ -760,6 +824,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListPartitionCursors` call.
      * Provide this to retrieve the subsequent page.
@@ -768,20 +834,22 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @param value The pageToken to set.
      * @return This builder for chaining.
      */
-    public Builder setPageToken(
-        java.lang.String value) {
+    public Builder setPageToken(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       pageToken_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListPartitionCursors` call.
      * Provide this to retrieve the subsequent page.
@@ -790,15 +858,18 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearPageToken() {
-      
+
       pageToken_ = getDefaultInstance().getPageToken();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListPartitionCursors` call.
      * Provide this to retrieve the subsequent page.
@@ -807,23 +878,23 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @param value The bytes for pageToken to set.
      * @return This builder for chaining.
      */
-    public Builder setPageTokenBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setPageTokenBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       pageToken_ = value;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -833,12 +904,13 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.ListPartitionCursorsRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.ListPartitionCursorsRequest)
-  private static final com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest DEFAULT_INSTANCE;
+  private static final com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest
+      DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest();
   }
@@ -847,16 +919,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<ListPartitionCursorsRequest>
-      PARSER = new com.google.protobuf.AbstractParser<ListPartitionCursorsRequest>() {
-    @java.lang.Override
-    public ListPartitionCursorsRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new ListPartitionCursorsRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<ListPartitionCursorsRequest> PARSER =
+      new com.google.protobuf.AbstractParser<ListPartitionCursorsRequest>() {
+        @java.lang.Override
+        public ListPartitionCursorsRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new ListPartitionCursorsRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<ListPartitionCursorsRequest> parser() {
     return PARSER;
@@ -871,6 +943,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.ListPartitionCursorsRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListPartitionCursorsRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListPartitionCursorsRequestOrBuilder.java
@@ -3,35 +3,47 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface ListPartitionCursorsRequestOrBuilder extends
+public interface ListPartitionCursorsRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.ListPartitionCursorsRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The subscription for which to retrieve cursors.
    * Structured like
    * `projects/{project_number}/locations/{location}/subscriptions/{subscription_id}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The parent.
    */
   java.lang.String getParent();
   /**
+   *
+   *
    * <pre>
    * The subscription for which to retrieve cursors.
    * Structured like
    * `projects/{project_number}/locations/{location}/subscriptions/{subscription_id}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for parent.
    */
-  com.google.protobuf.ByteString
-      getParentBytes();
+  com.google.protobuf.ByteString getParentBytes();
 
   /**
+   *
+   *
    * <pre>
    * The maximum number of cursors to return. The service may return fewer than
    * this value.
@@ -39,11 +51,14 @@ public interface ListPartitionCursorsRequestOrBuilder extends
    * </pre>
    *
    * <code>int32 page_size = 2;</code>
+   *
    * @return The pageSize.
    */
   int getPageSize();
 
   /**
+   *
+   *
    * <pre>
    * A page token, received from a previous `ListPartitionCursors` call.
    * Provide this to retrieve the subsequent page.
@@ -52,10 +67,13 @@ public interface ListPartitionCursorsRequestOrBuilder extends
    * </pre>
    *
    * <code>string page_token = 3;</code>
+   *
    * @return The pageToken.
    */
   java.lang.String getPageToken();
   /**
+   *
+   *
    * <pre>
    * A page token, received from a previous `ListPartitionCursors` call.
    * Provide this to retrieve the subsequent page.
@@ -64,8 +82,8 @@ public interface ListPartitionCursorsRequestOrBuilder extends
    * </pre>
    *
    * <code>string page_token = 3;</code>
+   *
    * @return The bytes for pageToken.
    */
-  com.google.protobuf.ByteString
-      getPageTokenBytes();
+  com.google.protobuf.ByteString getPageTokenBytes();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListPartitionCursorsResponse.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListPartitionCursorsResponse.java
@@ -4,21 +4,24 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Response for ListPartitionCursors
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.ListPartitionCursorsResponse}
  */
-public  final class ListPartitionCursorsResponse extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class ListPartitionCursorsResponse extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.ListPartitionCursorsResponse)
     ListPartitionCursorsResponseOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use ListPartitionCursorsResponse.newBuilder() to construct.
   private ListPartitionCursorsResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private ListPartitionCursorsResponse() {
     partitionCursors_ = java.util.Collections.emptyList();
     nextPageToken_ = "";
@@ -26,16 +29,15 @@ private static final long serialVersionUID = 0L;
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new ListPartitionCursorsResponse();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private ListPartitionCursorsResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -55,35 +57,39 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-              partitionCursors_ = new java.util.ArrayList<com.google.cloud.pubsublite.proto.PartitionCursor>();
-              mutable_bitField0_ |= 0x00000001;
+          case 10:
+            {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                partitionCursors_ =
+                    new java.util.ArrayList<com.google.cloud.pubsublite.proto.PartitionCursor>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              partitionCursors_.add(
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.PartitionCursor.parser(),
+                      extensionRegistry));
+              break;
             }
-            partitionCursors_.add(
-                input.readMessage(com.google.cloud.pubsublite.proto.PartitionCursor.parser(), extensionRegistry));
-            break;
-          }
-          case 18: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 18:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            nextPageToken_ = s;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              nextPageToken_ = s;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       if (((mutable_bitField0_ & 0x00000001) != 0)) {
         partitionCursors_ = java.util.Collections.unmodifiableList(partitionCursors_);
@@ -92,43 +98,53 @@ private static final long serialVersionUID = 0L;
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse.class, com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse.Builder.class);
+            com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse.class,
+            com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse.Builder.class);
   }
 
   public static final int PARTITION_CURSORS_FIELD_NUMBER = 1;
   private java.util.List<com.google.cloud.pubsublite.proto.PartitionCursor> partitionCursors_;
   /**
+   *
+   *
    * <pre>
    * The partition cursors from this request.
    * </pre>
    *
    * <code>repeated .google.cloud.pubsublite.v1.PartitionCursor partition_cursors = 1;</code>
    */
-  public java.util.List<com.google.cloud.pubsublite.proto.PartitionCursor> getPartitionCursorsList() {
+  public java.util.List<com.google.cloud.pubsublite.proto.PartitionCursor>
+      getPartitionCursorsList() {
     return partitionCursors_;
   }
   /**
+   *
+   *
    * <pre>
    * The partition cursors from this request.
    * </pre>
    *
    * <code>repeated .google.cloud.pubsublite.v1.PartitionCursor partition_cursors = 1;</code>
    */
-  public java.util.List<? extends com.google.cloud.pubsublite.proto.PartitionCursorOrBuilder> 
+  public java.util.List<? extends com.google.cloud.pubsublite.proto.PartitionCursorOrBuilder>
       getPartitionCursorsOrBuilderList() {
     return partitionCursors_;
   }
   /**
+   *
+   *
    * <pre>
    * The partition cursors from this request.
    * </pre>
@@ -139,6 +155,8 @@ private static final long serialVersionUID = 0L;
     return partitionCursors_.size();
   }
   /**
+   *
+   *
    * <pre>
    * The partition cursors from this request.
    * </pre>
@@ -149,6 +167,8 @@ private static final long serialVersionUID = 0L;
     return partitionCursors_.get(index);
   }
   /**
+   *
+   *
    * <pre>
    * The partition cursors from this request.
    * </pre>
@@ -163,12 +183,15 @@ private static final long serialVersionUID = 0L;
   public static final int NEXT_PAGE_TOKEN_FIELD_NUMBER = 2;
   private volatile java.lang.Object nextPageToken_;
   /**
+   *
+   *
    * <pre>
    * A token, which can be sent as `page_token` to retrieve the next page.
    * If this field is omitted, there are no subsequent pages.
    * </pre>
    *
    * <code>string next_page_token = 2;</code>
+   *
    * @return The nextPageToken.
    */
   public java.lang.String getNextPageToken() {
@@ -176,29 +199,29 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       nextPageToken_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * A token, which can be sent as `page_token` to retrieve the next page.
    * If this field is omitted, there are no subsequent pages.
    * </pre>
    *
    * <code>string next_page_token = 2;</code>
+   *
    * @return The bytes for nextPageToken.
    */
-  public com.google.protobuf.ByteString
-      getNextPageTokenBytes() {
+  public com.google.protobuf.ByteString getNextPageTokenBytes() {
     java.lang.Object ref = nextPageToken_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       nextPageToken_ = b;
       return b;
     } else {
@@ -207,6 +230,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -218,8 +242,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     for (int i = 0; i < partitionCursors_.size(); i++) {
       output.writeMessage(1, partitionCursors_.get(i));
     }
@@ -236,8 +259,7 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     for (int i = 0; i < partitionCursors_.size(); i++) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, partitionCursors_.get(i));
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(1, partitionCursors_.get(i));
     }
     if (!getNextPageTokenBytes().isEmpty()) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, nextPageToken_);
@@ -250,17 +272,16 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse other = (com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse) obj;
+    com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse other =
+        (com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse) obj;
 
-    if (!getPartitionCursorsList()
-        .equals(other.getPartitionCursorsList())) return false;
-    if (!getNextPageToken()
-        .equals(other.getNextPageToken())) return false;
+    if (!getPartitionCursorsList().equals(other.getPartitionCursorsList())) return false;
+    if (!getNextPageToken().equals(other.getNextPageToken())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -284,117 +305,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse parseFrom(byte[] data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+
+  public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse parseFrom(
+      byte[] data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Response for ListPartitionCursors
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.ListPartitionCursorsResponse}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.ListPartitionCursorsResponse)
       com.google.cloud.pubsublite.proto.ListPartitionCursorsResponseOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse.class, com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse.Builder.class);
+              com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse.class,
+              com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse.newBuilder()
@@ -402,17 +433,17 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {
         getPartitionCursorsFieldBuilder();
       }
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -428,13 +459,14 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_ListPartitionCursorsResponse_descriptor;
     }
 
     @java.lang.Override
-    public com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse getDefaultInstanceForType() {
+    public com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse
+        getDefaultInstanceForType() {
       return com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse.getDefaultInstance();
     }
 
@@ -449,7 +481,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse buildPartial() {
-      com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse result = new com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse(this);
+      com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse result =
+          new com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse(this);
       int from_bitField0_ = bitField0_;
       if (partitionCursorsBuilder_ == null) {
         if (((bitField0_ & 0x00000001) != 0)) {
@@ -469,38 +502,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -508,7 +542,9 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse other) {
-      if (other == com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse.getDefaultInstance()) return this;
+      if (other
+          == com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse.getDefaultInstance())
+        return this;
       if (partitionCursorsBuilder_ == null) {
         if (!other.partitionCursors_.isEmpty()) {
           if (partitionCursors_.isEmpty()) {
@@ -527,9 +563,10 @@ private static final long serialVersionUID = 0L;
             partitionCursorsBuilder_ = null;
             partitionCursors_ = other.partitionCursors_;
             bitField0_ = (bitField0_ & ~0x00000001);
-            partitionCursorsBuilder_ = 
-              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
-                 getPartitionCursorsFieldBuilder() : null;
+            partitionCursorsBuilder_ =
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders
+                    ? getPartitionCursorsFieldBuilder()
+                    : null;
           } else {
             partitionCursorsBuilder_.addAllMessages(other.partitionCursors_);
           }
@@ -558,7 +595,9 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse)
+                e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -567,28 +606,38 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     private int bitField0_;
 
     private java.util.List<com.google.cloud.pubsublite.proto.PartitionCursor> partitionCursors_ =
-      java.util.Collections.emptyList();
+        java.util.Collections.emptyList();
+
     private void ensurePartitionCursorsIsMutable() {
       if (!((bitField0_ & 0x00000001) != 0)) {
-        partitionCursors_ = new java.util.ArrayList<com.google.cloud.pubsublite.proto.PartitionCursor>(partitionCursors_);
+        partitionCursors_ =
+            new java.util.ArrayList<com.google.cloud.pubsublite.proto.PartitionCursor>(
+                partitionCursors_);
         bitField0_ |= 0x00000001;
-       }
+      }
     }
 
     private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.PartitionCursor, com.google.cloud.pubsublite.proto.PartitionCursor.Builder, com.google.cloud.pubsublite.proto.PartitionCursorOrBuilder> partitionCursorsBuilder_;
+            com.google.cloud.pubsublite.proto.PartitionCursor,
+            com.google.cloud.pubsublite.proto.PartitionCursor.Builder,
+            com.google.cloud.pubsublite.proto.PartitionCursorOrBuilder>
+        partitionCursorsBuilder_;
 
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
      *
      * <code>repeated .google.cloud.pubsublite.v1.PartitionCursor partition_cursors = 1;</code>
      */
-    public java.util.List<com.google.cloud.pubsublite.proto.PartitionCursor> getPartitionCursorsList() {
+    public java.util.List<com.google.cloud.pubsublite.proto.PartitionCursor>
+        getPartitionCursorsList() {
       if (partitionCursorsBuilder_ == null) {
         return java.util.Collections.unmodifiableList(partitionCursors_);
       } else {
@@ -596,6 +645,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
@@ -610,6 +661,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
@@ -624,6 +677,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
@@ -645,6 +700,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
@@ -663,6 +720,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
@@ -683,6 +742,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
@@ -704,6 +765,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
@@ -722,6 +785,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
@@ -740,6 +805,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
@@ -750,8 +817,7 @@ private static final long serialVersionUID = 0L;
         java.lang.Iterable<? extends com.google.cloud.pubsublite.proto.PartitionCursor> values) {
       if (partitionCursorsBuilder_ == null) {
         ensurePartitionCursorsIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, partitionCursors_);
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(values, partitionCursors_);
         onChanged();
       } else {
         partitionCursorsBuilder_.addAllMessages(values);
@@ -759,6 +825,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
@@ -776,6 +844,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
@@ -793,6 +863,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
@@ -804,6 +876,8 @@ private static final long serialVersionUID = 0L;
       return getPartitionCursorsFieldBuilder().getBuilder(index);
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
@@ -813,19 +887,22 @@ private static final long serialVersionUID = 0L;
     public com.google.cloud.pubsublite.proto.PartitionCursorOrBuilder getPartitionCursorsOrBuilder(
         int index) {
       if (partitionCursorsBuilder_ == null) {
-        return partitionCursors_.get(index);  } else {
+        return partitionCursors_.get(index);
+      } else {
         return partitionCursorsBuilder_.getMessageOrBuilder(index);
       }
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
      *
      * <code>repeated .google.cloud.pubsublite.v1.PartitionCursor partition_cursors = 1;</code>
      */
-    public java.util.List<? extends com.google.cloud.pubsublite.proto.PartitionCursorOrBuilder> 
-         getPartitionCursorsOrBuilderList() {
+    public java.util.List<? extends com.google.cloud.pubsublite.proto.PartitionCursorOrBuilder>
+        getPartitionCursorsOrBuilderList() {
       if (partitionCursorsBuilder_ != null) {
         return partitionCursorsBuilder_.getMessageOrBuilderList();
       } else {
@@ -833,6 +910,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
@@ -840,10 +919,12 @@ private static final long serialVersionUID = 0L;
      * <code>repeated .google.cloud.pubsublite.v1.PartitionCursor partition_cursors = 1;</code>
      */
     public com.google.cloud.pubsublite.proto.PartitionCursor.Builder addPartitionCursorsBuilder() {
-      return getPartitionCursorsFieldBuilder().addBuilder(
-          com.google.cloud.pubsublite.proto.PartitionCursor.getDefaultInstance());
+      return getPartitionCursorsFieldBuilder()
+          .addBuilder(com.google.cloud.pubsublite.proto.PartitionCursor.getDefaultInstance());
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
@@ -852,26 +933,35 @@ private static final long serialVersionUID = 0L;
      */
     public com.google.cloud.pubsublite.proto.PartitionCursor.Builder addPartitionCursorsBuilder(
         int index) {
-      return getPartitionCursorsFieldBuilder().addBuilder(
-          index, com.google.cloud.pubsublite.proto.PartitionCursor.getDefaultInstance());
+      return getPartitionCursorsFieldBuilder()
+          .addBuilder(
+              index, com.google.cloud.pubsublite.proto.PartitionCursor.getDefaultInstance());
     }
     /**
+     *
+     *
      * <pre>
      * The partition cursors from this request.
      * </pre>
      *
      * <code>repeated .google.cloud.pubsublite.v1.PartitionCursor partition_cursors = 1;</code>
      */
-    public java.util.List<com.google.cloud.pubsublite.proto.PartitionCursor.Builder> 
-         getPartitionCursorsBuilderList() {
+    public java.util.List<com.google.cloud.pubsublite.proto.PartitionCursor.Builder>
+        getPartitionCursorsBuilderList() {
       return getPartitionCursorsFieldBuilder().getBuilderList();
     }
+
     private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.PartitionCursor, com.google.cloud.pubsublite.proto.PartitionCursor.Builder, com.google.cloud.pubsublite.proto.PartitionCursorOrBuilder> 
+            com.google.cloud.pubsublite.proto.PartitionCursor,
+            com.google.cloud.pubsublite.proto.PartitionCursor.Builder,
+            com.google.cloud.pubsublite.proto.PartitionCursorOrBuilder>
         getPartitionCursorsFieldBuilder() {
       if (partitionCursorsBuilder_ == null) {
-        partitionCursorsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.PartitionCursor, com.google.cloud.pubsublite.proto.PartitionCursor.Builder, com.google.cloud.pubsublite.proto.PartitionCursorOrBuilder>(
+        partitionCursorsBuilder_ =
+            new com.google.protobuf.RepeatedFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.PartitionCursor,
+                com.google.cloud.pubsublite.proto.PartitionCursor.Builder,
+                com.google.cloud.pubsublite.proto.PartitionCursorOrBuilder>(
                 partitionCursors_,
                 ((bitField0_ & 0x00000001) != 0),
                 getParentForChildren(),
@@ -883,19 +973,21 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object nextPageToken_ = "";
     /**
+     *
+     *
      * <pre>
      * A token, which can be sent as `page_token` to retrieve the next page.
      * If this field is omitted, there are no subsequent pages.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @return The nextPageToken.
      */
     public java.lang.String getNextPageToken() {
       java.lang.Object ref = nextPageToken_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         nextPageToken_ = s;
         return s;
@@ -904,21 +996,22 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A token, which can be sent as `page_token` to retrieve the next page.
      * If this field is omitted, there are no subsequent pages.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @return The bytes for nextPageToken.
      */
-    public com.google.protobuf.ByteString
-        getNextPageTokenBytes() {
+    public com.google.protobuf.ByteString getNextPageTokenBytes() {
       java.lang.Object ref = nextPageToken_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         nextPageToken_ = b;
         return b;
       } else {
@@ -926,64 +1019,71 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A token, which can be sent as `page_token` to retrieve the next page.
      * If this field is omitted, there are no subsequent pages.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @param value The nextPageToken to set.
      * @return This builder for chaining.
      */
-    public Builder setNextPageToken(
-        java.lang.String value) {
+    public Builder setNextPageToken(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       nextPageToken_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A token, which can be sent as `page_token` to retrieve the next page.
      * If this field is omitted, there are no subsequent pages.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearNextPageToken() {
-      
+
       nextPageToken_ = getDefaultInstance().getNextPageToken();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A token, which can be sent as `page_token` to retrieve the next page.
      * If this field is omitted, there are no subsequent pages.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @param value The bytes for nextPageToken to set.
      * @return This builder for chaining.
      */
-    public Builder setNextPageTokenBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setNextPageTokenBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       nextPageToken_ = value;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -993,30 +1093,32 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.ListPartitionCursorsResponse)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.ListPartitionCursorsResponse)
-  private static final com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse DEFAULT_INSTANCE;
+  private static final com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse
+      DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse();
   }
 
-  public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse getDefaultInstance() {
+  public static com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse
+      getDefaultInstance() {
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<ListPartitionCursorsResponse>
-      PARSER = new com.google.protobuf.AbstractParser<ListPartitionCursorsResponse>() {
-    @java.lang.Override
-    public ListPartitionCursorsResponse parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new ListPartitionCursorsResponse(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<ListPartitionCursorsResponse> PARSER =
+      new com.google.protobuf.AbstractParser<ListPartitionCursorsResponse>() {
+        @java.lang.Override
+        public ListPartitionCursorsResponse parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new ListPartitionCursorsResponse(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<ListPartitionCursorsResponse> parser() {
     return PARSER;
@@ -1028,9 +1130,8 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse getDefaultInstanceForType() {
+  public com.google.cloud.pubsublite.proto.ListPartitionCursorsResponse
+      getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListPartitionCursorsResponseOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListPartitionCursorsResponseOrBuilder.java
@@ -3,20 +3,24 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface ListPartitionCursorsResponseOrBuilder extends
+public interface ListPartitionCursorsResponseOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.ListPartitionCursorsResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The partition cursors from this request.
    * </pre>
    *
    * <code>repeated .google.cloud.pubsublite.v1.PartitionCursor partition_cursors = 1;</code>
    */
-  java.util.List<com.google.cloud.pubsublite.proto.PartitionCursor> 
-      getPartitionCursorsList();
+  java.util.List<com.google.cloud.pubsublite.proto.PartitionCursor> getPartitionCursorsList();
   /**
+   *
+   *
    * <pre>
    * The partition cursors from this request.
    * </pre>
@@ -25,6 +29,8 @@ public interface ListPartitionCursorsResponseOrBuilder extends
    */
   com.google.cloud.pubsublite.proto.PartitionCursor getPartitionCursors(int index);
   /**
+   *
+   *
    * <pre>
    * The partition cursors from this request.
    * </pre>
@@ -33,15 +39,19 @@ public interface ListPartitionCursorsResponseOrBuilder extends
    */
   int getPartitionCursorsCount();
   /**
+   *
+   *
    * <pre>
    * The partition cursors from this request.
    * </pre>
    *
    * <code>repeated .google.cloud.pubsublite.v1.PartitionCursor partition_cursors = 1;</code>
    */
-  java.util.List<? extends com.google.cloud.pubsublite.proto.PartitionCursorOrBuilder> 
+  java.util.List<? extends com.google.cloud.pubsublite.proto.PartitionCursorOrBuilder>
       getPartitionCursorsOrBuilderList();
   /**
+   *
+   *
    * <pre>
    * The partition cursors from this request.
    * </pre>
@@ -52,24 +62,29 @@ public interface ListPartitionCursorsResponseOrBuilder extends
       int index);
 
   /**
+   *
+   *
    * <pre>
    * A token, which can be sent as `page_token` to retrieve the next page.
    * If this field is omitted, there are no subsequent pages.
    * </pre>
    *
    * <code>string next_page_token = 2;</code>
+   *
    * @return The nextPageToken.
    */
   java.lang.String getNextPageToken();
   /**
+   *
+   *
    * <pre>
    * A token, which can be sent as `page_token` to retrieve the next page.
    * If this field is omitted, there are no subsequent pages.
    * </pre>
    *
    * <code>string next_page_token = 2;</code>
+   *
    * @return The bytes for nextPageToken.
    */
-  com.google.protobuf.ByteString
-      getNextPageTokenBytes();
+  com.google.protobuf.ByteString getNextPageTokenBytes();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListSubscriptionsRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListSubscriptionsRequest.java
@@ -4,21 +4,24 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request for ListSubscriptions.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.ListSubscriptionsRequest}
  */
-public  final class ListSubscriptionsRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class ListSubscriptionsRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.ListSubscriptionsRequest)
     ListSubscriptionsRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use ListSubscriptionsRequest.newBuilder() to construct.
   private ListSubscriptionsRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private ListSubscriptionsRequest() {
     parent_ = "";
     pageToken_ = "";
@@ -26,16 +29,15 @@ private static final long serialVersionUID = 0L;
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new ListSubscriptionsRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private ListSubscriptionsRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -54,64 +56,73 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            parent_ = s;
-            break;
-          }
-          case 16: {
-
-            pageSize_ = input.readInt32();
-            break;
-          }
-          case 26: {
-            java.lang.String s = input.readStringRequireUtf8();
-
-            pageToken_ = s;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              parent_ = s;
+              break;
             }
-            break;
-          }
+          case 16:
+            {
+              pageSize_ = input.readInt32();
+              break;
+            }
+          case 26:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              pageToken_ = s;
+              break;
+            }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.ListSubscriptionsRequest.class, com.google.cloud.pubsublite.proto.ListSubscriptionsRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.ListSubscriptionsRequest.class,
+            com.google.cloud.pubsublite.proto.ListSubscriptionsRequest.Builder.class);
   }
 
   public static final int PARENT_FIELD_NUMBER = 1;
   private volatile java.lang.Object parent_;
   /**
+   *
+   *
    * <pre>
    * The parent whose subscriptions are to be listed.
    * Structured like `projects/{project_number}/locations/{location}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The parent.
    */
   public java.lang.String getParent() {
@@ -119,29 +130,31 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       parent_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The parent whose subscriptions are to be listed.
    * Structured like `projects/{project_number}/locations/{location}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for parent.
    */
-  public com.google.protobuf.ByteString
-      getParentBytes() {
+  public com.google.protobuf.ByteString getParentBytes() {
     java.lang.Object ref = parent_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       parent_ = b;
       return b;
     } else {
@@ -152,6 +165,8 @@ private static final long serialVersionUID = 0L;
   public static final int PAGE_SIZE_FIELD_NUMBER = 2;
   private int pageSize_;
   /**
+   *
+   *
    * <pre>
    * The maximum number of subscriptions to return. The service may return fewer
    * than this value.
@@ -159,6 +174,7 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>int32 page_size = 2;</code>
+   *
    * @return The pageSize.
    */
   public int getPageSize() {
@@ -168,6 +184,8 @@ private static final long serialVersionUID = 0L;
   public static final int PAGE_TOKEN_FIELD_NUMBER = 3;
   private volatile java.lang.Object pageToken_;
   /**
+   *
+   *
    * <pre>
    * A page token, received from a previous `ListSubscriptions` call.
    * Provide this to retrieve the subsequent page.
@@ -176,6 +194,7 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string page_token = 3;</code>
+   *
    * @return The pageToken.
    */
   public java.lang.String getPageToken() {
@@ -183,14 +202,15 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       pageToken_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * A page token, received from a previous `ListSubscriptions` call.
    * Provide this to retrieve the subsequent page.
@@ -199,15 +219,14 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string page_token = 3;</code>
+   *
    * @return The bytes for pageToken.
    */
-  public com.google.protobuf.ByteString
-      getPageTokenBytes() {
+  public com.google.protobuf.ByteString getPageTokenBytes() {
     java.lang.Object ref = pageToken_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       pageToken_ = b;
       return b;
     } else {
@@ -216,6 +235,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -227,8 +247,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getParentBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, parent_);
     }
@@ -251,8 +270,7 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, parent_);
     }
     if (pageSize_ != 0) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeInt32Size(2, pageSize_);
+      size += com.google.protobuf.CodedOutputStream.computeInt32Size(2, pageSize_);
     }
     if (!getPageTokenBytes().isEmpty()) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, pageToken_);
@@ -265,19 +283,17 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.ListSubscriptionsRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.ListSubscriptionsRequest other = (com.google.cloud.pubsublite.proto.ListSubscriptionsRequest) obj;
+    com.google.cloud.pubsublite.proto.ListSubscriptionsRequest other =
+        (com.google.cloud.pubsublite.proto.ListSubscriptionsRequest) obj;
 
-    if (!getParent()
-        .equals(other.getParent())) return false;
-    if (getPageSize()
-        != other.getPageSize()) return false;
-    if (!getPageToken()
-        .equals(other.getPageToken())) return false;
+    if (!getParent().equals(other.getParent())) return false;
+    if (getPageSize() != other.getPageSize()) return false;
+    if (!getPageToken().equals(other.getPageToken())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -301,117 +317,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.ListSubscriptionsRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.ListSubscriptionsRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.ListSubscriptionsRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.ListSubscriptionsRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.ListSubscriptionsRequest prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.ListSubscriptionsRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request for ListSubscriptions.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.ListSubscriptionsRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.ListSubscriptionsRequest)
       com.google.cloud.pubsublite.proto.ListSubscriptionsRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.ListSubscriptionsRequest.class, com.google.cloud.pubsublite.proto.ListSubscriptionsRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.ListSubscriptionsRequest.class,
+              com.google.cloud.pubsublite.proto.ListSubscriptionsRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.ListSubscriptionsRequest.newBuilder()
@@ -419,16 +445,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -442,9 +467,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListSubscriptionsRequest_descriptor;
     }
 
     @java.lang.Override
@@ -463,7 +488,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.ListSubscriptionsRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.ListSubscriptionsRequest result = new com.google.cloud.pubsublite.proto.ListSubscriptionsRequest(this);
+      com.google.cloud.pubsublite.proto.ListSubscriptionsRequest result =
+          new com.google.cloud.pubsublite.proto.ListSubscriptionsRequest(this);
       result.parent_ = parent_;
       result.pageSize_ = pageSize_;
       result.pageToken_ = pageToken_;
@@ -475,38 +501,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.ListSubscriptionsRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.ListSubscriptionsRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.ListSubscriptionsRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -514,7 +541,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.ListSubscriptionsRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.ListSubscriptionsRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.ListSubscriptionsRequest.getDefaultInstance())
+        return this;
       if (!other.getParent().isEmpty()) {
         parent_ = other.parent_;
         onChanged();
@@ -545,7 +573,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.ListSubscriptionsRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.ListSubscriptionsRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -557,19 +586,23 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object parent_ = "";
     /**
+     *
+     *
      * <pre>
      * The parent whose subscriptions are to be listed.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The parent.
      */
     public java.lang.String getParent() {
       java.lang.Object ref = parent_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         parent_ = s;
         return s;
@@ -578,21 +611,24 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The parent whose subscriptions are to be listed.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The bytes for parent.
      */
-    public com.google.protobuf.ByteString
-        getParentBytes() {
+    public com.google.protobuf.ByteString getParentBytes() {
       java.lang.Object ref = parent_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         parent_ = b;
         return b;
       } else {
@@ -600,64 +636,79 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The parent whose subscriptions are to be listed.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The parent to set.
      * @return This builder for chaining.
      */
-    public Builder setParent(
-        java.lang.String value) {
+    public Builder setParent(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       parent_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The parent whose subscriptions are to be listed.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearParent() {
-      
+
       parent_ = getDefaultInstance().getParent();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The parent whose subscriptions are to be listed.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The bytes for parent to set.
      * @return This builder for chaining.
      */
-    public Builder setParentBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setParentBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       parent_ = value;
       onChanged();
       return this;
     }
 
-    private int pageSize_ ;
+    private int pageSize_;
     /**
+     *
+     *
      * <pre>
      * The maximum number of subscriptions to return. The service may return fewer
      * than this value.
@@ -665,12 +716,15 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int32 page_size = 2;</code>
+     *
      * @return The pageSize.
      */
     public int getPageSize() {
       return pageSize_;
     }
     /**
+     *
+     *
      * <pre>
      * The maximum number of subscriptions to return. The service may return fewer
      * than this value.
@@ -678,16 +732,19 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int32 page_size = 2;</code>
+     *
      * @param value The pageSize to set.
      * @return This builder for chaining.
      */
     public Builder setPageSize(int value) {
-      
+
       pageSize_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The maximum number of subscriptions to return. The service may return fewer
      * than this value.
@@ -695,10 +752,11 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int32 page_size = 2;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearPageSize() {
-      
+
       pageSize_ = 0;
       onChanged();
       return this;
@@ -706,6 +764,8 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object pageToken_ = "";
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListSubscriptions` call.
      * Provide this to retrieve the subsequent page.
@@ -714,13 +774,13 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @return The pageToken.
      */
     public java.lang.String getPageToken() {
       java.lang.Object ref = pageToken_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         pageToken_ = s;
         return s;
@@ -729,6 +789,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListSubscriptions` call.
      * Provide this to retrieve the subsequent page.
@@ -737,15 +799,14 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @return The bytes for pageToken.
      */
-    public com.google.protobuf.ByteString
-        getPageTokenBytes() {
+    public com.google.protobuf.ByteString getPageTokenBytes() {
       java.lang.Object ref = pageToken_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         pageToken_ = b;
         return b;
       } else {
@@ -753,6 +814,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListSubscriptions` call.
      * Provide this to retrieve the subsequent page.
@@ -761,20 +824,22 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @param value The pageToken to set.
      * @return This builder for chaining.
      */
-    public Builder setPageToken(
-        java.lang.String value) {
+    public Builder setPageToken(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       pageToken_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListSubscriptions` call.
      * Provide this to retrieve the subsequent page.
@@ -783,15 +848,18 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearPageToken() {
-      
+
       pageToken_ = getDefaultInstance().getPageToken();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListSubscriptions` call.
      * Provide this to retrieve the subsequent page.
@@ -800,23 +868,23 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @param value The bytes for pageToken to set.
      * @return This builder for chaining.
      */
-    public Builder setPageTokenBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setPageTokenBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       pageToken_ = value;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -826,12 +894,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.ListSubscriptionsRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.ListSubscriptionsRequest)
   private static final com.google.cloud.pubsublite.proto.ListSubscriptionsRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.ListSubscriptionsRequest();
   }
@@ -840,16 +908,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<ListSubscriptionsRequest>
-      PARSER = new com.google.protobuf.AbstractParser<ListSubscriptionsRequest>() {
-    @java.lang.Override
-    public ListSubscriptionsRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new ListSubscriptionsRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<ListSubscriptionsRequest> PARSER =
+      new com.google.protobuf.AbstractParser<ListSubscriptionsRequest>() {
+        @java.lang.Override
+        public ListSubscriptionsRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new ListSubscriptionsRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<ListSubscriptionsRequest> parser() {
     return PARSER;
@@ -864,6 +932,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.ListSubscriptionsRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListSubscriptionsRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListSubscriptionsRequestOrBuilder.java
@@ -3,33 +3,45 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface ListSubscriptionsRequestOrBuilder extends
+public interface ListSubscriptionsRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.ListSubscriptionsRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The parent whose subscriptions are to be listed.
    * Structured like `projects/{project_number}/locations/{location}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The parent.
    */
   java.lang.String getParent();
   /**
+   *
+   *
    * <pre>
    * The parent whose subscriptions are to be listed.
    * Structured like `projects/{project_number}/locations/{location}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for parent.
    */
-  com.google.protobuf.ByteString
-      getParentBytes();
+  com.google.protobuf.ByteString getParentBytes();
 
   /**
+   *
+   *
    * <pre>
    * The maximum number of subscriptions to return. The service may return fewer
    * than this value.
@@ -37,11 +49,14 @@ public interface ListSubscriptionsRequestOrBuilder extends
    * </pre>
    *
    * <code>int32 page_size = 2;</code>
+   *
    * @return The pageSize.
    */
   int getPageSize();
 
   /**
+   *
+   *
    * <pre>
    * A page token, received from a previous `ListSubscriptions` call.
    * Provide this to retrieve the subsequent page.
@@ -50,10 +65,13 @@ public interface ListSubscriptionsRequestOrBuilder extends
    * </pre>
    *
    * <code>string page_token = 3;</code>
+   *
    * @return The pageToken.
    */
   java.lang.String getPageToken();
   /**
+   *
+   *
    * <pre>
    * A page token, received from a previous `ListSubscriptions` call.
    * Provide this to retrieve the subsequent page.
@@ -62,8 +80,8 @@ public interface ListSubscriptionsRequestOrBuilder extends
    * </pre>
    *
    * <code>string page_token = 3;</code>
+   *
    * @return The bytes for pageToken.
    */
-  com.google.protobuf.ByteString
-      getPageTokenBytes();
+  com.google.protobuf.ByteString getPageTokenBytes();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListSubscriptionsResponse.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListSubscriptionsResponse.java
@@ -4,21 +4,24 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Response for ListSubscriptions.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.ListSubscriptionsResponse}
  */
-public  final class ListSubscriptionsResponse extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class ListSubscriptionsResponse extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.ListSubscriptionsResponse)
     ListSubscriptionsResponseOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use ListSubscriptionsResponse.newBuilder() to construct.
   private ListSubscriptionsResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private ListSubscriptionsResponse() {
     subscriptions_ = java.util.Collections.emptyList();
     nextPageToken_ = "";
@@ -26,16 +29,15 @@ private static final long serialVersionUID = 0L;
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new ListSubscriptionsResponse();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private ListSubscriptionsResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -55,35 +57,38 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-              subscriptions_ = new java.util.ArrayList<com.google.cloud.pubsublite.proto.Subscription>();
-              mutable_bitField0_ |= 0x00000001;
+          case 10:
+            {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                subscriptions_ =
+                    new java.util.ArrayList<com.google.cloud.pubsublite.proto.Subscription>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              subscriptions_.add(
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Subscription.parser(), extensionRegistry));
+              break;
             }
-            subscriptions_.add(
-                input.readMessage(com.google.cloud.pubsublite.proto.Subscription.parser(), extensionRegistry));
-            break;
-          }
-          case 18: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 18:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            nextPageToken_ = s;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              nextPageToken_ = s;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       if (((mutable_bitField0_ & 0x00000001) != 0)) {
         subscriptions_ = java.util.Collections.unmodifiableList(subscriptions_);
@@ -92,22 +97,27 @@ private static final long serialVersionUID = 0L;
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.ListSubscriptionsResponse.class, com.google.cloud.pubsublite.proto.ListSubscriptionsResponse.Builder.class);
+            com.google.cloud.pubsublite.proto.ListSubscriptionsResponse.class,
+            com.google.cloud.pubsublite.proto.ListSubscriptionsResponse.Builder.class);
   }
 
   public static final int SUBSCRIPTIONS_FIELD_NUMBER = 1;
   private java.util.List<com.google.cloud.pubsublite.proto.Subscription> subscriptions_;
   /**
+   *
+   *
    * <pre>
    * The list of subscriptions in the requested parent. The order of the
    * subscriptions is unspecified.
@@ -119,6 +129,8 @@ private static final long serialVersionUID = 0L;
     return subscriptions_;
   }
   /**
+   *
+   *
    * <pre>
    * The list of subscriptions in the requested parent. The order of the
    * subscriptions is unspecified.
@@ -126,11 +138,13 @@ private static final long serialVersionUID = 0L;
    *
    * <code>repeated .google.cloud.pubsublite.v1.Subscription subscriptions = 1;</code>
    */
-  public java.util.List<? extends com.google.cloud.pubsublite.proto.SubscriptionOrBuilder> 
+  public java.util.List<? extends com.google.cloud.pubsublite.proto.SubscriptionOrBuilder>
       getSubscriptionsOrBuilderList() {
     return subscriptions_;
   }
   /**
+   *
+   *
    * <pre>
    * The list of subscriptions in the requested parent. The order of the
    * subscriptions is unspecified.
@@ -142,6 +156,8 @@ private static final long serialVersionUID = 0L;
     return subscriptions_.size();
   }
   /**
+   *
+   *
    * <pre>
    * The list of subscriptions in the requested parent. The order of the
    * subscriptions is unspecified.
@@ -153,6 +169,8 @@ private static final long serialVersionUID = 0L;
     return subscriptions_.get(index);
   }
   /**
+   *
+   *
    * <pre>
    * The list of subscriptions in the requested parent. The order of the
    * subscriptions is unspecified.
@@ -168,12 +186,15 @@ private static final long serialVersionUID = 0L;
   public static final int NEXT_PAGE_TOKEN_FIELD_NUMBER = 2;
   private volatile java.lang.Object nextPageToken_;
   /**
+   *
+   *
    * <pre>
    * A token that can be sent as `page_token` to retrieve the next page of
    * results. If this field is omitted, there are no more results.
    * </pre>
    *
    * <code>string next_page_token = 2;</code>
+   *
    * @return The nextPageToken.
    */
   public java.lang.String getNextPageToken() {
@@ -181,29 +202,29 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       nextPageToken_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * A token that can be sent as `page_token` to retrieve the next page of
    * results. If this field is omitted, there are no more results.
    * </pre>
    *
    * <code>string next_page_token = 2;</code>
+   *
    * @return The bytes for nextPageToken.
    */
-  public com.google.protobuf.ByteString
-      getNextPageTokenBytes() {
+  public com.google.protobuf.ByteString getNextPageTokenBytes() {
     java.lang.Object ref = nextPageToken_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       nextPageToken_ = b;
       return b;
     } else {
@@ -212,6 +233,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -223,8 +245,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     for (int i = 0; i < subscriptions_.size(); i++) {
       output.writeMessage(1, subscriptions_.get(i));
     }
@@ -241,8 +262,7 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     for (int i = 0; i < subscriptions_.size(); i++) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, subscriptions_.get(i));
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(1, subscriptions_.get(i));
     }
     if (!getNextPageTokenBytes().isEmpty()) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, nextPageToken_);
@@ -255,17 +275,16 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.ListSubscriptionsResponse)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.ListSubscriptionsResponse other = (com.google.cloud.pubsublite.proto.ListSubscriptionsResponse) obj;
+    com.google.cloud.pubsublite.proto.ListSubscriptionsResponse other =
+        (com.google.cloud.pubsublite.proto.ListSubscriptionsResponse) obj;
 
-    if (!getSubscriptionsList()
-        .equals(other.getSubscriptionsList())) return false;
-    if (!getNextPageToken()
-        .equals(other.getNextPageToken())) return false;
+    if (!getSubscriptionsList().equals(other.getSubscriptionsList())) return false;
+    if (!getNextPageToken().equals(other.getNextPageToken())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -289,117 +308,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsResponse parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsResponse parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsResponse parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsResponse parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsResponse parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.ListSubscriptionsResponse parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsResponse parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.ListSubscriptionsResponse parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.ListSubscriptionsResponse parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsResponse parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.ListSubscriptionsResponse parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsResponse parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.ListSubscriptionsResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.ListSubscriptionsResponse prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.ListSubscriptionsResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Response for ListSubscriptions.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.ListSubscriptionsResponse}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.ListSubscriptionsResponse)
       com.google.cloud.pubsublite.proto.ListSubscriptionsResponseOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.ListSubscriptionsResponse.class, com.google.cloud.pubsublite.proto.ListSubscriptionsResponse.Builder.class);
+              com.google.cloud.pubsublite.proto.ListSubscriptionsResponse.class,
+              com.google.cloud.pubsublite.proto.ListSubscriptionsResponse.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.ListSubscriptionsResponse.newBuilder()
@@ -407,17 +436,17 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {
         getSubscriptionsFieldBuilder();
       }
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -433,9 +462,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListSubscriptionsResponse_descriptor;
     }
 
     @java.lang.Override
@@ -454,7 +483,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.ListSubscriptionsResponse buildPartial() {
-      com.google.cloud.pubsublite.proto.ListSubscriptionsResponse result = new com.google.cloud.pubsublite.proto.ListSubscriptionsResponse(this);
+      com.google.cloud.pubsublite.proto.ListSubscriptionsResponse result =
+          new com.google.cloud.pubsublite.proto.ListSubscriptionsResponse(this);
       int from_bitField0_ = bitField0_;
       if (subscriptionsBuilder_ == null) {
         if (((bitField0_ & 0x00000001) != 0)) {
@@ -474,38 +504,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.ListSubscriptionsResponse) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.ListSubscriptionsResponse)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.ListSubscriptionsResponse) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -513,7 +544,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.ListSubscriptionsResponse other) {
-      if (other == com.google.cloud.pubsublite.proto.ListSubscriptionsResponse.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.ListSubscriptionsResponse.getDefaultInstance())
+        return this;
       if (subscriptionsBuilder_ == null) {
         if (!other.subscriptions_.isEmpty()) {
           if (subscriptions_.isEmpty()) {
@@ -532,9 +564,10 @@ private static final long serialVersionUID = 0L;
             subscriptionsBuilder_ = null;
             subscriptions_ = other.subscriptions_;
             bitField0_ = (bitField0_ & ~0x00000001);
-            subscriptionsBuilder_ = 
-              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
-                 getSubscriptionsFieldBuilder() : null;
+            subscriptionsBuilder_ =
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders
+                    ? getSubscriptionsFieldBuilder()
+                    : null;
           } else {
             subscriptionsBuilder_.addAllMessages(other.subscriptions_);
           }
@@ -563,7 +596,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.ListSubscriptionsResponse) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.ListSubscriptionsResponse) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -572,21 +606,29 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     private int bitField0_;
 
     private java.util.List<com.google.cloud.pubsublite.proto.Subscription> subscriptions_ =
-      java.util.Collections.emptyList();
+        java.util.Collections.emptyList();
+
     private void ensureSubscriptionsIsMutable() {
       if (!((bitField0_ & 0x00000001) != 0)) {
-        subscriptions_ = new java.util.ArrayList<com.google.cloud.pubsublite.proto.Subscription>(subscriptions_);
+        subscriptions_ =
+            new java.util.ArrayList<com.google.cloud.pubsublite.proto.Subscription>(subscriptions_);
         bitField0_ |= 0x00000001;
-       }
+      }
     }
 
     private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Subscription, com.google.cloud.pubsublite.proto.Subscription.Builder, com.google.cloud.pubsublite.proto.SubscriptionOrBuilder> subscriptionsBuilder_;
+            com.google.cloud.pubsublite.proto.Subscription,
+            com.google.cloud.pubsublite.proto.Subscription.Builder,
+            com.google.cloud.pubsublite.proto.SubscriptionOrBuilder>
+        subscriptionsBuilder_;
 
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -602,6 +644,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -617,6 +661,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -632,6 +678,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -654,6 +702,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -673,6 +723,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -694,6 +746,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -716,6 +770,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -735,6 +791,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -754,6 +812,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -765,8 +825,7 @@ private static final long serialVersionUID = 0L;
         java.lang.Iterable<? extends com.google.cloud.pubsublite.proto.Subscription> values) {
       if (subscriptionsBuilder_ == null) {
         ensureSubscriptionsIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, subscriptions_);
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(values, subscriptions_);
         onChanged();
       } else {
         subscriptionsBuilder_.addAllMessages(values);
@@ -774,6 +833,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -792,6 +853,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -810,6 +873,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -822,6 +887,8 @@ private static final long serialVersionUID = 0L;
       return getSubscriptionsFieldBuilder().getBuilder(index);
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -832,11 +899,14 @@ private static final long serialVersionUID = 0L;
     public com.google.cloud.pubsublite.proto.SubscriptionOrBuilder getSubscriptionsOrBuilder(
         int index) {
       if (subscriptionsBuilder_ == null) {
-        return subscriptions_.get(index);  } else {
+        return subscriptions_.get(index);
+      } else {
         return subscriptionsBuilder_.getMessageOrBuilder(index);
       }
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -844,8 +914,8 @@ private static final long serialVersionUID = 0L;
      *
      * <code>repeated .google.cloud.pubsublite.v1.Subscription subscriptions = 1;</code>
      */
-    public java.util.List<? extends com.google.cloud.pubsublite.proto.SubscriptionOrBuilder> 
-         getSubscriptionsOrBuilderList() {
+    public java.util.List<? extends com.google.cloud.pubsublite.proto.SubscriptionOrBuilder>
+        getSubscriptionsOrBuilderList() {
       if (subscriptionsBuilder_ != null) {
         return subscriptionsBuilder_.getMessageOrBuilderList();
       } else {
@@ -853,6 +923,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -861,10 +933,12 @@ private static final long serialVersionUID = 0L;
      * <code>repeated .google.cloud.pubsublite.v1.Subscription subscriptions = 1;</code>
      */
     public com.google.cloud.pubsublite.proto.Subscription.Builder addSubscriptionsBuilder() {
-      return getSubscriptionsFieldBuilder().addBuilder(
-          com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance());
+      return getSubscriptionsFieldBuilder()
+          .addBuilder(com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance());
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -874,10 +948,12 @@ private static final long serialVersionUID = 0L;
      */
     public com.google.cloud.pubsublite.proto.Subscription.Builder addSubscriptionsBuilder(
         int index) {
-      return getSubscriptionsFieldBuilder().addBuilder(
-          index, com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance());
+      return getSubscriptionsFieldBuilder()
+          .addBuilder(index, com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance());
     }
     /**
+     *
+     *
      * <pre>
      * The list of subscriptions in the requested parent. The order of the
      * subscriptions is unspecified.
@@ -885,16 +961,22 @@ private static final long serialVersionUID = 0L;
      *
      * <code>repeated .google.cloud.pubsublite.v1.Subscription subscriptions = 1;</code>
      */
-    public java.util.List<com.google.cloud.pubsublite.proto.Subscription.Builder> 
-         getSubscriptionsBuilderList() {
+    public java.util.List<com.google.cloud.pubsublite.proto.Subscription.Builder>
+        getSubscriptionsBuilderList() {
       return getSubscriptionsFieldBuilder().getBuilderList();
     }
+
     private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Subscription, com.google.cloud.pubsublite.proto.Subscription.Builder, com.google.cloud.pubsublite.proto.SubscriptionOrBuilder> 
+            com.google.cloud.pubsublite.proto.Subscription,
+            com.google.cloud.pubsublite.proto.Subscription.Builder,
+            com.google.cloud.pubsublite.proto.SubscriptionOrBuilder>
         getSubscriptionsFieldBuilder() {
       if (subscriptionsBuilder_ == null) {
-        subscriptionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Subscription, com.google.cloud.pubsublite.proto.Subscription.Builder, com.google.cloud.pubsublite.proto.SubscriptionOrBuilder>(
+        subscriptionsBuilder_ =
+            new com.google.protobuf.RepeatedFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Subscription,
+                com.google.cloud.pubsublite.proto.Subscription.Builder,
+                com.google.cloud.pubsublite.proto.SubscriptionOrBuilder>(
                 subscriptions_,
                 ((bitField0_ & 0x00000001) != 0),
                 getParentForChildren(),
@@ -906,19 +988,21 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object nextPageToken_ = "";
     /**
+     *
+     *
      * <pre>
      * A token that can be sent as `page_token` to retrieve the next page of
      * results. If this field is omitted, there are no more results.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @return The nextPageToken.
      */
     public java.lang.String getNextPageToken() {
       java.lang.Object ref = nextPageToken_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         nextPageToken_ = s;
         return s;
@@ -927,21 +1011,22 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A token that can be sent as `page_token` to retrieve the next page of
      * results. If this field is omitted, there are no more results.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @return The bytes for nextPageToken.
      */
-    public com.google.protobuf.ByteString
-        getNextPageTokenBytes() {
+    public com.google.protobuf.ByteString getNextPageTokenBytes() {
       java.lang.Object ref = nextPageToken_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         nextPageToken_ = b;
         return b;
       } else {
@@ -949,64 +1034,71 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A token that can be sent as `page_token` to retrieve the next page of
      * results. If this field is omitted, there are no more results.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @param value The nextPageToken to set.
      * @return This builder for chaining.
      */
-    public Builder setNextPageToken(
-        java.lang.String value) {
+    public Builder setNextPageToken(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       nextPageToken_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A token that can be sent as `page_token` to retrieve the next page of
      * results. If this field is omitted, there are no more results.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearNextPageToken() {
-      
+
       nextPageToken_ = getDefaultInstance().getNextPageToken();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A token that can be sent as `page_token` to retrieve the next page of
      * results. If this field is omitted, there are no more results.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @param value The bytes for nextPageToken to set.
      * @return This builder for chaining.
      */
-    public Builder setNextPageTokenBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setNextPageTokenBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       nextPageToken_ = value;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -1016,12 +1108,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.ListSubscriptionsResponse)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.ListSubscriptionsResponse)
   private static final com.google.cloud.pubsublite.proto.ListSubscriptionsResponse DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.ListSubscriptionsResponse();
   }
@@ -1030,16 +1122,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<ListSubscriptionsResponse>
-      PARSER = new com.google.protobuf.AbstractParser<ListSubscriptionsResponse>() {
-    @java.lang.Override
-    public ListSubscriptionsResponse parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new ListSubscriptionsResponse(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<ListSubscriptionsResponse> PARSER =
+      new com.google.protobuf.AbstractParser<ListSubscriptionsResponse>() {
+        @java.lang.Override
+        public ListSubscriptionsResponse parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new ListSubscriptionsResponse(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<ListSubscriptionsResponse> parser() {
     return PARSER;
@@ -1054,6 +1146,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.ListSubscriptionsResponse getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListSubscriptionsResponseOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListSubscriptionsResponseOrBuilder.java
@@ -3,11 +3,14 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface ListSubscriptionsResponseOrBuilder extends
+public interface ListSubscriptionsResponseOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.ListSubscriptionsResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The list of subscriptions in the requested parent. The order of the
    * subscriptions is unspecified.
@@ -15,9 +18,10 @@ public interface ListSubscriptionsResponseOrBuilder extends
    *
    * <code>repeated .google.cloud.pubsublite.v1.Subscription subscriptions = 1;</code>
    */
-  java.util.List<com.google.cloud.pubsublite.proto.Subscription> 
-      getSubscriptionsList();
+  java.util.List<com.google.cloud.pubsublite.proto.Subscription> getSubscriptionsList();
   /**
+   *
+   *
    * <pre>
    * The list of subscriptions in the requested parent. The order of the
    * subscriptions is unspecified.
@@ -27,6 +31,8 @@ public interface ListSubscriptionsResponseOrBuilder extends
    */
   com.google.cloud.pubsublite.proto.Subscription getSubscriptions(int index);
   /**
+   *
+   *
    * <pre>
    * The list of subscriptions in the requested parent. The order of the
    * subscriptions is unspecified.
@@ -36,6 +42,8 @@ public interface ListSubscriptionsResponseOrBuilder extends
    */
   int getSubscriptionsCount();
   /**
+   *
+   *
    * <pre>
    * The list of subscriptions in the requested parent. The order of the
    * subscriptions is unspecified.
@@ -43,9 +51,11 @@ public interface ListSubscriptionsResponseOrBuilder extends
    *
    * <code>repeated .google.cloud.pubsublite.v1.Subscription subscriptions = 1;</code>
    */
-  java.util.List<? extends com.google.cloud.pubsublite.proto.SubscriptionOrBuilder> 
+  java.util.List<? extends com.google.cloud.pubsublite.proto.SubscriptionOrBuilder>
       getSubscriptionsOrBuilderList();
   /**
+   *
+   *
    * <pre>
    * The list of subscriptions in the requested parent. The order of the
    * subscriptions is unspecified.
@@ -53,28 +63,32 @@ public interface ListSubscriptionsResponseOrBuilder extends
    *
    * <code>repeated .google.cloud.pubsublite.v1.Subscription subscriptions = 1;</code>
    */
-  com.google.cloud.pubsublite.proto.SubscriptionOrBuilder getSubscriptionsOrBuilder(
-      int index);
+  com.google.cloud.pubsublite.proto.SubscriptionOrBuilder getSubscriptionsOrBuilder(int index);
 
   /**
+   *
+   *
    * <pre>
    * A token that can be sent as `page_token` to retrieve the next page of
    * results. If this field is omitted, there are no more results.
    * </pre>
    *
    * <code>string next_page_token = 2;</code>
+   *
    * @return The nextPageToken.
    */
   java.lang.String getNextPageToken();
   /**
+   *
+   *
    * <pre>
    * A token that can be sent as `page_token` to retrieve the next page of
    * results. If this field is omitted, there are no more results.
    * </pre>
    *
    * <code>string next_page_token = 2;</code>
+   *
    * @return The bytes for nextPageToken.
    */
-  com.google.protobuf.ByteString
-      getNextPageTokenBytes();
+  com.google.protobuf.ByteString getNextPageTokenBytes();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListTopicSubscriptionsRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListTopicSubscriptionsRequest.java
@@ -4,21 +4,24 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request for ListTopicSubscriptions.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest}
  */
-public  final class ListTopicSubscriptionsRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class ListTopicSubscriptionsRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest)
     ListTopicSubscriptionsRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use ListTopicSubscriptionsRequest.newBuilder() to construct.
   private ListTopicSubscriptionsRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private ListTopicSubscriptionsRequest() {
     name_ = "";
     pageToken_ = "";
@@ -26,16 +29,15 @@ private static final long serialVersionUID = 0L;
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new ListTopicSubscriptionsRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private ListTopicSubscriptionsRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -54,63 +56,72 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            name_ = s;
-            break;
-          }
-          case 16: {
-
-            pageSize_ = input.readInt32();
-            break;
-          }
-          case 26: {
-            java.lang.String s = input.readStringRequireUtf8();
-
-            pageToken_ = s;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              name_ = s;
+              break;
             }
-            break;
-          }
+          case 16:
+            {
+              pageSize_ = input.readInt32();
+              break;
+            }
+          case 26:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              pageToken_ = s;
+              break;
+            }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest.class, com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest.class,
+            com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest.Builder.class);
   }
 
   public static final int NAME_FIELD_NUMBER = 1;
   private volatile java.lang.Object name_;
   /**
+   *
+   *
    * <pre>
    * The name of the topic whose subscriptions to list.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The name.
    */
   public java.lang.String getName() {
@@ -118,28 +129,30 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       name_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The name of the topic whose subscriptions to list.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for name.
    */
-  public com.google.protobuf.ByteString
-      getNameBytes() {
+  public com.google.protobuf.ByteString getNameBytes() {
     java.lang.Object ref = name_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       name_ = b;
       return b;
     } else {
@@ -150,6 +163,8 @@ private static final long serialVersionUID = 0L;
   public static final int PAGE_SIZE_FIELD_NUMBER = 2;
   private int pageSize_;
   /**
+   *
+   *
    * <pre>
    * The maximum number of subscriptions to return. The service may return fewer
    * than this value.
@@ -157,6 +172,7 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>int32 page_size = 2;</code>
+   *
    * @return The pageSize.
    */
   public int getPageSize() {
@@ -166,6 +182,8 @@ private static final long serialVersionUID = 0L;
   public static final int PAGE_TOKEN_FIELD_NUMBER = 3;
   private volatile java.lang.Object pageToken_;
   /**
+   *
+   *
    * <pre>
    * A page token, received from a previous `ListTopicSubscriptions` call.
    * Provide this to retrieve the subsequent page.
@@ -174,6 +192,7 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string page_token = 3;</code>
+   *
    * @return The pageToken.
    */
   public java.lang.String getPageToken() {
@@ -181,14 +200,15 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       pageToken_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * A page token, received from a previous `ListTopicSubscriptions` call.
    * Provide this to retrieve the subsequent page.
@@ -197,15 +217,14 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string page_token = 3;</code>
+   *
    * @return The bytes for pageToken.
    */
-  public com.google.protobuf.ByteString
-      getPageTokenBytes() {
+  public com.google.protobuf.ByteString getPageTokenBytes() {
     java.lang.Object ref = pageToken_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       pageToken_ = b;
       return b;
     } else {
@@ -214,6 +233,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -225,8 +245,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
@@ -249,8 +268,7 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     if (pageSize_ != 0) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeInt32Size(2, pageSize_);
+      size += com.google.protobuf.CodedOutputStream.computeInt32Size(2, pageSize_);
     }
     if (!getPageTokenBytes().isEmpty()) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, pageToken_);
@@ -263,19 +281,17 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest other = (com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest) obj;
+    com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest other =
+        (com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest) obj;
 
-    if (!getName()
-        .equals(other.getName())) return false;
-    if (getPageSize()
-        != other.getPageSize()) return false;
-    if (!getPageToken()
-        .equals(other.getPageToken())) return false;
+    if (!getName().equals(other.getName())) return false;
+    if (getPageSize() != other.getPageSize()) return false;
+    if (!getPageToken().equals(other.getPageToken())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -299,117 +315,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest parseFrom(byte[] data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+
+  public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest parseFrom(
+      byte[] data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request for ListTopicSubscriptions.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest)
       com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest.class, com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest.class,
+              com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest.newBuilder()
@@ -417,16 +443,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -440,13 +465,14 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsRequest_descriptor;
     }
 
     @java.lang.Override
-    public com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest getDefaultInstanceForType() {
+    public com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest
+        getDefaultInstanceForType() {
       return com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest.getDefaultInstance();
     }
 
@@ -461,7 +487,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest result = new com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest(this);
+      com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest result =
+          new com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest(this);
       result.name_ = name_;
       result.pageSize_ = pageSize_;
       result.pageToken_ = pageToken_;
@@ -473,46 +500,50 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
       }
     }
 
-    public Builder mergeFrom(com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest.getDefaultInstance()) return this;
+    public Builder mergeFrom(
+        com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest other) {
+      if (other
+          == com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest.getDefaultInstance())
+        return this;
       if (!other.getName().isEmpty()) {
         name_ = other.name_;
         onChanged();
@@ -543,7 +574,9 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest)
+                e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -555,18 +588,22 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object name_ = "";
     /**
+     *
+     *
      * <pre>
      * The name of the topic whose subscriptions to list.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The name.
      */
     public java.lang.String getName() {
       java.lang.Object ref = name_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         name_ = s;
         return s;
@@ -575,20 +612,23 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic whose subscriptions to list.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The bytes for name.
      */
-    public com.google.protobuf.ByteString
-        getNameBytes() {
+    public com.google.protobuf.ByteString getNameBytes() {
       java.lang.Object ref = name_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         name_ = b;
         return b;
       } else {
@@ -596,61 +636,76 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic whose subscriptions to list.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The name to set.
      * @return This builder for chaining.
      */
-    public Builder setName(
-        java.lang.String value) {
+    public Builder setName(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       name_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic whose subscriptions to list.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearName() {
-      
+
       name_ = getDefaultInstance().getName();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic whose subscriptions to list.
      * </pre>
      *
-     * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The bytes for name to set.
      * @return This builder for chaining.
      */
-    public Builder setNameBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setNameBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       name_ = value;
       onChanged();
       return this;
     }
 
-    private int pageSize_ ;
+    private int pageSize_;
     /**
+     *
+     *
      * <pre>
      * The maximum number of subscriptions to return. The service may return fewer
      * than this value.
@@ -658,12 +713,15 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int32 page_size = 2;</code>
+     *
      * @return The pageSize.
      */
     public int getPageSize() {
       return pageSize_;
     }
     /**
+     *
+     *
      * <pre>
      * The maximum number of subscriptions to return. The service may return fewer
      * than this value.
@@ -671,16 +729,19 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int32 page_size = 2;</code>
+     *
      * @param value The pageSize to set.
      * @return This builder for chaining.
      */
     public Builder setPageSize(int value) {
-      
+
       pageSize_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The maximum number of subscriptions to return. The service may return fewer
      * than this value.
@@ -688,10 +749,11 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int32 page_size = 2;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearPageSize() {
-      
+
       pageSize_ = 0;
       onChanged();
       return this;
@@ -699,6 +761,8 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object pageToken_ = "";
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListTopicSubscriptions` call.
      * Provide this to retrieve the subsequent page.
@@ -707,13 +771,13 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @return The pageToken.
      */
     public java.lang.String getPageToken() {
       java.lang.Object ref = pageToken_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         pageToken_ = s;
         return s;
@@ -722,6 +786,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListTopicSubscriptions` call.
      * Provide this to retrieve the subsequent page.
@@ -730,15 +796,14 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @return The bytes for pageToken.
      */
-    public com.google.protobuf.ByteString
-        getPageTokenBytes() {
+    public com.google.protobuf.ByteString getPageTokenBytes() {
       java.lang.Object ref = pageToken_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         pageToken_ = b;
         return b;
       } else {
@@ -746,6 +811,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListTopicSubscriptions` call.
      * Provide this to retrieve the subsequent page.
@@ -754,20 +821,22 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @param value The pageToken to set.
      * @return This builder for chaining.
      */
-    public Builder setPageToken(
-        java.lang.String value) {
+    public Builder setPageToken(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       pageToken_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListTopicSubscriptions` call.
      * Provide this to retrieve the subsequent page.
@@ -776,15 +845,18 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearPageToken() {
-      
+
       pageToken_ = getDefaultInstance().getPageToken();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListTopicSubscriptions` call.
      * Provide this to retrieve the subsequent page.
@@ -793,23 +865,23 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @param value The bytes for pageToken to set.
      * @return This builder for chaining.
      */
-    public Builder setPageTokenBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setPageTokenBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       pageToken_ = value;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -819,30 +891,32 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest)
-  private static final com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest DEFAULT_INSTANCE;
+  private static final com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest
+      DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest();
   }
 
-  public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest getDefaultInstance() {
+  public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest
+      getDefaultInstance() {
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<ListTopicSubscriptionsRequest>
-      PARSER = new com.google.protobuf.AbstractParser<ListTopicSubscriptionsRequest>() {
-    @java.lang.Override
-    public ListTopicSubscriptionsRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new ListTopicSubscriptionsRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<ListTopicSubscriptionsRequest> PARSER =
+      new com.google.protobuf.AbstractParser<ListTopicSubscriptionsRequest>() {
+        @java.lang.Override
+        public ListTopicSubscriptionsRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new ListTopicSubscriptionsRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<ListTopicSubscriptionsRequest> parser() {
     return PARSER;
@@ -854,9 +928,8 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest getDefaultInstanceForType() {
+  public com.google.cloud.pubsublite.proto.ListTopicSubscriptionsRequest
+      getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListTopicSubscriptionsRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListTopicSubscriptionsRequestOrBuilder.java
@@ -3,31 +3,43 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface ListTopicSubscriptionsRequestOrBuilder extends
+public interface ListTopicSubscriptionsRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The name of the topic whose subscriptions to list.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The name.
    */
   java.lang.String getName();
   /**
+   *
+   *
    * <pre>
    * The name of the topic whose subscriptions to list.
    * </pre>
    *
-   * <code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for name.
    */
-  com.google.protobuf.ByteString
-      getNameBytes();
+  com.google.protobuf.ByteString getNameBytes();
 
   /**
+   *
+   *
    * <pre>
    * The maximum number of subscriptions to return. The service may return fewer
    * than this value.
@@ -35,11 +47,14 @@ public interface ListTopicSubscriptionsRequestOrBuilder extends
    * </pre>
    *
    * <code>int32 page_size = 2;</code>
+   *
    * @return The pageSize.
    */
   int getPageSize();
 
   /**
+   *
+   *
    * <pre>
    * A page token, received from a previous `ListTopicSubscriptions` call.
    * Provide this to retrieve the subsequent page.
@@ -48,10 +63,13 @@ public interface ListTopicSubscriptionsRequestOrBuilder extends
    * </pre>
    *
    * <code>string page_token = 3;</code>
+   *
    * @return The pageToken.
    */
   java.lang.String getPageToken();
   /**
+   *
+   *
    * <pre>
    * A page token, received from a previous `ListTopicSubscriptions` call.
    * Provide this to retrieve the subsequent page.
@@ -60,8 +78,8 @@ public interface ListTopicSubscriptionsRequestOrBuilder extends
    * </pre>
    *
    * <code>string page_token = 3;</code>
+   *
    * @return The bytes for pageToken.
    */
-  com.google.protobuf.ByteString
-      getPageTokenBytes();
+  com.google.protobuf.ByteString getPageTokenBytes();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListTopicSubscriptionsResponse.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListTopicSubscriptionsResponse.java
@@ -4,21 +4,25 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Response for ListTopicSubscriptions.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.ListTopicSubscriptionsResponse}
  */
-public  final class ListTopicSubscriptionsResponse extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class ListTopicSubscriptionsResponse extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.ListTopicSubscriptionsResponse)
     ListTopicSubscriptionsResponseOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use ListTopicSubscriptionsResponse.newBuilder() to construct.
-  private ListTopicSubscriptionsResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+  private ListTopicSubscriptionsResponse(
+      com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private ListTopicSubscriptionsResponse() {
     subscriptions_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     nextPageToken_ = "";
@@ -26,16 +30,15 @@ private static final long serialVersionUID = 0L;
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new ListTopicSubscriptionsResponse();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private ListTopicSubscriptionsResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -55,35 +58,36 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
-            if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-              subscriptions_ = new com.google.protobuf.LazyStringArrayList();
-              mutable_bitField0_ |= 0x00000001;
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                subscriptions_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              subscriptions_.add(s);
+              break;
             }
-            subscriptions_.add(s);
-            break;
-          }
-          case 18: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 18:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            nextPageToken_ = s;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              nextPageToken_ = s;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       if (((mutable_bitField0_ & 0x00000001) != 0)) {
         subscriptions_ = subscriptions_.getUnmodifiableView();
@@ -92,53 +96,64 @@ private static final long serialVersionUID = 0L;
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse.class, com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse.Builder.class);
+            com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse.class,
+            com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse.Builder.class);
   }
 
   public static final int SUBSCRIPTIONS_FIELD_NUMBER = 1;
   private com.google.protobuf.LazyStringList subscriptions_;
   /**
+   *
+   *
    * <pre>
    * The names of subscriptions attached to the topic. The order of the
    * subscriptions is unspecified.
    * </pre>
    *
    * <code>repeated string subscriptions = 1;</code>
+   *
    * @return A list containing the subscriptions.
    */
-  public com.google.protobuf.ProtocolStringList
-      getSubscriptionsList() {
+  public com.google.protobuf.ProtocolStringList getSubscriptionsList() {
     return subscriptions_;
   }
   /**
+   *
+   *
    * <pre>
    * The names of subscriptions attached to the topic. The order of the
    * subscriptions is unspecified.
    * </pre>
    *
    * <code>repeated string subscriptions = 1;</code>
+   *
    * @return The count of subscriptions.
    */
   public int getSubscriptionsCount() {
     return subscriptions_.size();
   }
   /**
+   *
+   *
    * <pre>
    * The names of subscriptions attached to the topic. The order of the
    * subscriptions is unspecified.
    * </pre>
    *
    * <code>repeated string subscriptions = 1;</code>
+   *
    * @param index The index of the element to return.
    * @return The subscriptions at the given index.
    */
@@ -146,29 +161,34 @@ private static final long serialVersionUID = 0L;
     return subscriptions_.get(index);
   }
   /**
+   *
+   *
    * <pre>
    * The names of subscriptions attached to the topic. The order of the
    * subscriptions is unspecified.
    * </pre>
    *
    * <code>repeated string subscriptions = 1;</code>
+   *
    * @param index The index of the value to return.
    * @return The bytes of the subscriptions at the given index.
    */
-  public com.google.protobuf.ByteString
-      getSubscriptionsBytes(int index) {
+  public com.google.protobuf.ByteString getSubscriptionsBytes(int index) {
     return subscriptions_.getByteString(index);
   }
 
   public static final int NEXT_PAGE_TOKEN_FIELD_NUMBER = 2;
   private volatile java.lang.Object nextPageToken_;
   /**
+   *
+   *
    * <pre>
    * A token that can be sent as `page_token` to retrieve the next page of
    * results. If this field is omitted, there are no more results.
    * </pre>
    *
    * <code>string next_page_token = 2;</code>
+   *
    * @return The nextPageToken.
    */
   public java.lang.String getNextPageToken() {
@@ -176,29 +196,29 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       nextPageToken_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * A token that can be sent as `page_token` to retrieve the next page of
    * results. If this field is omitted, there are no more results.
    * </pre>
    *
    * <code>string next_page_token = 2;</code>
+   *
    * @return The bytes for nextPageToken.
    */
-  public com.google.protobuf.ByteString
-      getNextPageTokenBytes() {
+  public com.google.protobuf.ByteString getNextPageTokenBytes() {
     java.lang.Object ref = nextPageToken_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       nextPageToken_ = b;
       return b;
     } else {
@@ -207,6 +227,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -218,8 +239,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     for (int i = 0; i < subscriptions_.size(); i++) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, subscriptions_.getRaw(i));
     }
@@ -254,17 +274,16 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse other = (com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse) obj;
+    com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse other =
+        (com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse) obj;
 
-    if (!getSubscriptionsList()
-        .equals(other.getSubscriptionsList())) return false;
-    if (!getNextPageToken()
-        .equals(other.getNextPageToken())) return false;
+    if (!getSubscriptionsList().equals(other.getSubscriptionsList())) return false;
+    if (!getNextPageToken().equals(other.getNextPageToken())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -288,117 +307,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse parseFrom(byte[] data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+
+  public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse parseFrom(
+      byte[] data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Response for ListTopicSubscriptions.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.ListTopicSubscriptionsResponse}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.ListTopicSubscriptionsResponse)
       com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponseOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse.class, com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse.Builder.class);
+              com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse.class,
+              com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse.newBuilder()
@@ -406,16 +435,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -427,13 +455,14 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListTopicSubscriptionsResponse_descriptor;
     }
 
     @java.lang.Override
-    public com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse getDefaultInstanceForType() {
+    public com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse
+        getDefaultInstanceForType() {
       return com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse.getDefaultInstance();
     }
 
@@ -448,7 +477,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse buildPartial() {
-      com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse result = new com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse(this);
+      com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse result =
+          new com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse(this);
       int from_bitField0_ = bitField0_;
       if (((bitField0_ & 0x00000001) != 0)) {
         subscriptions_ = subscriptions_.getUnmodifiableView();
@@ -464,46 +494,50 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse) other);
       } else {
         super.mergeFrom(other);
         return this;
       }
     }
 
-    public Builder mergeFrom(com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse other) {
-      if (other == com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse.getDefaultInstance()) return this;
+    public Builder mergeFrom(
+        com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse other) {
+      if (other
+          == com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse.getDefaultInstance())
+        return this;
       if (!other.subscriptions_.isEmpty()) {
         if (subscriptions_.isEmpty()) {
           subscriptions_ = other.subscriptions_;
@@ -537,7 +571,9 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse)
+                e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -546,47 +582,58 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     private int bitField0_;
 
-    private com.google.protobuf.LazyStringList subscriptions_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    private com.google.protobuf.LazyStringList subscriptions_ =
+        com.google.protobuf.LazyStringArrayList.EMPTY;
+
     private void ensureSubscriptionsIsMutable() {
       if (!((bitField0_ & 0x00000001) != 0)) {
         subscriptions_ = new com.google.protobuf.LazyStringArrayList(subscriptions_);
         bitField0_ |= 0x00000001;
-       }
+      }
     }
     /**
+     *
+     *
      * <pre>
      * The names of subscriptions attached to the topic. The order of the
      * subscriptions is unspecified.
      * </pre>
      *
      * <code>repeated string subscriptions = 1;</code>
+     *
      * @return A list containing the subscriptions.
      */
-    public com.google.protobuf.ProtocolStringList
-        getSubscriptionsList() {
+    public com.google.protobuf.ProtocolStringList getSubscriptionsList() {
       return subscriptions_.getUnmodifiableView();
     }
     /**
+     *
+     *
      * <pre>
      * The names of subscriptions attached to the topic. The order of the
      * subscriptions is unspecified.
      * </pre>
      *
      * <code>repeated string subscriptions = 1;</code>
+     *
      * @return The count of subscriptions.
      */
     public int getSubscriptionsCount() {
       return subscriptions_.size();
     }
     /**
+     *
+     *
      * <pre>
      * The names of subscriptions attached to the topic. The order of the
      * subscriptions is unspecified.
      * </pre>
      *
      * <code>repeated string subscriptions = 1;</code>
+     *
      * @param index The index of the element to return.
      * @return The subscriptions at the given index.
      */
@@ -594,85 +641,95 @@ private static final long serialVersionUID = 0L;
       return subscriptions_.get(index);
     }
     /**
+     *
+     *
      * <pre>
      * The names of subscriptions attached to the topic. The order of the
      * subscriptions is unspecified.
      * </pre>
      *
      * <code>repeated string subscriptions = 1;</code>
+     *
      * @param index The index of the value to return.
      * @return The bytes of the subscriptions at the given index.
      */
-    public com.google.protobuf.ByteString
-        getSubscriptionsBytes(int index) {
+    public com.google.protobuf.ByteString getSubscriptionsBytes(int index) {
       return subscriptions_.getByteString(index);
     }
     /**
+     *
+     *
      * <pre>
      * The names of subscriptions attached to the topic. The order of the
      * subscriptions is unspecified.
      * </pre>
      *
      * <code>repeated string subscriptions = 1;</code>
+     *
      * @param index The index to set the value at.
      * @param value The subscriptions to set.
      * @return This builder for chaining.
      */
-    public Builder setSubscriptions(
-        int index, java.lang.String value) {
+    public Builder setSubscriptions(int index, java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureSubscriptionsIsMutable();
+        throw new NullPointerException();
+      }
+      ensureSubscriptionsIsMutable();
       subscriptions_.set(index, value);
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The names of subscriptions attached to the topic. The order of the
      * subscriptions is unspecified.
      * </pre>
      *
      * <code>repeated string subscriptions = 1;</code>
+     *
      * @param value The subscriptions to add.
      * @return This builder for chaining.
      */
-    public Builder addSubscriptions(
-        java.lang.String value) {
+    public Builder addSubscriptions(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureSubscriptionsIsMutable();
+        throw new NullPointerException();
+      }
+      ensureSubscriptionsIsMutable();
       subscriptions_.add(value);
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The names of subscriptions attached to the topic. The order of the
      * subscriptions is unspecified.
      * </pre>
      *
      * <code>repeated string subscriptions = 1;</code>
+     *
      * @param values The subscriptions to add.
      * @return This builder for chaining.
      */
-    public Builder addAllSubscriptions(
-        java.lang.Iterable<java.lang.String> values) {
+    public Builder addAllSubscriptions(java.lang.Iterable<java.lang.String> values) {
       ensureSubscriptionsIsMutable();
-      com.google.protobuf.AbstractMessageLite.Builder.addAll(
-          values, subscriptions_);
+      com.google.protobuf.AbstractMessageLite.Builder.addAll(values, subscriptions_);
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The names of subscriptions attached to the topic. The order of the
      * subscriptions is unspecified.
      * </pre>
      *
      * <code>repeated string subscriptions = 1;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearSubscriptions() {
@@ -682,21 +739,23 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The names of subscriptions attached to the topic. The order of the
      * subscriptions is unspecified.
      * </pre>
      *
      * <code>repeated string subscriptions = 1;</code>
+     *
      * @param value The bytes of the subscriptions to add.
      * @return This builder for chaining.
      */
-    public Builder addSubscriptionsBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder addSubscriptionsBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
       ensureSubscriptionsIsMutable();
       subscriptions_.add(value);
       onChanged();
@@ -705,19 +764,21 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object nextPageToken_ = "";
     /**
+     *
+     *
      * <pre>
      * A token that can be sent as `page_token` to retrieve the next page of
      * results. If this field is omitted, there are no more results.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @return The nextPageToken.
      */
     public java.lang.String getNextPageToken() {
       java.lang.Object ref = nextPageToken_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         nextPageToken_ = s;
         return s;
@@ -726,21 +787,22 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A token that can be sent as `page_token` to retrieve the next page of
      * results. If this field is omitted, there are no more results.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @return The bytes for nextPageToken.
      */
-    public com.google.protobuf.ByteString
-        getNextPageTokenBytes() {
+    public com.google.protobuf.ByteString getNextPageTokenBytes() {
       java.lang.Object ref = nextPageToken_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         nextPageToken_ = b;
         return b;
       } else {
@@ -748,64 +810,71 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A token that can be sent as `page_token` to retrieve the next page of
      * results. If this field is omitted, there are no more results.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @param value The nextPageToken to set.
      * @return This builder for chaining.
      */
-    public Builder setNextPageToken(
-        java.lang.String value) {
+    public Builder setNextPageToken(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       nextPageToken_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A token that can be sent as `page_token` to retrieve the next page of
      * results. If this field is omitted, there are no more results.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearNextPageToken() {
-      
+
       nextPageToken_ = getDefaultInstance().getNextPageToken();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A token that can be sent as `page_token` to retrieve the next page of
      * results. If this field is omitted, there are no more results.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @param value The bytes for nextPageToken to set.
      * @return This builder for chaining.
      */
-    public Builder setNextPageTokenBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setNextPageTokenBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       nextPageToken_ = value;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -815,30 +884,32 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.ListTopicSubscriptionsResponse)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.ListTopicSubscriptionsResponse)
-  private static final com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse DEFAULT_INSTANCE;
+  private static final com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse
+      DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse();
   }
 
-  public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse getDefaultInstance() {
+  public static com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse
+      getDefaultInstance() {
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<ListTopicSubscriptionsResponse>
-      PARSER = new com.google.protobuf.AbstractParser<ListTopicSubscriptionsResponse>() {
-    @java.lang.Override
-    public ListTopicSubscriptionsResponse parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new ListTopicSubscriptionsResponse(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<ListTopicSubscriptionsResponse> PARSER =
+      new com.google.protobuf.AbstractParser<ListTopicSubscriptionsResponse>() {
+        @java.lang.Override
+        public ListTopicSubscriptionsResponse parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new ListTopicSubscriptionsResponse(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<ListTopicSubscriptionsResponse> parser() {
     return PARSER;
@@ -850,9 +921,8 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse getDefaultInstanceForType() {
+  public com.google.cloud.pubsublite.proto.ListTopicSubscriptionsResponse
+      getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListTopicSubscriptionsResponseOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListTopicSubscriptionsResponseOrBuilder.java
@@ -3,74 +3,90 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface ListTopicSubscriptionsResponseOrBuilder extends
+public interface ListTopicSubscriptionsResponseOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.ListTopicSubscriptionsResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The names of subscriptions attached to the topic. The order of the
    * subscriptions is unspecified.
    * </pre>
    *
    * <code>repeated string subscriptions = 1;</code>
+   *
    * @return A list containing the subscriptions.
    */
-  java.util.List<java.lang.String>
-      getSubscriptionsList();
+  java.util.List<java.lang.String> getSubscriptionsList();
   /**
+   *
+   *
    * <pre>
    * The names of subscriptions attached to the topic. The order of the
    * subscriptions is unspecified.
    * </pre>
    *
    * <code>repeated string subscriptions = 1;</code>
+   *
    * @return The count of subscriptions.
    */
   int getSubscriptionsCount();
   /**
+   *
+   *
    * <pre>
    * The names of subscriptions attached to the topic. The order of the
    * subscriptions is unspecified.
    * </pre>
    *
    * <code>repeated string subscriptions = 1;</code>
+   *
    * @param index The index of the element to return.
    * @return The subscriptions at the given index.
    */
   java.lang.String getSubscriptions(int index);
   /**
+   *
+   *
    * <pre>
    * The names of subscriptions attached to the topic. The order of the
    * subscriptions is unspecified.
    * </pre>
    *
    * <code>repeated string subscriptions = 1;</code>
+   *
    * @param index The index of the value to return.
    * @return The bytes of the subscriptions at the given index.
    */
-  com.google.protobuf.ByteString
-      getSubscriptionsBytes(int index);
+  com.google.protobuf.ByteString getSubscriptionsBytes(int index);
 
   /**
+   *
+   *
    * <pre>
    * A token that can be sent as `page_token` to retrieve the next page of
    * results. If this field is omitted, there are no more results.
    * </pre>
    *
    * <code>string next_page_token = 2;</code>
+   *
    * @return The nextPageToken.
    */
   java.lang.String getNextPageToken();
   /**
+   *
+   *
    * <pre>
    * A token that can be sent as `page_token` to retrieve the next page of
    * results. If this field is omitted, there are no more results.
    * </pre>
    *
    * <code>string next_page_token = 2;</code>
+   *
    * @return The bytes for nextPageToken.
    */
-  com.google.protobuf.ByteString
-      getNextPageTokenBytes();
+  com.google.protobuf.ByteString getNextPageTokenBytes();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListTopicsRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListTopicsRequest.java
@@ -4,21 +4,24 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request for ListTopics.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.ListTopicsRequest}
  */
-public  final class ListTopicsRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class ListTopicsRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.ListTopicsRequest)
     ListTopicsRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use ListTopicsRequest.newBuilder() to construct.
   private ListTopicsRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private ListTopicsRequest() {
     parent_ = "";
     pageToken_ = "";
@@ -26,16 +29,15 @@ private static final long serialVersionUID = 0L;
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new ListTopicsRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private ListTopicsRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -54,64 +56,73 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            parent_ = s;
-            break;
-          }
-          case 16: {
-
-            pageSize_ = input.readInt32();
-            break;
-          }
-          case 26: {
-            java.lang.String s = input.readStringRequireUtf8();
-
-            pageToken_ = s;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              parent_ = s;
+              break;
             }
-            break;
-          }
+          case 16:
+            {
+              pageSize_ = input.readInt32();
+              break;
+            }
+          case 26:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              pageToken_ = s;
+              break;
+            }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.ListTopicsRequest.class, com.google.cloud.pubsublite.proto.ListTopicsRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.ListTopicsRequest.class,
+            com.google.cloud.pubsublite.proto.ListTopicsRequest.Builder.class);
   }
 
   public static final int PARENT_FIELD_NUMBER = 1;
   private volatile java.lang.Object parent_;
   /**
+   *
+   *
    * <pre>
    * The parent whose topics are to be listed.
    * Structured like `projects/{project_number}/locations/{location}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The parent.
    */
   public java.lang.String getParent() {
@@ -119,29 +130,31 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       parent_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The parent whose topics are to be listed.
    * Structured like `projects/{project_number}/locations/{location}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for parent.
    */
-  public com.google.protobuf.ByteString
-      getParentBytes() {
+  public com.google.protobuf.ByteString getParentBytes() {
     java.lang.Object ref = parent_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       parent_ = b;
       return b;
     } else {
@@ -152,6 +165,8 @@ private static final long serialVersionUID = 0L;
   public static final int PAGE_SIZE_FIELD_NUMBER = 2;
   private int pageSize_;
   /**
+   *
+   *
    * <pre>
    * The maximum number of topics to return. The service may return fewer than
    * this value.
@@ -159,6 +174,7 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>int32 page_size = 2;</code>
+   *
    * @return The pageSize.
    */
   public int getPageSize() {
@@ -168,6 +184,8 @@ private static final long serialVersionUID = 0L;
   public static final int PAGE_TOKEN_FIELD_NUMBER = 3;
   private volatile java.lang.Object pageToken_;
   /**
+   *
+   *
    * <pre>
    * A page token, received from a previous `ListTopics` call.
    * Provide this to retrieve the subsequent page.
@@ -176,6 +194,7 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string page_token = 3;</code>
+   *
    * @return The pageToken.
    */
   public java.lang.String getPageToken() {
@@ -183,14 +202,15 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       pageToken_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * A page token, received from a previous `ListTopics` call.
    * Provide this to retrieve the subsequent page.
@@ -199,15 +219,14 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string page_token = 3;</code>
+   *
    * @return The bytes for pageToken.
    */
-  public com.google.protobuf.ByteString
-      getPageTokenBytes() {
+  public com.google.protobuf.ByteString getPageTokenBytes() {
     java.lang.Object ref = pageToken_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       pageToken_ = b;
       return b;
     } else {
@@ -216,6 +235,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -227,8 +247,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getParentBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, parent_);
     }
@@ -251,8 +270,7 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, parent_);
     }
     if (pageSize_ != 0) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeInt32Size(2, pageSize_);
+      size += com.google.protobuf.CodedOutputStream.computeInt32Size(2, pageSize_);
     }
     if (!getPageTokenBytes().isEmpty()) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, pageToken_);
@@ -265,19 +283,17 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.ListTopicsRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.ListTopicsRequest other = (com.google.cloud.pubsublite.proto.ListTopicsRequest) obj;
+    com.google.cloud.pubsublite.proto.ListTopicsRequest other =
+        (com.google.cloud.pubsublite.proto.ListTopicsRequest) obj;
 
-    if (!getParent()
-        .equals(other.getParent())) return false;
-    if (getPageSize()
-        != other.getPageSize()) return false;
-    if (!getPageToken()
-        .equals(other.getPageToken())) return false;
+    if (!getParent().equals(other.getParent())) return false;
+    if (getPageSize() != other.getPageSize()) return false;
+    if (!getPageToken().equals(other.getPageToken())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -301,117 +317,126 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.ListTopicsRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.ListTopicsRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.ListTopicsRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.ListTopicsRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.ListTopicsRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.ListTopicsRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request for ListTopics.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.ListTopicsRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.ListTopicsRequest)
       com.google.cloud.pubsublite.proto.ListTopicsRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.ListTopicsRequest.class, com.google.cloud.pubsublite.proto.ListTopicsRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.ListTopicsRequest.class,
+              com.google.cloud.pubsublite.proto.ListTopicsRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.ListTopicsRequest.newBuilder()
@@ -419,16 +444,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -442,9 +466,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListTopicsRequest_descriptor;
     }
 
     @java.lang.Override
@@ -463,7 +487,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.ListTopicsRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.ListTopicsRequest result = new com.google.cloud.pubsublite.proto.ListTopicsRequest(this);
+      com.google.cloud.pubsublite.proto.ListTopicsRequest result =
+          new com.google.cloud.pubsublite.proto.ListTopicsRequest(this);
       result.parent_ = parent_;
       result.pageSize_ = pageSize_;
       result.pageToken_ = pageToken_;
@@ -475,38 +500,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.ListTopicsRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.ListTopicsRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.ListTopicsRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -514,7 +540,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.ListTopicsRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.ListTopicsRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.ListTopicsRequest.getDefaultInstance())
+        return this;
       if (!other.getParent().isEmpty()) {
         parent_ = other.parent_;
         onChanged();
@@ -545,7 +572,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.ListTopicsRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.ListTopicsRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -557,19 +585,23 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object parent_ = "";
     /**
+     *
+     *
      * <pre>
      * The parent whose topics are to be listed.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The parent.
      */
     public java.lang.String getParent() {
       java.lang.Object ref = parent_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         parent_ = s;
         return s;
@@ -578,21 +610,24 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The parent whose topics are to be listed.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return The bytes for parent.
      */
-    public com.google.protobuf.ByteString
-        getParentBytes() {
+    public com.google.protobuf.ByteString getParentBytes() {
       java.lang.Object ref = parent_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         parent_ = b;
         return b;
       } else {
@@ -600,64 +635,79 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The parent whose topics are to be listed.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The parent to set.
      * @return This builder for chaining.
      */
-    public Builder setParent(
-        java.lang.String value) {
+    public Builder setParent(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       parent_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The parent whose topics are to be listed.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearParent() {
-      
+
       parent_ = getDefaultInstance().getParent();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The parent whose topics are to be listed.
      * Structured like `projects/{project_number}/locations/{location}`.
      * </pre>
      *
-     * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+     * <code>
+     * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+     * </code>
+     *
      * @param value The bytes for parent to set.
      * @return This builder for chaining.
      */
-    public Builder setParentBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setParentBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       parent_ = value;
       onChanged();
       return this;
     }
 
-    private int pageSize_ ;
+    private int pageSize_;
     /**
+     *
+     *
      * <pre>
      * The maximum number of topics to return. The service may return fewer than
      * this value.
@@ -665,12 +715,15 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int32 page_size = 2;</code>
+     *
      * @return The pageSize.
      */
     public int getPageSize() {
       return pageSize_;
     }
     /**
+     *
+     *
      * <pre>
      * The maximum number of topics to return. The service may return fewer than
      * this value.
@@ -678,16 +731,19 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int32 page_size = 2;</code>
+     *
      * @param value The pageSize to set.
      * @return This builder for chaining.
      */
     public Builder setPageSize(int value) {
-      
+
       pageSize_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The maximum number of topics to return. The service may return fewer than
      * this value.
@@ -695,10 +751,11 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int32 page_size = 2;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearPageSize() {
-      
+
       pageSize_ = 0;
       onChanged();
       return this;
@@ -706,6 +763,8 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object pageToken_ = "";
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListTopics` call.
      * Provide this to retrieve the subsequent page.
@@ -714,13 +773,13 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @return The pageToken.
      */
     public java.lang.String getPageToken() {
       java.lang.Object ref = pageToken_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         pageToken_ = s;
         return s;
@@ -729,6 +788,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListTopics` call.
      * Provide this to retrieve the subsequent page.
@@ -737,15 +798,14 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @return The bytes for pageToken.
      */
-    public com.google.protobuf.ByteString
-        getPageTokenBytes() {
+    public com.google.protobuf.ByteString getPageTokenBytes() {
       java.lang.Object ref = pageToken_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         pageToken_ = b;
         return b;
       } else {
@@ -753,6 +813,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListTopics` call.
      * Provide this to retrieve the subsequent page.
@@ -761,20 +823,22 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @param value The pageToken to set.
      * @return This builder for chaining.
      */
-    public Builder setPageToken(
-        java.lang.String value) {
+    public Builder setPageToken(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       pageToken_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListTopics` call.
      * Provide this to retrieve the subsequent page.
@@ -783,15 +847,18 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearPageToken() {
-      
+
       pageToken_ = getDefaultInstance().getPageToken();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A page token, received from a previous `ListTopics` call.
      * Provide this to retrieve the subsequent page.
@@ -800,23 +867,23 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string page_token = 3;</code>
+     *
      * @param value The bytes for pageToken to set.
      * @return This builder for chaining.
      */
-    public Builder setPageTokenBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setPageTokenBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       pageToken_ = value;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -826,12 +893,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.ListTopicsRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.ListTopicsRequest)
   private static final com.google.cloud.pubsublite.proto.ListTopicsRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.ListTopicsRequest();
   }
@@ -840,16 +907,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<ListTopicsRequest>
-      PARSER = new com.google.protobuf.AbstractParser<ListTopicsRequest>() {
-    @java.lang.Override
-    public ListTopicsRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new ListTopicsRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<ListTopicsRequest> PARSER =
+      new com.google.protobuf.AbstractParser<ListTopicsRequest>() {
+        @java.lang.Override
+        public ListTopicsRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new ListTopicsRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<ListTopicsRequest> parser() {
     return PARSER;
@@ -864,6 +931,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.ListTopicsRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListTopicsRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListTopicsRequestOrBuilder.java
@@ -3,33 +3,45 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface ListTopicsRequestOrBuilder extends
+public interface ListTopicsRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.ListTopicsRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The parent whose topics are to be listed.
    * Structured like `projects/{project_number}/locations/{location}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The parent.
    */
   java.lang.String getParent();
   /**
+   *
+   *
    * <pre>
    * The parent whose topics are to be listed.
    * Structured like `projects/{project_number}/locations/{location}`.
    * </pre>
    *
-   * <code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code>
+   * <code>
+   * string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }
+   * </code>
+   *
    * @return The bytes for parent.
    */
-  com.google.protobuf.ByteString
-      getParentBytes();
+  com.google.protobuf.ByteString getParentBytes();
 
   /**
+   *
+   *
    * <pre>
    * The maximum number of topics to return. The service may return fewer than
    * this value.
@@ -37,11 +49,14 @@ public interface ListTopicsRequestOrBuilder extends
    * </pre>
    *
    * <code>int32 page_size = 2;</code>
+   *
    * @return The pageSize.
    */
   int getPageSize();
 
   /**
+   *
+   *
    * <pre>
    * A page token, received from a previous `ListTopics` call.
    * Provide this to retrieve the subsequent page.
@@ -50,10 +65,13 @@ public interface ListTopicsRequestOrBuilder extends
    * </pre>
    *
    * <code>string page_token = 3;</code>
+   *
    * @return The pageToken.
    */
   java.lang.String getPageToken();
   /**
+   *
+   *
    * <pre>
    * A page token, received from a previous `ListTopics` call.
    * Provide this to retrieve the subsequent page.
@@ -62,8 +80,8 @@ public interface ListTopicsRequestOrBuilder extends
    * </pre>
    *
    * <code>string page_token = 3;</code>
+   *
    * @return The bytes for pageToken.
    */
-  com.google.protobuf.ByteString
-      getPageTokenBytes();
+  com.google.protobuf.ByteString getPageTokenBytes();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListTopicsResponse.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListTopicsResponse.java
@@ -4,21 +4,24 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Response for ListTopics.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.ListTopicsResponse}
  */
-public  final class ListTopicsResponse extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class ListTopicsResponse extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.ListTopicsResponse)
     ListTopicsResponseOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use ListTopicsResponse.newBuilder() to construct.
   private ListTopicsResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private ListTopicsResponse() {
     topics_ = java.util.Collections.emptyList();
     nextPageToken_ = "";
@@ -26,16 +29,15 @@ private static final long serialVersionUID = 0L;
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new ListTopicsResponse();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private ListTopicsResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -55,35 +57,37 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-              topics_ = new java.util.ArrayList<com.google.cloud.pubsublite.proto.Topic>();
-              mutable_bitField0_ |= 0x00000001;
+          case 10:
+            {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                topics_ = new java.util.ArrayList<com.google.cloud.pubsublite.proto.Topic>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              topics_.add(
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Topic.parser(), extensionRegistry));
+              break;
             }
-            topics_.add(
-                input.readMessage(com.google.cloud.pubsublite.proto.Topic.parser(), extensionRegistry));
-            break;
-          }
-          case 18: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 18:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            nextPageToken_ = s;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              nextPageToken_ = s;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       if (((mutable_bitField0_ & 0x00000001) != 0)) {
         topics_ = java.util.Collections.unmodifiableList(topics_);
@@ -92,22 +96,27 @@ private static final long serialVersionUID = 0L;
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.ListTopicsResponse.class, com.google.cloud.pubsublite.proto.ListTopicsResponse.Builder.class);
+            com.google.cloud.pubsublite.proto.ListTopicsResponse.class,
+            com.google.cloud.pubsublite.proto.ListTopicsResponse.Builder.class);
   }
 
   public static final int TOPICS_FIELD_NUMBER = 1;
   private java.util.List<com.google.cloud.pubsublite.proto.Topic> topics_;
   /**
+   *
+   *
    * <pre>
    * The list of topic in the requested parent. The order of the topics is
    * unspecified.
@@ -119,6 +128,8 @@ private static final long serialVersionUID = 0L;
     return topics_;
   }
   /**
+   *
+   *
    * <pre>
    * The list of topic in the requested parent. The order of the topics is
    * unspecified.
@@ -126,11 +137,13 @@ private static final long serialVersionUID = 0L;
    *
    * <code>repeated .google.cloud.pubsublite.v1.Topic topics = 1;</code>
    */
-  public java.util.List<? extends com.google.cloud.pubsublite.proto.TopicOrBuilder> 
+  public java.util.List<? extends com.google.cloud.pubsublite.proto.TopicOrBuilder>
       getTopicsOrBuilderList() {
     return topics_;
   }
   /**
+   *
+   *
    * <pre>
    * The list of topic in the requested parent. The order of the topics is
    * unspecified.
@@ -142,6 +155,8 @@ private static final long serialVersionUID = 0L;
     return topics_.size();
   }
   /**
+   *
+   *
    * <pre>
    * The list of topic in the requested parent. The order of the topics is
    * unspecified.
@@ -153,6 +168,8 @@ private static final long serialVersionUID = 0L;
     return topics_.get(index);
   }
   /**
+   *
+   *
    * <pre>
    * The list of topic in the requested parent. The order of the topics is
    * unspecified.
@@ -160,20 +177,22 @@ private static final long serialVersionUID = 0L;
    *
    * <code>repeated .google.cloud.pubsublite.v1.Topic topics = 1;</code>
    */
-  public com.google.cloud.pubsublite.proto.TopicOrBuilder getTopicsOrBuilder(
-      int index) {
+  public com.google.cloud.pubsublite.proto.TopicOrBuilder getTopicsOrBuilder(int index) {
     return topics_.get(index);
   }
 
   public static final int NEXT_PAGE_TOKEN_FIELD_NUMBER = 2;
   private volatile java.lang.Object nextPageToken_;
   /**
+   *
+   *
    * <pre>
    * A token that can be sent as `page_token` to retrieve the next page of
    * results. If this field is omitted, there are no more results.
    * </pre>
    *
    * <code>string next_page_token = 2;</code>
+   *
    * @return The nextPageToken.
    */
   public java.lang.String getNextPageToken() {
@@ -181,29 +200,29 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       nextPageToken_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * A token that can be sent as `page_token` to retrieve the next page of
    * results. If this field is omitted, there are no more results.
    * </pre>
    *
    * <code>string next_page_token = 2;</code>
+   *
    * @return The bytes for nextPageToken.
    */
-  public com.google.protobuf.ByteString
-      getNextPageTokenBytes() {
+  public com.google.protobuf.ByteString getNextPageTokenBytes() {
     java.lang.Object ref = nextPageToken_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       nextPageToken_ = b;
       return b;
     } else {
@@ -212,6 +231,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -223,8 +243,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     for (int i = 0; i < topics_.size(); i++) {
       output.writeMessage(1, topics_.get(i));
     }
@@ -241,8 +260,7 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     for (int i = 0; i < topics_.size(); i++) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, topics_.get(i));
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(1, topics_.get(i));
     }
     if (!getNextPageTokenBytes().isEmpty()) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, nextPageToken_);
@@ -255,17 +273,16 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.ListTopicsResponse)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.ListTopicsResponse other = (com.google.cloud.pubsublite.proto.ListTopicsResponse) obj;
+    com.google.cloud.pubsublite.proto.ListTopicsResponse other =
+        (com.google.cloud.pubsublite.proto.ListTopicsResponse) obj;
 
-    if (!getTopicsList()
-        .equals(other.getTopicsList())) return false;
-    if (!getNextPageToken()
-        .equals(other.getNextPageToken())) return false;
+    if (!getTopicsList().equals(other.getTopicsList())) return false;
+    if (!getNextPageToken().equals(other.getNextPageToken())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -289,117 +306,126 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.ListTopicsResponse parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsResponse parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsResponse parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsResponse parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsResponse parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.ListTopicsResponse parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsResponse parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.ListTopicsResponse parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.ListTopicsResponse parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsResponse parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.ListTopicsResponse parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsResponse parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.ListTopicsResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.ListTopicsResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Response for ListTopics.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.ListTopicsResponse}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.ListTopicsResponse)
       com.google.cloud.pubsublite.proto.ListTopicsResponseOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.ListTopicsResponse.class, com.google.cloud.pubsublite.proto.ListTopicsResponse.Builder.class);
+              com.google.cloud.pubsublite.proto.ListTopicsResponse.class,
+              com.google.cloud.pubsublite.proto.ListTopicsResponse.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.ListTopicsResponse.newBuilder()
@@ -407,17 +433,17 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {
         getTopicsFieldBuilder();
       }
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -433,9 +459,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_ListTopicsResponse_descriptor;
     }
 
     @java.lang.Override
@@ -454,7 +480,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.ListTopicsResponse buildPartial() {
-      com.google.cloud.pubsublite.proto.ListTopicsResponse result = new com.google.cloud.pubsublite.proto.ListTopicsResponse(this);
+      com.google.cloud.pubsublite.proto.ListTopicsResponse result =
+          new com.google.cloud.pubsublite.proto.ListTopicsResponse(this);
       int from_bitField0_ = bitField0_;
       if (topicsBuilder_ == null) {
         if (((bitField0_ & 0x00000001) != 0)) {
@@ -474,38 +501,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.ListTopicsResponse) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.ListTopicsResponse)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.ListTopicsResponse) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -513,7 +541,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.ListTopicsResponse other) {
-      if (other == com.google.cloud.pubsublite.proto.ListTopicsResponse.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.ListTopicsResponse.getDefaultInstance())
+        return this;
       if (topicsBuilder_ == null) {
         if (!other.topics_.isEmpty()) {
           if (topics_.isEmpty()) {
@@ -532,9 +561,10 @@ private static final long serialVersionUID = 0L;
             topicsBuilder_ = null;
             topics_ = other.topics_;
             bitField0_ = (bitField0_ & ~0x00000001);
-            topicsBuilder_ = 
-              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
-                 getTopicsFieldBuilder() : null;
+            topicsBuilder_ =
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders
+                    ? getTopicsFieldBuilder()
+                    : null;
           } else {
             topicsBuilder_.addAllMessages(other.topics_);
           }
@@ -563,7 +593,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.ListTopicsResponse) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.ListTopicsResponse) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -572,21 +603,28 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     private int bitField0_;
 
     private java.util.List<com.google.cloud.pubsublite.proto.Topic> topics_ =
-      java.util.Collections.emptyList();
+        java.util.Collections.emptyList();
+
     private void ensureTopicsIsMutable() {
       if (!((bitField0_ & 0x00000001) != 0)) {
         topics_ = new java.util.ArrayList<com.google.cloud.pubsublite.proto.Topic>(topics_);
         bitField0_ |= 0x00000001;
-       }
+      }
     }
 
     private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Topic, com.google.cloud.pubsublite.proto.Topic.Builder, com.google.cloud.pubsublite.proto.TopicOrBuilder> topicsBuilder_;
+            com.google.cloud.pubsublite.proto.Topic,
+            com.google.cloud.pubsublite.proto.Topic.Builder,
+            com.google.cloud.pubsublite.proto.TopicOrBuilder>
+        topicsBuilder_;
 
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -602,6 +640,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -617,6 +657,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -632,6 +674,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -639,8 +683,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>repeated .google.cloud.pubsublite.v1.Topic topics = 1;</code>
      */
-    public Builder setTopics(
-        int index, com.google.cloud.pubsublite.proto.Topic value) {
+    public Builder setTopics(int index, com.google.cloud.pubsublite.proto.Topic value) {
       if (topicsBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
@@ -654,6 +697,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -673,6 +718,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -694,6 +741,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -701,8 +750,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>repeated .google.cloud.pubsublite.v1.Topic topics = 1;</code>
      */
-    public Builder addTopics(
-        int index, com.google.cloud.pubsublite.proto.Topic value) {
+    public Builder addTopics(int index, com.google.cloud.pubsublite.proto.Topic value) {
       if (topicsBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
@@ -716,6 +764,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -723,8 +773,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>repeated .google.cloud.pubsublite.v1.Topic topics = 1;</code>
      */
-    public Builder addTopics(
-        com.google.cloud.pubsublite.proto.Topic.Builder builderForValue) {
+    public Builder addTopics(com.google.cloud.pubsublite.proto.Topic.Builder builderForValue) {
       if (topicsBuilder_ == null) {
         ensureTopicsIsMutable();
         topics_.add(builderForValue.build());
@@ -735,6 +784,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -754,6 +805,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -765,8 +818,7 @@ private static final long serialVersionUID = 0L;
         java.lang.Iterable<? extends com.google.cloud.pubsublite.proto.Topic> values) {
       if (topicsBuilder_ == null) {
         ensureTopicsIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, topics_);
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(values, topics_);
         onChanged();
       } else {
         topicsBuilder_.addAllMessages(values);
@@ -774,6 +826,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -792,6 +846,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -810,6 +866,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -817,11 +875,12 @@ private static final long serialVersionUID = 0L;
      *
      * <code>repeated .google.cloud.pubsublite.v1.Topic topics = 1;</code>
      */
-    public com.google.cloud.pubsublite.proto.Topic.Builder getTopicsBuilder(
-        int index) {
+    public com.google.cloud.pubsublite.proto.Topic.Builder getTopicsBuilder(int index) {
       return getTopicsFieldBuilder().getBuilder(index);
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -829,14 +888,16 @@ private static final long serialVersionUID = 0L;
      *
      * <code>repeated .google.cloud.pubsublite.v1.Topic topics = 1;</code>
      */
-    public com.google.cloud.pubsublite.proto.TopicOrBuilder getTopicsOrBuilder(
-        int index) {
+    public com.google.cloud.pubsublite.proto.TopicOrBuilder getTopicsOrBuilder(int index) {
       if (topicsBuilder_ == null) {
-        return topics_.get(index);  } else {
+        return topics_.get(index);
+      } else {
         return topicsBuilder_.getMessageOrBuilder(index);
       }
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -844,8 +905,8 @@ private static final long serialVersionUID = 0L;
      *
      * <code>repeated .google.cloud.pubsublite.v1.Topic topics = 1;</code>
      */
-    public java.util.List<? extends com.google.cloud.pubsublite.proto.TopicOrBuilder> 
-         getTopicsOrBuilderList() {
+    public java.util.List<? extends com.google.cloud.pubsublite.proto.TopicOrBuilder>
+        getTopicsOrBuilderList() {
       if (topicsBuilder_ != null) {
         return topicsBuilder_.getMessageOrBuilderList();
       } else {
@@ -853,6 +914,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -861,10 +924,12 @@ private static final long serialVersionUID = 0L;
      * <code>repeated .google.cloud.pubsublite.v1.Topic topics = 1;</code>
      */
     public com.google.cloud.pubsublite.proto.Topic.Builder addTopicsBuilder() {
-      return getTopicsFieldBuilder().addBuilder(
-          com.google.cloud.pubsublite.proto.Topic.getDefaultInstance());
+      return getTopicsFieldBuilder()
+          .addBuilder(com.google.cloud.pubsublite.proto.Topic.getDefaultInstance());
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -872,12 +937,13 @@ private static final long serialVersionUID = 0L;
      *
      * <code>repeated .google.cloud.pubsublite.v1.Topic topics = 1;</code>
      */
-    public com.google.cloud.pubsublite.proto.Topic.Builder addTopicsBuilder(
-        int index) {
-      return getTopicsFieldBuilder().addBuilder(
-          index, com.google.cloud.pubsublite.proto.Topic.getDefaultInstance());
+    public com.google.cloud.pubsublite.proto.Topic.Builder addTopicsBuilder(int index) {
+      return getTopicsFieldBuilder()
+          .addBuilder(index, com.google.cloud.pubsublite.proto.Topic.getDefaultInstance());
     }
     /**
+     *
+     *
      * <pre>
      * The list of topic in the requested parent. The order of the topics is
      * unspecified.
@@ -885,20 +951,22 @@ private static final long serialVersionUID = 0L;
      *
      * <code>repeated .google.cloud.pubsublite.v1.Topic topics = 1;</code>
      */
-    public java.util.List<com.google.cloud.pubsublite.proto.Topic.Builder> 
-         getTopicsBuilderList() {
+    public java.util.List<com.google.cloud.pubsublite.proto.Topic.Builder> getTopicsBuilderList() {
       return getTopicsFieldBuilder().getBuilderList();
     }
+
     private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Topic, com.google.cloud.pubsublite.proto.Topic.Builder, com.google.cloud.pubsublite.proto.TopicOrBuilder> 
+            com.google.cloud.pubsublite.proto.Topic,
+            com.google.cloud.pubsublite.proto.Topic.Builder,
+            com.google.cloud.pubsublite.proto.TopicOrBuilder>
         getTopicsFieldBuilder() {
       if (topicsBuilder_ == null) {
-        topicsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Topic, com.google.cloud.pubsublite.proto.Topic.Builder, com.google.cloud.pubsublite.proto.TopicOrBuilder>(
-                topics_,
-                ((bitField0_ & 0x00000001) != 0),
-                getParentForChildren(),
-                isClean());
+        topicsBuilder_ =
+            new com.google.protobuf.RepeatedFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Topic,
+                com.google.cloud.pubsublite.proto.Topic.Builder,
+                com.google.cloud.pubsublite.proto.TopicOrBuilder>(
+                topics_, ((bitField0_ & 0x00000001) != 0), getParentForChildren(), isClean());
         topics_ = null;
       }
       return topicsBuilder_;
@@ -906,19 +974,21 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object nextPageToken_ = "";
     /**
+     *
+     *
      * <pre>
      * A token that can be sent as `page_token` to retrieve the next page of
      * results. If this field is omitted, there are no more results.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @return The nextPageToken.
      */
     public java.lang.String getNextPageToken() {
       java.lang.Object ref = nextPageToken_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         nextPageToken_ = s;
         return s;
@@ -927,21 +997,22 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A token that can be sent as `page_token` to retrieve the next page of
      * results. If this field is omitted, there are no more results.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @return The bytes for nextPageToken.
      */
-    public com.google.protobuf.ByteString
-        getNextPageTokenBytes() {
+    public com.google.protobuf.ByteString getNextPageTokenBytes() {
       java.lang.Object ref = nextPageToken_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         nextPageToken_ = b;
         return b;
       } else {
@@ -949,64 +1020,71 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A token that can be sent as `page_token` to retrieve the next page of
      * results. If this field is omitted, there are no more results.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @param value The nextPageToken to set.
      * @return This builder for chaining.
      */
-    public Builder setNextPageToken(
-        java.lang.String value) {
+    public Builder setNextPageToken(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       nextPageToken_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A token that can be sent as `page_token` to retrieve the next page of
      * results. If this field is omitted, there are no more results.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearNextPageToken() {
-      
+
       nextPageToken_ = getDefaultInstance().getNextPageToken();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A token that can be sent as `page_token` to retrieve the next page of
      * results. If this field is omitted, there are no more results.
      * </pre>
      *
      * <code>string next_page_token = 2;</code>
+     *
      * @param value The bytes for nextPageToken to set.
      * @return This builder for chaining.
      */
-    public Builder setNextPageTokenBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setNextPageTokenBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       nextPageToken_ = value;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -1016,12 +1094,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.ListTopicsResponse)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.ListTopicsResponse)
   private static final com.google.cloud.pubsublite.proto.ListTopicsResponse DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.ListTopicsResponse();
   }
@@ -1030,16 +1108,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<ListTopicsResponse>
-      PARSER = new com.google.protobuf.AbstractParser<ListTopicsResponse>() {
-    @java.lang.Override
-    public ListTopicsResponse parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new ListTopicsResponse(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<ListTopicsResponse> PARSER =
+      new com.google.protobuf.AbstractParser<ListTopicsResponse>() {
+        @java.lang.Override
+        public ListTopicsResponse parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new ListTopicsResponse(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<ListTopicsResponse> parser() {
     return PARSER;
@@ -1054,6 +1132,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.ListTopicsResponse getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListTopicsResponseOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/ListTopicsResponseOrBuilder.java
@@ -3,11 +3,14 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface ListTopicsResponseOrBuilder extends
+public interface ListTopicsResponseOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.ListTopicsResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The list of topic in the requested parent. The order of the topics is
    * unspecified.
@@ -15,9 +18,10 @@ public interface ListTopicsResponseOrBuilder extends
    *
    * <code>repeated .google.cloud.pubsublite.v1.Topic topics = 1;</code>
    */
-  java.util.List<com.google.cloud.pubsublite.proto.Topic> 
-      getTopicsList();
+  java.util.List<com.google.cloud.pubsublite.proto.Topic> getTopicsList();
   /**
+   *
+   *
    * <pre>
    * The list of topic in the requested parent. The order of the topics is
    * unspecified.
@@ -27,6 +31,8 @@ public interface ListTopicsResponseOrBuilder extends
    */
   com.google.cloud.pubsublite.proto.Topic getTopics(int index);
   /**
+   *
+   *
    * <pre>
    * The list of topic in the requested parent. The order of the topics is
    * unspecified.
@@ -36,6 +42,8 @@ public interface ListTopicsResponseOrBuilder extends
    */
   int getTopicsCount();
   /**
+   *
+   *
    * <pre>
    * The list of topic in the requested parent. The order of the topics is
    * unspecified.
@@ -43,9 +51,11 @@ public interface ListTopicsResponseOrBuilder extends
    *
    * <code>repeated .google.cloud.pubsublite.v1.Topic topics = 1;</code>
    */
-  java.util.List<? extends com.google.cloud.pubsublite.proto.TopicOrBuilder> 
+  java.util.List<? extends com.google.cloud.pubsublite.proto.TopicOrBuilder>
       getTopicsOrBuilderList();
   /**
+   *
+   *
    * <pre>
    * The list of topic in the requested parent. The order of the topics is
    * unspecified.
@@ -53,28 +63,32 @@ public interface ListTopicsResponseOrBuilder extends
    *
    * <code>repeated .google.cloud.pubsublite.v1.Topic topics = 1;</code>
    */
-  com.google.cloud.pubsublite.proto.TopicOrBuilder getTopicsOrBuilder(
-      int index);
+  com.google.cloud.pubsublite.proto.TopicOrBuilder getTopicsOrBuilder(int index);
 
   /**
+   *
+   *
    * <pre>
    * A token that can be sent as `page_token` to retrieve the next page of
    * results. If this field is omitted, there are no more results.
    * </pre>
    *
    * <code>string next_page_token = 2;</code>
+   *
    * @return The nextPageToken.
    */
   java.lang.String getNextPageToken();
   /**
+   *
+   *
    * <pre>
    * A token that can be sent as `page_token` to retrieve the next page of
    * results. If this field is omitted, there are no more results.
    * </pre>
    *
    * <code>string next_page_token = 2;</code>
+   *
    * @return The bytes for nextPageToken.
    */
-  com.google.protobuf.ByteString
-      getNextPageTokenBytes();
+  com.google.protobuf.ByteString getNextPageTokenBytes();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/MessagePublishRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/MessagePublishRequest.java
@@ -4,37 +4,39 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request to publish messages to the topic.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.MessagePublishRequest}
  */
-public  final class MessagePublishRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class MessagePublishRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.MessagePublishRequest)
     MessagePublishRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use MessagePublishRequest.newBuilder() to construct.
   private MessagePublishRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private MessagePublishRequest() {
     messages_ = java.util.Collections.emptyList();
   }
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new MessagePublishRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private MessagePublishRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -54,29 +56,31 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-              messages_ = new java.util.ArrayList<com.google.cloud.pubsublite.proto.PubSubMessage>();
-              mutable_bitField0_ |= 0x00000001;
+          case 10:
+            {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                messages_ =
+                    new java.util.ArrayList<com.google.cloud.pubsublite.proto.PubSubMessage>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              messages_.add(
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.PubSubMessage.parser(), extensionRegistry));
+              break;
             }
-            messages_.add(
-                input.readMessage(com.google.cloud.pubsublite.proto.PubSubMessage.parser(), extensionRegistry));
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
             }
-            break;
-          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       if (((mutable_bitField0_ & 0x00000001) != 0)) {
         messages_ = java.util.Collections.unmodifiableList(messages_);
@@ -85,55 +89,48 @@ private static final long serialVersionUID = 0L;
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.PublisherProto
+        .internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.PublisherProto
+        .internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.MessagePublishRequest.class, com.google.cloud.pubsublite.proto.MessagePublishRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.MessagePublishRequest.class,
+            com.google.cloud.pubsublite.proto.MessagePublishRequest.Builder.class);
   }
 
   public static final int MESSAGES_FIELD_NUMBER = 1;
   private java.util.List<com.google.cloud.pubsublite.proto.PubSubMessage> messages_;
-  /**
-   * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-   */
+  /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
   public java.util.List<com.google.cloud.pubsublite.proto.PubSubMessage> getMessagesList() {
     return messages_;
   }
-  /**
-   * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-   */
-  public java.util.List<? extends com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder> 
+  /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
+  public java.util.List<? extends com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder>
       getMessagesOrBuilderList() {
     return messages_;
   }
-  /**
-   * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-   */
+  /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
   public int getMessagesCount() {
     return messages_.size();
   }
-  /**
-   * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-   */
+  /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
   public com.google.cloud.pubsublite.proto.PubSubMessage getMessages(int index) {
     return messages_.get(index);
   }
-  /**
-   * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-   */
-  public com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder getMessagesOrBuilder(
-      int index) {
+  /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
+  public com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder getMessagesOrBuilder(int index) {
     return messages_.get(index);
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -145,8 +142,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     for (int i = 0; i < messages_.size(); i++) {
       output.writeMessage(1, messages_.get(i));
     }
@@ -160,8 +156,7 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     for (int i = 0; i < messages_.size(); i++) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, messages_.get(i));
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(1, messages_.get(i));
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -171,15 +166,15 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.MessagePublishRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.MessagePublishRequest other = (com.google.cloud.pubsublite.proto.MessagePublishRequest) obj;
+    com.google.cloud.pubsublite.proto.MessagePublishRequest other =
+        (com.google.cloud.pubsublite.proto.MessagePublishRequest) obj;
 
-    if (!getMessagesList()
-        .equals(other.getMessagesList())) return false;
+    if (!getMessagesList().equals(other.getMessagesList())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -201,117 +196,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.MessagePublishRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.MessagePublishRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.MessagePublishRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.MessagePublishRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.MessagePublishRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.MessagePublishRequest prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.MessagePublishRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request to publish messages to the topic.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.MessagePublishRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.MessagePublishRequest)
       com.google.cloud.pubsublite.proto.MessagePublishRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.MessagePublishRequest.class, com.google.cloud.pubsublite.proto.MessagePublishRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.MessagePublishRequest.class,
+              com.google.cloud.pubsublite.proto.MessagePublishRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.MessagePublishRequest.newBuilder()
@@ -319,17 +324,17 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {
         getMessagesFieldBuilder();
       }
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -343,9 +348,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_descriptor;
     }
 
     @java.lang.Override
@@ -364,7 +369,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.MessagePublishRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.MessagePublishRequest result = new com.google.cloud.pubsublite.proto.MessagePublishRequest(this);
+      com.google.cloud.pubsublite.proto.MessagePublishRequest result =
+          new com.google.cloud.pubsublite.proto.MessagePublishRequest(this);
       int from_bitField0_ = bitField0_;
       if (messagesBuilder_ == null) {
         if (((bitField0_ & 0x00000001) != 0)) {
@@ -383,38 +389,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.MessagePublishRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.MessagePublishRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.MessagePublishRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -422,7 +429,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.MessagePublishRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.MessagePublishRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.MessagePublishRequest.getDefaultInstance())
+        return this;
       if (messagesBuilder_ == null) {
         if (!other.messages_.isEmpty()) {
           if (messages_.isEmpty()) {
@@ -441,9 +449,10 @@ private static final long serialVersionUID = 0L;
             messagesBuilder_ = null;
             messages_ = other.messages_;
             bitField0_ = (bitField0_ & ~0x00000001);
-            messagesBuilder_ = 
-              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
-                 getMessagesFieldBuilder() : null;
+            messagesBuilder_ =
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders
+                    ? getMessagesFieldBuilder()
+                    : null;
           } else {
             messagesBuilder_.addAllMessages(other.messages_);
           }
@@ -468,7 +477,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.MessagePublishRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.MessagePublishRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -477,23 +487,27 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     private int bitField0_;
 
     private java.util.List<com.google.cloud.pubsublite.proto.PubSubMessage> messages_ =
-      java.util.Collections.emptyList();
+        java.util.Collections.emptyList();
+
     private void ensureMessagesIsMutable() {
       if (!((bitField0_ & 0x00000001) != 0)) {
-        messages_ = new java.util.ArrayList<com.google.cloud.pubsublite.proto.PubSubMessage>(messages_);
+        messages_ =
+            new java.util.ArrayList<com.google.cloud.pubsublite.proto.PubSubMessage>(messages_);
         bitField0_ |= 0x00000001;
-       }
+      }
     }
 
     private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.PubSubMessage, com.google.cloud.pubsublite.proto.PubSubMessage.Builder, com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder> messagesBuilder_;
+            com.google.cloud.pubsublite.proto.PubSubMessage,
+            com.google.cloud.pubsublite.proto.PubSubMessage.Builder,
+            com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder>
+        messagesBuilder_;
 
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
     public java.util.List<com.google.cloud.pubsublite.proto.PubSubMessage> getMessagesList() {
       if (messagesBuilder_ == null) {
         return java.util.Collections.unmodifiableList(messages_);
@@ -501,9 +515,7 @@ private static final long serialVersionUID = 0L;
         return messagesBuilder_.getMessageList();
       }
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
     public int getMessagesCount() {
       if (messagesBuilder_ == null) {
         return messages_.size();
@@ -511,9 +523,7 @@ private static final long serialVersionUID = 0L;
         return messagesBuilder_.getCount();
       }
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
     public com.google.cloud.pubsublite.proto.PubSubMessage getMessages(int index) {
       if (messagesBuilder_ == null) {
         return messages_.get(index);
@@ -521,11 +531,8 @@ private static final long serialVersionUID = 0L;
         return messagesBuilder_.getMessage(index);
       }
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
-    public Builder setMessages(
-        int index, com.google.cloud.pubsublite.proto.PubSubMessage value) {
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
+    public Builder setMessages(int index, com.google.cloud.pubsublite.proto.PubSubMessage value) {
       if (messagesBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
@@ -538,9 +545,7 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
     public Builder setMessages(
         int index, com.google.cloud.pubsublite.proto.PubSubMessage.Builder builderForValue) {
       if (messagesBuilder_ == null) {
@@ -552,9 +557,7 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
     public Builder addMessages(com.google.cloud.pubsublite.proto.PubSubMessage value) {
       if (messagesBuilder_ == null) {
         if (value == null) {
@@ -568,11 +571,8 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
-    public Builder addMessages(
-        int index, com.google.cloud.pubsublite.proto.PubSubMessage value) {
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
+    public Builder addMessages(int index, com.google.cloud.pubsublite.proto.PubSubMessage value) {
       if (messagesBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
@@ -585,9 +585,7 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
     public Builder addMessages(
         com.google.cloud.pubsublite.proto.PubSubMessage.Builder builderForValue) {
       if (messagesBuilder_ == null) {
@@ -599,9 +597,7 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
     public Builder addMessages(
         int index, com.google.cloud.pubsublite.proto.PubSubMessage.Builder builderForValue) {
       if (messagesBuilder_ == null) {
@@ -613,24 +609,19 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
     public Builder addAllMessages(
         java.lang.Iterable<? extends com.google.cloud.pubsublite.proto.PubSubMessage> values) {
       if (messagesBuilder_ == null) {
         ensureMessagesIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, messages_);
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(values, messages_);
         onChanged();
       } else {
         messagesBuilder_.addAllMessages(values);
       }
       return this;
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
     public Builder clearMessages() {
       if (messagesBuilder_ == null) {
         messages_ = java.util.Collections.emptyList();
@@ -641,9 +632,7 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
     public Builder removeMessages(int index) {
       if (messagesBuilder_ == null) {
         ensureMessagesIsMutable();
@@ -654,73 +643,63 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
-    public com.google.cloud.pubsublite.proto.PubSubMessage.Builder getMessagesBuilder(
-        int index) {
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
+    public com.google.cloud.pubsublite.proto.PubSubMessage.Builder getMessagesBuilder(int index) {
       return getMessagesFieldBuilder().getBuilder(index);
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
     public com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder getMessagesOrBuilder(
         int index) {
       if (messagesBuilder_ == null) {
-        return messages_.get(index);  } else {
+        return messages_.get(index);
+      } else {
         return messagesBuilder_.getMessageOrBuilder(index);
       }
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
-    public java.util.List<? extends com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder> 
-         getMessagesOrBuilderList() {
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
+    public java.util.List<? extends com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder>
+        getMessagesOrBuilderList() {
       if (messagesBuilder_ != null) {
         return messagesBuilder_.getMessageOrBuilderList();
       } else {
         return java.util.Collections.unmodifiableList(messages_);
       }
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
     public com.google.cloud.pubsublite.proto.PubSubMessage.Builder addMessagesBuilder() {
-      return getMessagesFieldBuilder().addBuilder(
-          com.google.cloud.pubsublite.proto.PubSubMessage.getDefaultInstance());
+      return getMessagesFieldBuilder()
+          .addBuilder(com.google.cloud.pubsublite.proto.PubSubMessage.getDefaultInstance());
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
-    public com.google.cloud.pubsublite.proto.PubSubMessage.Builder addMessagesBuilder(
-        int index) {
-      return getMessagesFieldBuilder().addBuilder(
-          index, com.google.cloud.pubsublite.proto.PubSubMessage.getDefaultInstance());
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
+    public com.google.cloud.pubsublite.proto.PubSubMessage.Builder addMessagesBuilder(int index) {
+      return getMessagesFieldBuilder()
+          .addBuilder(index, com.google.cloud.pubsublite.proto.PubSubMessage.getDefaultInstance());
     }
-    /**
-     * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-     */
-    public java.util.List<com.google.cloud.pubsublite.proto.PubSubMessage.Builder> 
-         getMessagesBuilderList() {
+    /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
+    public java.util.List<com.google.cloud.pubsublite.proto.PubSubMessage.Builder>
+        getMessagesBuilderList() {
       return getMessagesFieldBuilder().getBuilderList();
     }
+
     private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.PubSubMessage, com.google.cloud.pubsublite.proto.PubSubMessage.Builder, com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder> 
+            com.google.cloud.pubsublite.proto.PubSubMessage,
+            com.google.cloud.pubsublite.proto.PubSubMessage.Builder,
+            com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder>
         getMessagesFieldBuilder() {
       if (messagesBuilder_ == null) {
-        messagesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.PubSubMessage, com.google.cloud.pubsublite.proto.PubSubMessage.Builder, com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder>(
-                messages_,
-                ((bitField0_ & 0x00000001) != 0),
-                getParentForChildren(),
-                isClean());
+        messagesBuilder_ =
+            new com.google.protobuf.RepeatedFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.PubSubMessage,
+                com.google.cloud.pubsublite.proto.PubSubMessage.Builder,
+                com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder>(
+                messages_, ((bitField0_ & 0x00000001) != 0), getParentForChildren(), isClean());
         messages_ = null;
       }
       return messagesBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -730,12 +709,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.MessagePublishRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.MessagePublishRequest)
   private static final com.google.cloud.pubsublite.proto.MessagePublishRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.MessagePublishRequest();
   }
@@ -744,16 +723,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<MessagePublishRequest>
-      PARSER = new com.google.protobuf.AbstractParser<MessagePublishRequest>() {
-    @java.lang.Override
-    public MessagePublishRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new MessagePublishRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<MessagePublishRequest> PARSER =
+      new com.google.protobuf.AbstractParser<MessagePublishRequest>() {
+        @java.lang.Override
+        public MessagePublishRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new MessagePublishRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<MessagePublishRequest> parser() {
     return PARSER;
@@ -768,6 +747,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.MessagePublishRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/MessagePublishRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/MessagePublishRequestOrBuilder.java
@@ -3,31 +3,20 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface MessagePublishRequestOrBuilder extends
+public interface MessagePublishRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.MessagePublishRequest)
     com.google.protobuf.MessageOrBuilder {
 
-  /**
-   * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-   */
-  java.util.List<com.google.cloud.pubsublite.proto.PubSubMessage> 
-      getMessagesList();
-  /**
-   * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-   */
+  /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
+  java.util.List<com.google.cloud.pubsublite.proto.PubSubMessage> getMessagesList();
+  /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
   com.google.cloud.pubsublite.proto.PubSubMessage getMessages(int index);
-  /**
-   * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-   */
+  /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
   int getMessagesCount();
-  /**
-   * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-   */
-  java.util.List<? extends com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder> 
+  /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
+  java.util.List<? extends com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder>
       getMessagesOrBuilderList();
-  /**
-   * <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code>
-   */
-  com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder getMessagesOrBuilder(
-      int index);
+  /** <code>repeated .google.cloud.pubsublite.v1.PubSubMessage messages = 1;</code> */
+  com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder getMessagesOrBuilder(int index);
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/MessagePublishResponse.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/MessagePublishResponse.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Response to a MessagePublishRequest.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.MessagePublishResponse}
  */
-public  final class MessagePublishResponse extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class MessagePublishResponse extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.MessagePublishResponse)
     MessagePublishResponseOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use MessagePublishResponse.newBuilder() to construct.
   private MessagePublishResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private MessagePublishResponse() {
-  }
+
+  private MessagePublishResponse() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new MessagePublishResponse();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private MessagePublishResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,78 +53,93 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            com.google.cloud.pubsublite.proto.Cursor.Builder subBuilder = null;
-            if (startCursor_ != null) {
-              subBuilder = startCursor_.toBuilder();
-            }
-            startCursor_ = input.readMessage(com.google.cloud.pubsublite.proto.Cursor.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(startCursor_);
-              startCursor_ = subBuilder.buildPartial();
-            }
+          case 10:
+            {
+              com.google.cloud.pubsublite.proto.Cursor.Builder subBuilder = null;
+              if (startCursor_ != null) {
+                subBuilder = startCursor_.toBuilder();
+              }
+              startCursor_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Cursor.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(startCursor_);
+                startCursor_ = subBuilder.buildPartial();
+              }
 
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.PublisherProto
+        .internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.PublisherProto
+        .internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.MessagePublishResponse.class, com.google.cloud.pubsublite.proto.MessagePublishResponse.Builder.class);
+            com.google.cloud.pubsublite.proto.MessagePublishResponse.class,
+            com.google.cloud.pubsublite.proto.MessagePublishResponse.Builder.class);
   }
 
   public static final int START_CURSOR_FIELD_NUMBER = 1;
   private com.google.cloud.pubsublite.proto.Cursor startCursor_;
   /**
+   *
+   *
    * <pre>
    * The cursor of the first published message in the batch. The cursors for any
    * remaining messages in the batch are guaranteed to be sequential.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor start_cursor = 1;</code>
+   *
    * @return Whether the startCursor field is set.
    */
   public boolean hasStartCursor() {
     return startCursor_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * The cursor of the first published message in the batch. The cursors for any
    * remaining messages in the batch are guaranteed to be sequential.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor start_cursor = 1;</code>
+   *
    * @return The startCursor.
    */
   public com.google.cloud.pubsublite.proto.Cursor getStartCursor() {
-    return startCursor_ == null ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : startCursor_;
+    return startCursor_ == null
+        ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+        : startCursor_;
   }
   /**
+   *
+   *
    * <pre>
    * The cursor of the first published message in the batch. The cursors for any
    * remaining messages in the batch are guaranteed to be sequential.
@@ -136,6 +152,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -147,8 +164,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (startCursor_ != null) {
       output.writeMessage(1, getStartCursor());
     }
@@ -162,8 +178,7 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (startCursor_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, getStartCursor());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(1, getStartCursor());
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -173,17 +188,17 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.MessagePublishResponse)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.MessagePublishResponse other = (com.google.cloud.pubsublite.proto.MessagePublishResponse) obj;
+    com.google.cloud.pubsublite.proto.MessagePublishResponse other =
+        (com.google.cloud.pubsublite.proto.MessagePublishResponse) obj;
 
     if (hasStartCursor() != other.hasStartCursor()) return false;
     if (hasStartCursor()) {
-      if (!getStartCursor()
-          .equals(other.getStartCursor())) return false;
+      if (!getStartCursor().equals(other.getStartCursor())) return false;
     }
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
@@ -206,117 +221,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.MessagePublishResponse parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishResponse parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishResponse parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishResponse parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishResponse parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.MessagePublishResponse parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishResponse parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.MessagePublishResponse parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.MessagePublishResponse parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishResponse parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.MessagePublishResponse parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishResponse parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.MessagePublishResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.MessagePublishResponse prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.MessagePublishResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Response to a MessagePublishRequest.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.MessagePublishResponse}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.MessagePublishResponse)
       com.google.cloud.pubsublite.proto.MessagePublishResponseOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.MessagePublishResponse.class, com.google.cloud.pubsublite.proto.MessagePublishResponse.Builder.class);
+              com.google.cloud.pubsublite.proto.MessagePublishResponse.class,
+              com.google.cloud.pubsublite.proto.MessagePublishResponse.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.MessagePublishResponse.newBuilder()
@@ -324,16 +349,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -347,9 +371,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_descriptor;
     }
 
     @java.lang.Override
@@ -368,7 +392,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.MessagePublishResponse buildPartial() {
-      com.google.cloud.pubsublite.proto.MessagePublishResponse result = new com.google.cloud.pubsublite.proto.MessagePublishResponse(this);
+      com.google.cloud.pubsublite.proto.MessagePublishResponse result =
+          new com.google.cloud.pubsublite.proto.MessagePublishResponse(this);
       if (startCursorBuilder_ == null) {
         result.startCursor_ = startCursor_;
       } else {
@@ -382,38 +407,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.MessagePublishResponse) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.MessagePublishResponse)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.MessagePublishResponse) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -421,7 +447,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.MessagePublishResponse other) {
-      if (other == com.google.cloud.pubsublite.proto.MessagePublishResponse.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.MessagePublishResponse.getDefaultInstance())
+        return this;
       if (other.hasStartCursor()) {
         mergeStartCursor(other.getStartCursor());
       }
@@ -444,7 +471,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.MessagePublishResponse) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.MessagePublishResponse) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -456,36 +484,49 @@ private static final long serialVersionUID = 0L;
 
     private com.google.cloud.pubsublite.proto.Cursor startCursor_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder> startCursorBuilder_;
+            com.google.cloud.pubsublite.proto.Cursor,
+            com.google.cloud.pubsublite.proto.Cursor.Builder,
+            com.google.cloud.pubsublite.proto.CursorOrBuilder>
+        startCursorBuilder_;
     /**
+     *
+     *
      * <pre>
      * The cursor of the first published message in the batch. The cursors for any
      * remaining messages in the batch are guaranteed to be sequential.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor start_cursor = 1;</code>
+     *
      * @return Whether the startCursor field is set.
      */
     public boolean hasStartCursor() {
       return startCursorBuilder_ != null || startCursor_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * The cursor of the first published message in the batch. The cursors for any
      * remaining messages in the batch are guaranteed to be sequential.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor start_cursor = 1;</code>
+     *
      * @return The startCursor.
      */
     public com.google.cloud.pubsublite.proto.Cursor getStartCursor() {
       if (startCursorBuilder_ == null) {
-        return startCursor_ == null ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : startCursor_;
+        return startCursor_ == null
+            ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+            : startCursor_;
       } else {
         return startCursorBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * The cursor of the first published message in the batch. The cursors for any
      * remaining messages in the batch are guaranteed to be sequential.
@@ -507,6 +548,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The cursor of the first published message in the batch. The cursors for any
      * remaining messages in the batch are guaranteed to be sequential.
@@ -526,6 +569,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The cursor of the first published message in the batch. The cursors for any
      * remaining messages in the batch are guaranteed to be sequential.
@@ -537,7 +582,9 @@ private static final long serialVersionUID = 0L;
       if (startCursorBuilder_ == null) {
         if (startCursor_ != null) {
           startCursor_ =
-            com.google.cloud.pubsublite.proto.Cursor.newBuilder(startCursor_).mergeFrom(value).buildPartial();
+              com.google.cloud.pubsublite.proto.Cursor.newBuilder(startCursor_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           startCursor_ = value;
         }
@@ -549,6 +596,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The cursor of the first published message in the batch. The cursors for any
      * remaining messages in the batch are guaranteed to be sequential.
@@ -568,6 +617,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The cursor of the first published message in the batch. The cursors for any
      * remaining messages in the batch are guaranteed to be sequential.
@@ -576,11 +627,13 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Cursor start_cursor = 1;</code>
      */
     public com.google.cloud.pubsublite.proto.Cursor.Builder getStartCursorBuilder() {
-      
+
       onChanged();
       return getStartCursorFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * The cursor of the first published message in the batch. The cursors for any
      * remaining messages in the batch are guaranteed to be sequential.
@@ -592,11 +645,14 @@ private static final long serialVersionUID = 0L;
       if (startCursorBuilder_ != null) {
         return startCursorBuilder_.getMessageOrBuilder();
       } else {
-        return startCursor_ == null ?
-            com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : startCursor_;
+        return startCursor_ == null
+            ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+            : startCursor_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The cursor of the first published message in the batch. The cursors for any
      * remaining messages in the batch are guaranteed to be sequential.
@@ -605,21 +661,24 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Cursor start_cursor = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder> 
+            com.google.cloud.pubsublite.proto.Cursor,
+            com.google.cloud.pubsublite.proto.Cursor.Builder,
+            com.google.cloud.pubsublite.proto.CursorOrBuilder>
         getStartCursorFieldBuilder() {
       if (startCursorBuilder_ == null) {
-        startCursorBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder>(
-                getStartCursor(),
-                getParentForChildren(),
-                isClean());
+        startCursorBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Cursor,
+                com.google.cloud.pubsublite.proto.Cursor.Builder,
+                com.google.cloud.pubsublite.proto.CursorOrBuilder>(
+                getStartCursor(), getParentForChildren(), isClean());
         startCursor_ = null;
       }
       return startCursorBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -629,12 +688,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.MessagePublishResponse)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.MessagePublishResponse)
   private static final com.google.cloud.pubsublite.proto.MessagePublishResponse DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.MessagePublishResponse();
   }
@@ -643,16 +702,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<MessagePublishResponse>
-      PARSER = new com.google.protobuf.AbstractParser<MessagePublishResponse>() {
-    @java.lang.Override
-    public MessagePublishResponse parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new MessagePublishResponse(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<MessagePublishResponse> PARSER =
+      new com.google.protobuf.AbstractParser<MessagePublishResponse>() {
+        @java.lang.Override
+        public MessagePublishResponse parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new MessagePublishResponse(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<MessagePublishResponse> parser() {
     return PARSER;
@@ -667,6 +726,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.MessagePublishResponse getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/MessagePublishResponseOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/MessagePublishResponseOrBuilder.java
@@ -3,31 +3,40 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface MessagePublishResponseOrBuilder extends
+public interface MessagePublishResponseOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.MessagePublishResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The cursor of the first published message in the batch. The cursors for any
    * remaining messages in the batch are guaranteed to be sequential.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor start_cursor = 1;</code>
+   *
    * @return Whether the startCursor field is set.
    */
   boolean hasStartCursor();
   /**
+   *
+   *
    * <pre>
    * The cursor of the first published message in the batch. The cursors for any
    * remaining messages in the batch are guaranteed to be sequential.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor start_cursor = 1;</code>
+   *
    * @return The startCursor.
    */
   com.google.cloud.pubsublite.proto.Cursor getStartCursor();
   /**
+   *
+   *
    * <pre>
    * The cursor of the first published message in the batch. The cursors for any
    * remaining messages in the batch are guaranteed to be sequential.

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/MessageResponse.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/MessageResponse.java
@@ -4,6 +4,8 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Response containing a list of messages. Upon delivering a MessageResponse to
  * the client, the server:
@@ -15,31 +17,31 @@ package com.google.cloud.pubsublite.proto;
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.MessageResponse}
  */
-public  final class MessageResponse extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class MessageResponse extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.MessageResponse)
     MessageResponseOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use MessageResponse.newBuilder() to construct.
   private MessageResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private MessageResponse() {
     messages_ = java.util.Collections.emptyList();
   }
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new MessageResponse();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private MessageResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -59,29 +61,32 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-              messages_ = new java.util.ArrayList<com.google.cloud.pubsublite.proto.SequencedMessage>();
-              mutable_bitField0_ |= 0x00000001;
+          case 10:
+            {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                messages_ =
+                    new java.util.ArrayList<com.google.cloud.pubsublite.proto.SequencedMessage>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              messages_.add(
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.SequencedMessage.parser(),
+                      extensionRegistry));
+              break;
             }
-            messages_.add(
-                input.readMessage(com.google.cloud.pubsublite.proto.SequencedMessage.parser(), extensionRegistry));
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
             }
-            break;
-          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       if (((mutable_bitField0_ & 0x00000001) != 0)) {
         messages_ = java.util.Collections.unmodifiableList(messages_);
@@ -90,22 +95,27 @@ private static final long serialVersionUID = 0L;
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_MessageResponse_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.SubscriberProto
+        .internal_static_google_cloud_pubsublite_v1_MessageResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_MessageResponse_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.SubscriberProto
+        .internal_static_google_cloud_pubsublite_v1_MessageResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.MessageResponse.class, com.google.cloud.pubsublite.proto.MessageResponse.Builder.class);
+            com.google.cloud.pubsublite.proto.MessageResponse.class,
+            com.google.cloud.pubsublite.proto.MessageResponse.Builder.class);
   }
 
   public static final int MESSAGES_FIELD_NUMBER = 1;
   private java.util.List<com.google.cloud.pubsublite.proto.SequencedMessage> messages_;
   /**
+   *
+   *
    * <pre>
    * Messages from the topic partition.
    * </pre>
@@ -116,17 +126,21 @@ private static final long serialVersionUID = 0L;
     return messages_;
   }
   /**
+   *
+   *
    * <pre>
    * Messages from the topic partition.
    * </pre>
    *
    * <code>repeated .google.cloud.pubsublite.v1.SequencedMessage messages = 1;</code>
    */
-  public java.util.List<? extends com.google.cloud.pubsublite.proto.SequencedMessageOrBuilder> 
+  public java.util.List<? extends com.google.cloud.pubsublite.proto.SequencedMessageOrBuilder>
       getMessagesOrBuilderList() {
     return messages_;
   }
   /**
+   *
+   *
    * <pre>
    * Messages from the topic partition.
    * </pre>
@@ -137,6 +151,8 @@ private static final long serialVersionUID = 0L;
     return messages_.size();
   }
   /**
+   *
+   *
    * <pre>
    * Messages from the topic partition.
    * </pre>
@@ -147,6 +163,8 @@ private static final long serialVersionUID = 0L;
     return messages_.get(index);
   }
   /**
+   *
+   *
    * <pre>
    * Messages from the topic partition.
    * </pre>
@@ -159,6 +177,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -170,8 +189,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     for (int i = 0; i < messages_.size(); i++) {
       output.writeMessage(1, messages_.get(i));
     }
@@ -185,8 +203,7 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     for (int i = 0; i < messages_.size(); i++) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, messages_.get(i));
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(1, messages_.get(i));
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -196,15 +213,15 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.MessageResponse)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.MessageResponse other = (com.google.cloud.pubsublite.proto.MessageResponse) obj;
+    com.google.cloud.pubsublite.proto.MessageResponse other =
+        (com.google.cloud.pubsublite.proto.MessageResponse) obj;
 
-    if (!getMessagesList()
-        .equals(other.getMessagesList())) return false;
+    if (!getMessagesList().equals(other.getMessagesList())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -226,96 +243,103 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.MessageResponse parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.MessageResponse parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.MessageResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.MessageResponse parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.MessageResponse parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.MessageResponse parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.MessageResponse parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.MessageResponse parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.MessageResponse parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.MessageResponse parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.MessageResponse parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.MessageResponse parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.MessageResponse parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.MessageResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.MessageResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Response containing a list of messages. Upon delivering a MessageResponse to
    * the client, the server:
@@ -327,21 +351,23 @@ private static final long serialVersionUID = 0L;
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.MessageResponse}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.MessageResponse)
       com.google.cloud.pubsublite.proto.MessageResponseOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_MessageResponse_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_MessageResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_MessageResponse_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_MessageResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.MessageResponse.class, com.google.cloud.pubsublite.proto.MessageResponse.Builder.class);
+              com.google.cloud.pubsublite.proto.MessageResponse.class,
+              com.google.cloud.pubsublite.proto.MessageResponse.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.MessageResponse.newBuilder()
@@ -349,17 +375,17 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {
         getMessagesFieldBuilder();
       }
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -373,9 +399,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_MessageResponse_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_MessageResponse_descriptor;
     }
 
     @java.lang.Override
@@ -394,7 +420,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.MessageResponse buildPartial() {
-      com.google.cloud.pubsublite.proto.MessageResponse result = new com.google.cloud.pubsublite.proto.MessageResponse(this);
+      com.google.cloud.pubsublite.proto.MessageResponse result =
+          new com.google.cloud.pubsublite.proto.MessageResponse(this);
       int from_bitField0_ = bitField0_;
       if (messagesBuilder_ == null) {
         if (((bitField0_ & 0x00000001) != 0)) {
@@ -413,38 +440,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.MessageResponse) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.MessageResponse)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.MessageResponse) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -452,7 +480,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.MessageResponse other) {
-      if (other == com.google.cloud.pubsublite.proto.MessageResponse.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.MessageResponse.getDefaultInstance())
+        return this;
       if (messagesBuilder_ == null) {
         if (!other.messages_.isEmpty()) {
           if (messages_.isEmpty()) {
@@ -471,9 +500,10 @@ private static final long serialVersionUID = 0L;
             messagesBuilder_ = null;
             messages_ = other.messages_;
             bitField0_ = (bitField0_ & ~0x00000001);
-            messagesBuilder_ = 
-              com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
-                 getMessagesFieldBuilder() : null;
+            messagesBuilder_ =
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders
+                    ? getMessagesFieldBuilder()
+                    : null;
           } else {
             messagesBuilder_.addAllMessages(other.messages_);
           }
@@ -498,7 +528,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.MessageResponse) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.MessageResponse) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -507,21 +538,29 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     private int bitField0_;
 
     private java.util.List<com.google.cloud.pubsublite.proto.SequencedMessage> messages_ =
-      java.util.Collections.emptyList();
+        java.util.Collections.emptyList();
+
     private void ensureMessagesIsMutable() {
       if (!((bitField0_ & 0x00000001) != 0)) {
-        messages_ = new java.util.ArrayList<com.google.cloud.pubsublite.proto.SequencedMessage>(messages_);
+        messages_ =
+            new java.util.ArrayList<com.google.cloud.pubsublite.proto.SequencedMessage>(messages_);
         bitField0_ |= 0x00000001;
-       }
+      }
     }
 
     private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.SequencedMessage, com.google.cloud.pubsublite.proto.SequencedMessage.Builder, com.google.cloud.pubsublite.proto.SequencedMessageOrBuilder> messagesBuilder_;
+            com.google.cloud.pubsublite.proto.SequencedMessage,
+            com.google.cloud.pubsublite.proto.SequencedMessage.Builder,
+            com.google.cloud.pubsublite.proto.SequencedMessageOrBuilder>
+        messagesBuilder_;
 
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
@@ -536,6 +575,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
@@ -550,6 +591,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
@@ -564,6 +607,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
@@ -585,6 +630,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
@@ -603,6 +650,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
@@ -623,6 +672,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
@@ -644,6 +695,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
@@ -662,6 +715,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
@@ -680,6 +735,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
@@ -690,8 +747,7 @@ private static final long serialVersionUID = 0L;
         java.lang.Iterable<? extends com.google.cloud.pubsublite.proto.SequencedMessage> values) {
       if (messagesBuilder_ == null) {
         ensureMessagesIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, messages_);
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(values, messages_);
         onChanged();
       } else {
         messagesBuilder_.addAllMessages(values);
@@ -699,6 +755,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
@@ -716,6 +774,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
@@ -733,6 +793,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
@@ -744,6 +806,8 @@ private static final long serialVersionUID = 0L;
       return getMessagesFieldBuilder().getBuilder(index);
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
@@ -753,19 +817,22 @@ private static final long serialVersionUID = 0L;
     public com.google.cloud.pubsublite.proto.SequencedMessageOrBuilder getMessagesOrBuilder(
         int index) {
       if (messagesBuilder_ == null) {
-        return messages_.get(index);  } else {
+        return messages_.get(index);
+      } else {
         return messagesBuilder_.getMessageOrBuilder(index);
       }
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
      *
      * <code>repeated .google.cloud.pubsublite.v1.SequencedMessage messages = 1;</code>
      */
-    public java.util.List<? extends com.google.cloud.pubsublite.proto.SequencedMessageOrBuilder> 
-         getMessagesOrBuilderList() {
+    public java.util.List<? extends com.google.cloud.pubsublite.proto.SequencedMessageOrBuilder>
+        getMessagesOrBuilderList() {
       if (messagesBuilder_ != null) {
         return messagesBuilder_.getMessageOrBuilderList();
       } else {
@@ -773,6 +840,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
@@ -780,10 +849,12 @@ private static final long serialVersionUID = 0L;
      * <code>repeated .google.cloud.pubsublite.v1.SequencedMessage messages = 1;</code>
      */
     public com.google.cloud.pubsublite.proto.SequencedMessage.Builder addMessagesBuilder() {
-      return getMessagesFieldBuilder().addBuilder(
-          com.google.cloud.pubsublite.proto.SequencedMessage.getDefaultInstance());
+      return getMessagesFieldBuilder()
+          .addBuilder(com.google.cloud.pubsublite.proto.SequencedMessage.getDefaultInstance());
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
@@ -792,37 +863,43 @@ private static final long serialVersionUID = 0L;
      */
     public com.google.cloud.pubsublite.proto.SequencedMessage.Builder addMessagesBuilder(
         int index) {
-      return getMessagesFieldBuilder().addBuilder(
-          index, com.google.cloud.pubsublite.proto.SequencedMessage.getDefaultInstance());
+      return getMessagesFieldBuilder()
+          .addBuilder(
+              index, com.google.cloud.pubsublite.proto.SequencedMessage.getDefaultInstance());
     }
     /**
+     *
+     *
      * <pre>
      * Messages from the topic partition.
      * </pre>
      *
      * <code>repeated .google.cloud.pubsublite.v1.SequencedMessage messages = 1;</code>
      */
-    public java.util.List<com.google.cloud.pubsublite.proto.SequencedMessage.Builder> 
-         getMessagesBuilderList() {
+    public java.util.List<com.google.cloud.pubsublite.proto.SequencedMessage.Builder>
+        getMessagesBuilderList() {
       return getMessagesFieldBuilder().getBuilderList();
     }
+
     private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.SequencedMessage, com.google.cloud.pubsublite.proto.SequencedMessage.Builder, com.google.cloud.pubsublite.proto.SequencedMessageOrBuilder> 
+            com.google.cloud.pubsublite.proto.SequencedMessage,
+            com.google.cloud.pubsublite.proto.SequencedMessage.Builder,
+            com.google.cloud.pubsublite.proto.SequencedMessageOrBuilder>
         getMessagesFieldBuilder() {
       if (messagesBuilder_ == null) {
-        messagesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.SequencedMessage, com.google.cloud.pubsublite.proto.SequencedMessage.Builder, com.google.cloud.pubsublite.proto.SequencedMessageOrBuilder>(
-                messages_,
-                ((bitField0_ & 0x00000001) != 0),
-                getParentForChildren(),
-                isClean());
+        messagesBuilder_ =
+            new com.google.protobuf.RepeatedFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.SequencedMessage,
+                com.google.cloud.pubsublite.proto.SequencedMessage.Builder,
+                com.google.cloud.pubsublite.proto.SequencedMessageOrBuilder>(
+                messages_, ((bitField0_ & 0x00000001) != 0), getParentForChildren(), isClean());
         messages_ = null;
       }
       return messagesBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -832,12 +909,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.MessageResponse)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.MessageResponse)
   private static final com.google.cloud.pubsublite.proto.MessageResponse DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.MessageResponse();
   }
@@ -846,16 +923,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<MessageResponse>
-      PARSER = new com.google.protobuf.AbstractParser<MessageResponse>() {
-    @java.lang.Override
-    public MessageResponse parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new MessageResponse(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<MessageResponse> PARSER =
+      new com.google.protobuf.AbstractParser<MessageResponse>() {
+        @java.lang.Override
+        public MessageResponse parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new MessageResponse(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<MessageResponse> parser() {
     return PARSER;
@@ -870,6 +947,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.MessageResponse getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/MessageResponseOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/MessageResponseOrBuilder.java
@@ -3,20 +3,24 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface MessageResponseOrBuilder extends
+public interface MessageResponseOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.MessageResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * Messages from the topic partition.
    * </pre>
    *
    * <code>repeated .google.cloud.pubsublite.v1.SequencedMessage messages = 1;</code>
    */
-  java.util.List<com.google.cloud.pubsublite.proto.SequencedMessage> 
-      getMessagesList();
+  java.util.List<com.google.cloud.pubsublite.proto.SequencedMessage> getMessagesList();
   /**
+   *
+   *
    * <pre>
    * Messages from the topic partition.
    * </pre>
@@ -25,6 +29,8 @@ public interface MessageResponseOrBuilder extends
    */
   com.google.cloud.pubsublite.proto.SequencedMessage getMessages(int index);
   /**
+   *
+   *
    * <pre>
    * Messages from the topic partition.
    * </pre>
@@ -33,21 +39,24 @@ public interface MessageResponseOrBuilder extends
    */
   int getMessagesCount();
   /**
+   *
+   *
    * <pre>
    * Messages from the topic partition.
    * </pre>
    *
    * <code>repeated .google.cloud.pubsublite.v1.SequencedMessage messages = 1;</code>
    */
-  java.util.List<? extends com.google.cloud.pubsublite.proto.SequencedMessageOrBuilder> 
+  java.util.List<? extends com.google.cloud.pubsublite.proto.SequencedMessageOrBuilder>
       getMessagesOrBuilderList();
   /**
+   *
+   *
    * <pre>
    * Messages from the topic partition.
    * </pre>
    *
    * <code>repeated .google.cloud.pubsublite.v1.SequencedMessage messages = 1;</code>
    */
-  com.google.cloud.pubsublite.proto.SequencedMessageOrBuilder getMessagesOrBuilder(
-      int index);
+  com.google.cloud.pubsublite.proto.SequencedMessageOrBuilder getMessagesOrBuilder(int index);
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PartitionCursor.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PartitionCursor.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * A pair of a Cursor and the partition it is for.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.PartitionCursor}
  */
-public  final class PartitionCursor extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class PartitionCursor extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.PartitionCursor)
     PartitionCursorOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use PartitionCursor.newBuilder() to construct.
   private PartitionCursor(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private PartitionCursor() {
-  }
+
+  private PartitionCursor() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new PartitionCursor();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private PartitionCursor(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,64 +53,72 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 8: {
+          case 8:
+            {
+              partition_ = input.readInt64();
+              break;
+            }
+          case 18:
+            {
+              com.google.cloud.pubsublite.proto.Cursor.Builder subBuilder = null;
+              if (cursor_ != null) {
+                subBuilder = cursor_.toBuilder();
+              }
+              cursor_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Cursor.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(cursor_);
+                cursor_ = subBuilder.buildPartial();
+              }
 
-            partition_ = input.readInt64();
-            break;
-          }
-          case 18: {
-            com.google.cloud.pubsublite.proto.Cursor.Builder subBuilder = null;
-            if (cursor_ != null) {
-              subBuilder = cursor_.toBuilder();
+              break;
             }
-            cursor_ = input.readMessage(com.google.cloud.pubsublite.proto.Cursor.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(cursor_);
-              cursor_ = subBuilder.buildPartial();
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
             }
-
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_PartitionCursor_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_PartitionCursor_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_PartitionCursor_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_PartitionCursor_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.PartitionCursor.class, com.google.cloud.pubsublite.proto.PartitionCursor.Builder.class);
+            com.google.cloud.pubsublite.proto.PartitionCursor.class,
+            com.google.cloud.pubsublite.proto.PartitionCursor.Builder.class);
   }
 
   public static final int PARTITION_FIELD_NUMBER = 1;
   private long partition_;
   /**
+   *
+   *
    * <pre>
    * The partition this is for.
    * </pre>
    *
    * <code>int64 partition = 1;</code>
+   *
    * @return The partition.
    */
   public long getPartition() {
@@ -119,28 +128,38 @@ private static final long serialVersionUID = 0L;
   public static final int CURSOR_FIELD_NUMBER = 2;
   private com.google.cloud.pubsublite.proto.Cursor cursor_;
   /**
+   *
+   *
    * <pre>
    * The value of the cursor.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
+   *
    * @return Whether the cursor field is set.
    */
   public boolean hasCursor() {
     return cursor_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * The value of the cursor.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
+   *
    * @return The cursor.
    */
   public com.google.cloud.pubsublite.proto.Cursor getCursor() {
-    return cursor_ == null ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+    return cursor_ == null
+        ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+        : cursor_;
   }
   /**
+   *
+   *
    * <pre>
    * The value of the cursor.
    * </pre>
@@ -152,6 +171,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -163,8 +183,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (partition_ != 0L) {
       output.writeInt64(1, partition_);
     }
@@ -181,12 +200,10 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (partition_ != 0L) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeInt64Size(1, partition_);
+      size += com.google.protobuf.CodedOutputStream.computeInt64Size(1, partition_);
     }
     if (cursor_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, getCursor());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(2, getCursor());
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -196,19 +213,18 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.PartitionCursor)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.PartitionCursor other = (com.google.cloud.pubsublite.proto.PartitionCursor) obj;
+    com.google.cloud.pubsublite.proto.PartitionCursor other =
+        (com.google.cloud.pubsublite.proto.PartitionCursor) obj;
 
-    if (getPartition()
-        != other.getPartition()) return false;
+    if (getPartition() != other.getPartition()) return false;
     if (hasCursor() != other.hasCursor()) return false;
     if (hasCursor()) {
-      if (!getCursor()
-          .equals(other.getCursor())) return false;
+      if (!getCursor().equals(other.getCursor())) return false;
     }
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
@@ -222,8 +238,7 @@ private static final long serialVersionUID = 0L;
     int hash = 41;
     hash = (19 * hash) + getDescriptor().hashCode();
     hash = (37 * hash) + PARTITION_FIELD_NUMBER;
-    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-        getPartition());
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(getPartition());
     if (hasCursor()) {
       hash = (37 * hash) + CURSOR_FIELD_NUMBER;
       hash = (53 * hash) + getCursor().hashCode();
@@ -234,117 +249,126 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.PartitionCursor parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.PartitionCursor parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.PartitionCursor parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.PartitionCursor parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.PartitionCursor parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.PartitionCursor parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.PartitionCursor parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.PartitionCursor parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.PartitionCursor parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.PartitionCursor parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.PartitionCursor parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.PartitionCursor parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.PartitionCursor parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.PartitionCursor parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.PartitionCursor prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * A pair of a Cursor and the partition it is for.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.PartitionCursor}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.PartitionCursor)
       com.google.cloud.pubsublite.proto.PartitionCursorOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_PartitionCursor_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_PartitionCursor_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_PartitionCursor_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_PartitionCursor_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.PartitionCursor.class, com.google.cloud.pubsublite.proto.PartitionCursor.Builder.class);
+              com.google.cloud.pubsublite.proto.PartitionCursor.class,
+              com.google.cloud.pubsublite.proto.PartitionCursor.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.PartitionCursor.newBuilder()
@@ -352,16 +376,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -377,9 +400,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_PartitionCursor_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_PartitionCursor_descriptor;
     }
 
     @java.lang.Override
@@ -398,7 +421,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.PartitionCursor buildPartial() {
-      com.google.cloud.pubsublite.proto.PartitionCursor result = new com.google.cloud.pubsublite.proto.PartitionCursor(this);
+      com.google.cloud.pubsublite.proto.PartitionCursor result =
+          new com.google.cloud.pubsublite.proto.PartitionCursor(this);
       result.partition_ = partition_;
       if (cursorBuilder_ == null) {
         result.cursor_ = cursor_;
@@ -413,38 +437,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.PartitionCursor) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.PartitionCursor)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.PartitionCursor) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -452,7 +477,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.PartitionCursor other) {
-      if (other == com.google.cloud.pubsublite.proto.PartitionCursor.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.PartitionCursor.getDefaultInstance())
+        return this;
       if (other.getPartition() != 0L) {
         setPartition(other.getPartition());
       }
@@ -478,7 +504,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.PartitionCursor) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.PartitionCursor) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -488,43 +515,52 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-    private long partition_ ;
+    private long partition_;
     /**
+     *
+     *
      * <pre>
      * The partition this is for.
      * </pre>
      *
      * <code>int64 partition = 1;</code>
+     *
      * @return The partition.
      */
     public long getPartition() {
       return partition_;
     }
     /**
+     *
+     *
      * <pre>
      * The partition this is for.
      * </pre>
      *
      * <code>int64 partition = 1;</code>
+     *
      * @param value The partition to set.
      * @return This builder for chaining.
      */
     public Builder setPartition(long value) {
-      
+
       partition_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The partition this is for.
      * </pre>
      *
      * <code>int64 partition = 1;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearPartition() {
-      
+
       partition_ = 0L;
       onChanged();
       return this;
@@ -532,34 +568,47 @@ private static final long serialVersionUID = 0L;
 
     private com.google.cloud.pubsublite.proto.Cursor cursor_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder> cursorBuilder_;
+            com.google.cloud.pubsublite.proto.Cursor,
+            com.google.cloud.pubsublite.proto.Cursor.Builder,
+            com.google.cloud.pubsublite.proto.CursorOrBuilder>
+        cursorBuilder_;
     /**
+     *
+     *
      * <pre>
      * The value of the cursor.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
+     *
      * @return Whether the cursor field is set.
      */
     public boolean hasCursor() {
       return cursorBuilder_ != null || cursor_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * The value of the cursor.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
+     *
      * @return The cursor.
      */
     public com.google.cloud.pubsublite.proto.Cursor getCursor() {
       if (cursorBuilder_ == null) {
-        return cursor_ == null ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+        return cursor_ == null
+            ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+            : cursor_;
       } else {
         return cursorBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * The value of the cursor.
      * </pre>
@@ -580,14 +629,15 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The value of the cursor.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
      */
-    public Builder setCursor(
-        com.google.cloud.pubsublite.proto.Cursor.Builder builderForValue) {
+    public Builder setCursor(com.google.cloud.pubsublite.proto.Cursor.Builder builderForValue) {
       if (cursorBuilder_ == null) {
         cursor_ = builderForValue.build();
         onChanged();
@@ -598,6 +648,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The value of the cursor.
      * </pre>
@@ -608,7 +660,9 @@ private static final long serialVersionUID = 0L;
       if (cursorBuilder_ == null) {
         if (cursor_ != null) {
           cursor_ =
-            com.google.cloud.pubsublite.proto.Cursor.newBuilder(cursor_).mergeFrom(value).buildPartial();
+              com.google.cloud.pubsublite.proto.Cursor.newBuilder(cursor_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           cursor_ = value;
         }
@@ -620,6 +674,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The value of the cursor.
      * </pre>
@@ -638,6 +694,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The value of the cursor.
      * </pre>
@@ -645,11 +703,13 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
      */
     public com.google.cloud.pubsublite.proto.Cursor.Builder getCursorBuilder() {
-      
+
       onChanged();
       return getCursorFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * The value of the cursor.
      * </pre>
@@ -660,11 +720,14 @@ private static final long serialVersionUID = 0L;
       if (cursorBuilder_ != null) {
         return cursorBuilder_.getMessageOrBuilder();
       } else {
-        return cursor_ == null ?
-            com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+        return cursor_ == null
+            ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+            : cursor_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The value of the cursor.
      * </pre>
@@ -672,21 +735,24 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder> 
+            com.google.cloud.pubsublite.proto.Cursor,
+            com.google.cloud.pubsublite.proto.Cursor.Builder,
+            com.google.cloud.pubsublite.proto.CursorOrBuilder>
         getCursorFieldBuilder() {
       if (cursorBuilder_ == null) {
-        cursorBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder>(
-                getCursor(),
-                getParentForChildren(),
-                isClean());
+        cursorBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Cursor,
+                com.google.cloud.pubsublite.proto.Cursor.Builder,
+                com.google.cloud.pubsublite.proto.CursorOrBuilder>(
+                getCursor(), getParentForChildren(), isClean());
         cursor_ = null;
       }
       return cursorBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -696,12 +762,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.PartitionCursor)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.PartitionCursor)
   private static final com.google.cloud.pubsublite.proto.PartitionCursor DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.PartitionCursor();
   }
@@ -710,16 +776,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<PartitionCursor>
-      PARSER = new com.google.protobuf.AbstractParser<PartitionCursor>() {
-    @java.lang.Override
-    public PartitionCursor parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new PartitionCursor(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<PartitionCursor> PARSER =
+      new com.google.protobuf.AbstractParser<PartitionCursor>() {
+        @java.lang.Override
+        public PartitionCursor parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new PartitionCursor(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<PartitionCursor> parser() {
     return PARSER;
@@ -734,6 +800,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.PartitionCursor getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PartitionCursorOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PartitionCursorOrBuilder.java
@@ -3,39 +3,51 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface PartitionCursorOrBuilder extends
+public interface PartitionCursorOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.PartitionCursor)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The partition this is for.
    * </pre>
    *
    * <code>int64 partition = 1;</code>
+   *
    * @return The partition.
    */
   long getPartition();
 
   /**
+   *
+   *
    * <pre>
    * The value of the cursor.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
+   *
    * @return Whether the cursor field is set.
    */
   boolean hasCursor();
   /**
+   *
+   *
    * <pre>
    * The value of the cursor.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
+   *
    * @return The cursor.
    */
   com.google.cloud.pubsublite.proto.Cursor getCursor();
   /**
+   *
+   *
    * <pre>
    * The value of the cursor.
    * </pre>

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PubSubMessage.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PubSubMessage.java
@@ -4,21 +4,24 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * A message that is published by publishers and delivered to subscribers.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.PubSubMessage}
  */
-public  final class PubSubMessage extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class PubSubMessage extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.PubSubMessage)
     PubSubMessageOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use PubSubMessage.newBuilder() to construct.
   private PubSubMessage(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private PubSubMessage() {
     key_ = com.google.protobuf.ByteString.EMPTY;
     data_ = com.google.protobuf.ByteString.EMPTY;
@@ -26,16 +29,15 @@ private static final long serialVersionUID = 0L;
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new PubSubMessage();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private PubSubMessage(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -55,89 +57,98 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
+          case 10:
+            {
+              key_ = input.readBytes();
+              break;
+            }
+          case 18:
+            {
+              data_ = input.readBytes();
+              break;
+            }
+          case 26:
+            {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                attributes_ =
+                    com.google.protobuf.MapField.newMapField(
+                        AttributesDefaultEntryHolder.defaultEntry);
+                mutable_bitField0_ |= 0x00000001;
+              }
+              com.google.protobuf.MapEntry<
+                      java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
+                  attributes__ =
+                      input.readMessage(
+                          AttributesDefaultEntryHolder.defaultEntry.getParserForType(),
+                          extensionRegistry);
+              attributes_.getMutableMap().put(attributes__.getKey(), attributes__.getValue());
+              break;
+            }
+          case 34:
+            {
+              com.google.protobuf.Timestamp.Builder subBuilder = null;
+              if (eventTime_ != null) {
+                subBuilder = eventTime_.toBuilder();
+              }
+              eventTime_ =
+                  input.readMessage(com.google.protobuf.Timestamp.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(eventTime_);
+                eventTime_ = subBuilder.buildPartial();
+              }
 
-            key_ = input.readBytes();
-            break;
-          }
-          case 18: {
-
-            data_ = input.readBytes();
-            break;
-          }
-          case 26: {
-            if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-              attributes_ = com.google.protobuf.MapField.newMapField(
-                  AttributesDefaultEntryHolder.defaultEntry);
-              mutable_bitField0_ |= 0x00000001;
+              break;
             }
-            com.google.protobuf.MapEntry<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
-            attributes__ = input.readMessage(
-                AttributesDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
-            attributes_.getMutableMap().put(
-                attributes__.getKey(), attributes__.getValue());
-            break;
-          }
-          case 34: {
-            com.google.protobuf.Timestamp.Builder subBuilder = null;
-            if (eventTime_ != null) {
-              subBuilder = eventTime_.toBuilder();
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
             }
-            eventTime_ = input.readMessage(com.google.protobuf.Timestamp.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(eventTime_);
-              eventTime_ = subBuilder.buildPartial();
-            }
-
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_PubSubMessage_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CommonProto
+        .internal_static_google_cloud_pubsublite_v1_PubSubMessage_descriptor;
   }
 
   @SuppressWarnings({"rawtypes"})
   @java.lang.Override
-  protected com.google.protobuf.MapField internalGetMapField(
-      int number) {
+  protected com.google.protobuf.MapField internalGetMapField(int number) {
     switch (number) {
       case 3:
         return internalGetAttributes();
       default:
-        throw new RuntimeException(
-            "Invalid map field number: " + number);
+        throw new RuntimeException("Invalid map field number: " + number);
     }
   }
+
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_PubSubMessage_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CommonProto
+        .internal_static_google_cloud_pubsublite_v1_PubSubMessage_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.PubSubMessage.class, com.google.cloud.pubsublite.proto.PubSubMessage.Builder.class);
+            com.google.cloud.pubsublite.proto.PubSubMessage.class,
+            com.google.cloud.pubsublite.proto.PubSubMessage.Builder.class);
   }
 
   public static final int KEY_FIELD_NUMBER = 1;
   private com.google.protobuf.ByteString key_;
   /**
+   *
+   *
    * <pre>
    * The key used for routing messages to partitions or for compaction (e.g.,
    * keep the last N messages per key). If the key is empty, the message is
@@ -145,6 +156,7 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>bytes key = 1;</code>
+   *
    * @return The key.
    */
   public com.google.protobuf.ByteString getKey() {
@@ -154,11 +166,14 @@ private static final long serialVersionUID = 0L;
   public static final int DATA_FIELD_NUMBER = 2;
   private com.google.protobuf.ByteString data_;
   /**
+   *
+   *
    * <pre>
    * The payload of the message.
    * </pre>
    *
    * <code>bytes data = 2;</code>
+   *
    * @return The data.
    */
   public com.google.protobuf.ByteString getData() {
@@ -166,24 +181,31 @@ private static final long serialVersionUID = 0L;
   }
 
   public static final int ATTRIBUTES_FIELD_NUMBER = 3;
+
   private static final class AttributesDefaultEntryHolder {
     static final com.google.protobuf.MapEntry<
-        java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues> defaultEntry =
+            java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
+        defaultEntry =
             com.google.protobuf.MapEntry
-            .<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>newDefaultInstance(
-                com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_PubSubMessage_AttributesEntry_descriptor, 
-                com.google.protobuf.WireFormat.FieldType.STRING,
-                "",
-                com.google.protobuf.WireFormat.FieldType.MESSAGE,
-                com.google.cloud.pubsublite.proto.AttributeValues.getDefaultInstance());
+                .<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
+                    newDefaultInstance(
+                        com.google.cloud.pubsublite.proto.CommonProto
+                            .internal_static_google_cloud_pubsublite_v1_PubSubMessage_AttributesEntry_descriptor,
+                        com.google.protobuf.WireFormat.FieldType.STRING,
+                        "",
+                        com.google.protobuf.WireFormat.FieldType.MESSAGE,
+                        com.google.cloud.pubsublite.proto.AttributeValues.getDefaultInstance());
   }
+
   private com.google.protobuf.MapField<
-      java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues> attributes_;
-  private com.google.protobuf.MapField<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
-  internalGetAttributes() {
+          java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
+      attributes_;
+
+  private com.google.protobuf.MapField<
+          java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
+      internalGetAttributes() {
     if (attributes_ == null) {
-      return com.google.protobuf.MapField.emptyMapField(
-          AttributesDefaultEntryHolder.defaultEntry);
+      return com.google.protobuf.MapField.emptyMapField(AttributesDefaultEntryHolder.defaultEntry);
     }
     return attributes_;
   }
@@ -192,63 +214,71 @@ private static final long serialVersionUID = 0L;
     return internalGetAttributes().getMap().size();
   }
   /**
+   *
+   *
    * <pre>
    * Optional attributes that can be used for message metadata/headers.
    * </pre>
    *
    * <code>map&lt;string, .google.cloud.pubsublite.v1.AttributeValues&gt; attributes = 3;</code>
    */
-
-  public boolean containsAttributes(
-      java.lang.String key) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+  public boolean containsAttributes(java.lang.String key) {
+    if (key == null) {
+      throw new java.lang.NullPointerException();
+    }
     return internalGetAttributes().getMap().containsKey(key);
   }
-  /**
-   * Use {@link #getAttributesMap()} instead.
-   */
+  /** Use {@link #getAttributesMap()} instead. */
   @java.lang.Deprecated
-  public java.util.Map<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues> getAttributes() {
+  public java.util.Map<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
+      getAttributes() {
     return getAttributesMap();
   }
   /**
+   *
+   *
    * <pre>
    * Optional attributes that can be used for message metadata/headers.
    * </pre>
    *
    * <code>map&lt;string, .google.cloud.pubsublite.v1.AttributeValues&gt; attributes = 3;</code>
    */
-
-  public java.util.Map<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues> getAttributesMap() {
+  public java.util.Map<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
+      getAttributesMap() {
     return internalGetAttributes().getMap();
   }
   /**
+   *
+   *
    * <pre>
    * Optional attributes that can be used for message metadata/headers.
    * </pre>
    *
    * <code>map&lt;string, .google.cloud.pubsublite.v1.AttributeValues&gt; attributes = 3;</code>
    */
-
   public com.google.cloud.pubsublite.proto.AttributeValues getAttributesOrDefault(
-      java.lang.String key,
-      com.google.cloud.pubsublite.proto.AttributeValues defaultValue) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+      java.lang.String key, com.google.cloud.pubsublite.proto.AttributeValues defaultValue) {
+    if (key == null) {
+      throw new java.lang.NullPointerException();
+    }
     java.util.Map<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues> map =
         internalGetAttributes().getMap();
     return map.containsKey(key) ? map.get(key) : defaultValue;
   }
   /**
+   *
+   *
    * <pre>
    * Optional attributes that can be used for message metadata/headers.
    * </pre>
    *
    * <code>map&lt;string, .google.cloud.pubsublite.v1.AttributeValues&gt; attributes = 3;</code>
    */
-
   public com.google.cloud.pubsublite.proto.AttributeValues getAttributesOrThrow(
       java.lang.String key) {
-    if (key == null) { throw new java.lang.NullPointerException(); }
+    if (key == null) {
+      throw new java.lang.NullPointerException();
+    }
     java.util.Map<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues> map =
         internalGetAttributes().getMap();
     if (!map.containsKey(key)) {
@@ -260,28 +290,36 @@ private static final long serialVersionUID = 0L;
   public static final int EVENT_TIME_FIELD_NUMBER = 4;
   private com.google.protobuf.Timestamp eventTime_;
   /**
+   *
+   *
    * <pre>
    * An optional, user-specified event time.
    * </pre>
    *
    * <code>.google.protobuf.Timestamp event_time = 4;</code>
+   *
    * @return Whether the eventTime field is set.
    */
   public boolean hasEventTime() {
     return eventTime_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * An optional, user-specified event time.
    * </pre>
    *
    * <code>.google.protobuf.Timestamp event_time = 4;</code>
+   *
    * @return The eventTime.
    */
   public com.google.protobuf.Timestamp getEventTime() {
     return eventTime_ == null ? com.google.protobuf.Timestamp.getDefaultInstance() : eventTime_;
   }
   /**
+   *
+   *
    * <pre>
    * An optional, user-specified event time.
    * </pre>
@@ -293,6 +331,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -304,20 +343,15 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!key_.isEmpty()) {
       output.writeBytes(1, key_);
     }
     if (!data_.isEmpty()) {
       output.writeBytes(2, data_);
     }
-    com.google.protobuf.GeneratedMessageV3
-      .serializeStringMapTo(
-        output,
-        internalGetAttributes(),
-        AttributesDefaultEntryHolder.defaultEntry,
-        3);
+    com.google.protobuf.GeneratedMessageV3.serializeStringMapTo(
+        output, internalGetAttributes(), AttributesDefaultEntryHolder.defaultEntry, 3);
     if (eventTime_ != null) {
       output.writeMessage(4, getEventTime());
     }
@@ -331,26 +365,25 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (!key_.isEmpty()) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeBytesSize(1, key_);
+      size += com.google.protobuf.CodedOutputStream.computeBytesSize(1, key_);
     }
     if (!data_.isEmpty()) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeBytesSize(2, data_);
+      size += com.google.protobuf.CodedOutputStream.computeBytesSize(2, data_);
     }
-    for (java.util.Map.Entry<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues> entry
-         : internalGetAttributes().getMap().entrySet()) {
-      com.google.protobuf.MapEntry<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
-      attributes__ = AttributesDefaultEntryHolder.defaultEntry.newBuilderForType()
-          .setKey(entry.getKey())
-          .setValue(entry.getValue())
-          .build();
-      size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(3, attributes__);
+    for (java.util.Map.Entry<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
+        entry : internalGetAttributes().getMap().entrySet()) {
+      com.google.protobuf.MapEntry<
+              java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
+          attributes__ =
+              AttributesDefaultEntryHolder.defaultEntry
+                  .newBuilderForType()
+                  .setKey(entry.getKey())
+                  .setValue(entry.getValue())
+                  .build();
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(3, attributes__);
     }
     if (eventTime_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(4, getEventTime());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(4, getEventTime());
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -360,23 +393,20 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.PubSubMessage)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.PubSubMessage other = (com.google.cloud.pubsublite.proto.PubSubMessage) obj;
+    com.google.cloud.pubsublite.proto.PubSubMessage other =
+        (com.google.cloud.pubsublite.proto.PubSubMessage) obj;
 
-    if (!getKey()
-        .equals(other.getKey())) return false;
-    if (!getData()
-        .equals(other.getData())) return false;
-    if (!internalGetAttributes().equals(
-        other.internalGetAttributes())) return false;
+    if (!getKey().equals(other.getKey())) return false;
+    if (!getData().equals(other.getData())) return false;
+    if (!internalGetAttributes().equals(other.internalGetAttributes())) return false;
     if (hasEventTime() != other.hasEventTime()) return false;
     if (hasEventTime()) {
-      if (!getEventTime()
-          .equals(other.getEventTime())) return false;
+      if (!getEventTime().equals(other.getEventTime())) return false;
     }
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
@@ -406,140 +436,147 @@ private static final long serialVersionUID = 0L;
     return hash;
   }
 
-  public static com.google.cloud.pubsublite.proto.PubSubMessage parseFrom(
-      java.nio.ByteBuffer data)
+  public static com.google.cloud.pubsublite.proto.PubSubMessage parseFrom(java.nio.ByteBuffer data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.PubSubMessage parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.PubSubMessage parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.PubSubMessage parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.PubSubMessage parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.PubSubMessage parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.PubSubMessage parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.PubSubMessage parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.PubSubMessage parseDelimitedFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.PubSubMessage parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.PubSubMessage parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.PubSubMessage parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.PubSubMessage parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.PubSubMessage prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * A message that is published by publishers and delivered to subscribers.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.PubSubMessage}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.PubSubMessage)
       com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_PubSubMessage_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_PubSubMessage_descriptor;
     }
 
     @SuppressWarnings({"rawtypes"})
-    protected com.google.protobuf.MapField internalGetMapField(
-        int number) {
+    protected com.google.protobuf.MapField internalGetMapField(int number) {
       switch (number) {
         case 3:
           return internalGetAttributes();
         default:
-          throw new RuntimeException(
-              "Invalid map field number: " + number);
+          throw new RuntimeException("Invalid map field number: " + number);
       }
     }
+
     @SuppressWarnings({"rawtypes"})
-    protected com.google.protobuf.MapField internalGetMutableMapField(
-        int number) {
+    protected com.google.protobuf.MapField internalGetMutableMapField(int number) {
       switch (number) {
         case 3:
           return internalGetMutableAttributes();
         default:
-          throw new RuntimeException(
-              "Invalid map field number: " + number);
+          throw new RuntimeException("Invalid map field number: " + number);
       }
     }
+
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_PubSubMessage_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_PubSubMessage_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.PubSubMessage.class, com.google.cloud.pubsublite.proto.PubSubMessage.Builder.class);
+              com.google.cloud.pubsublite.proto.PubSubMessage.class,
+              com.google.cloud.pubsublite.proto.PubSubMessage.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.PubSubMessage.newBuilder()
@@ -547,16 +584,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -575,9 +611,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_PubSubMessage_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_PubSubMessage_descriptor;
     }
 
     @java.lang.Override
@@ -596,7 +632,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.PubSubMessage buildPartial() {
-      com.google.cloud.pubsublite.proto.PubSubMessage result = new com.google.cloud.pubsublite.proto.PubSubMessage(this);
+      com.google.cloud.pubsublite.proto.PubSubMessage result =
+          new com.google.cloud.pubsublite.proto.PubSubMessage(this);
       int from_bitField0_ = bitField0_;
       result.key_ = key_;
       result.data_ = data_;
@@ -615,38 +652,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.PubSubMessage) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.PubSubMessage)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.PubSubMessage) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -654,15 +692,15 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.PubSubMessage other) {
-      if (other == com.google.cloud.pubsublite.proto.PubSubMessage.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.PubSubMessage.getDefaultInstance())
+        return this;
       if (other.getKey() != com.google.protobuf.ByteString.EMPTY) {
         setKey(other.getKey());
       }
       if (other.getData() != com.google.protobuf.ByteString.EMPTY) {
         setData(other.getData());
       }
-      internalGetMutableAttributes().mergeFrom(
-          other.internalGetAttributes());
+      internalGetMutableAttributes().mergeFrom(other.internalGetAttributes());
       if (other.hasEventTime()) {
         mergeEventTime(other.getEventTime());
       }
@@ -694,10 +732,13 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     private int bitField0_;
 
     private com.google.protobuf.ByteString key_ = com.google.protobuf.ByteString.EMPTY;
     /**
+     *
+     *
      * <pre>
      * The key used for routing messages to partitions or for compaction (e.g.,
      * keep the last N messages per key). If the key is empty, the message is
@@ -705,12 +746,15 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>bytes key = 1;</code>
+     *
      * @return The key.
      */
     public com.google.protobuf.ByteString getKey() {
       return key_;
     }
     /**
+     *
+     *
      * <pre>
      * The key used for routing messages to partitions or for compaction (e.g.,
      * keep the last N messages per key). If the key is empty, the message is
@@ -718,19 +762,22 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>bytes key = 1;</code>
+     *
      * @param value The key to set.
      * @return This builder for chaining.
      */
     public Builder setKey(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       key_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The key used for routing messages to partitions or for compaction (e.g.,
      * keep the last N messages per key). If the key is empty, the message is
@@ -738,10 +785,11 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>bytes key = 1;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearKey() {
-      
+
       key_ = getDefaultInstance().getKey();
       onChanged();
       return this;
@@ -749,65 +797,80 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.ByteString data_ = com.google.protobuf.ByteString.EMPTY;
     /**
+     *
+     *
      * <pre>
      * The payload of the message.
      * </pre>
      *
      * <code>bytes data = 2;</code>
+     *
      * @return The data.
      */
     public com.google.protobuf.ByteString getData() {
       return data_;
     }
     /**
+     *
+     *
      * <pre>
      * The payload of the message.
      * </pre>
      *
      * <code>bytes data = 2;</code>
+     *
      * @param value The data to set.
      * @return This builder for chaining.
      */
     public Builder setData(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       data_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The payload of the message.
      * </pre>
      *
      * <code>bytes data = 2;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearData() {
-      
+
       data_ = getDefaultInstance().getData();
       onChanged();
       return this;
     }
 
     private com.google.protobuf.MapField<
-        java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues> attributes_;
-    private com.google.protobuf.MapField<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
-    internalGetAttributes() {
+            java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
+        attributes_;
+
+    private com.google.protobuf.MapField<
+            java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
+        internalGetAttributes() {
       if (attributes_ == null) {
         return com.google.protobuf.MapField.emptyMapField(
             AttributesDefaultEntryHolder.defaultEntry);
       }
       return attributes_;
     }
-    private com.google.protobuf.MapField<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
-    internalGetMutableAttributes() {
-      onChanged();;
+
+    private com.google.protobuf.MapField<
+            java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
+        internalGetMutableAttributes() {
+      onChanged();
+      ;
       if (attributes_ == null) {
-        attributes_ = com.google.protobuf.MapField.newMapField(
-            AttributesDefaultEntryHolder.defaultEntry);
+        attributes_ =
+            com.google.protobuf.MapField.newMapField(AttributesDefaultEntryHolder.defaultEntry);
       }
       if (!attributes_.isMutable()) {
         attributes_ = attributes_.copy();
@@ -819,63 +882,71 @@ private static final long serialVersionUID = 0L;
       return internalGetAttributes().getMap().size();
     }
     /**
+     *
+     *
      * <pre>
      * Optional attributes that can be used for message metadata/headers.
      * </pre>
      *
      * <code>map&lt;string, .google.cloud.pubsublite.v1.AttributeValues&gt; attributes = 3;</code>
      */
-
-    public boolean containsAttributes(
-        java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+    public boolean containsAttributes(java.lang.String key) {
+      if (key == null) {
+        throw new java.lang.NullPointerException();
+      }
       return internalGetAttributes().getMap().containsKey(key);
     }
-    /**
-     * Use {@link #getAttributesMap()} instead.
-     */
+    /** Use {@link #getAttributesMap()} instead. */
     @java.lang.Deprecated
-    public java.util.Map<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues> getAttributes() {
+    public java.util.Map<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
+        getAttributes() {
       return getAttributesMap();
     }
     /**
+     *
+     *
      * <pre>
      * Optional attributes that can be used for message metadata/headers.
      * </pre>
      *
      * <code>map&lt;string, .google.cloud.pubsublite.v1.AttributeValues&gt; attributes = 3;</code>
      */
-
-    public java.util.Map<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues> getAttributesMap() {
+    public java.util.Map<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
+        getAttributesMap() {
       return internalGetAttributes().getMap();
     }
     /**
+     *
+     *
      * <pre>
      * Optional attributes that can be used for message metadata/headers.
      * </pre>
      *
      * <code>map&lt;string, .google.cloud.pubsublite.v1.AttributeValues&gt; attributes = 3;</code>
      */
-
     public com.google.cloud.pubsublite.proto.AttributeValues getAttributesOrDefault(
-        java.lang.String key,
-        com.google.cloud.pubsublite.proto.AttributeValues defaultValue) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+        java.lang.String key, com.google.cloud.pubsublite.proto.AttributeValues defaultValue) {
+      if (key == null) {
+        throw new java.lang.NullPointerException();
+      }
       java.util.Map<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues> map =
           internalGetAttributes().getMap();
       return map.containsKey(key) ? map.get(key) : defaultValue;
     }
     /**
+     *
+     *
      * <pre>
      * Optional attributes that can be used for message metadata/headers.
      * </pre>
      *
      * <code>map&lt;string, .google.cloud.pubsublite.v1.AttributeValues&gt; attributes = 3;</code>
      */
-
     public com.google.cloud.pubsublite.proto.AttributeValues getAttributesOrThrow(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) {
+        throw new java.lang.NullPointerException();
+      }
       java.util.Map<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues> map =
           internalGetAttributes().getMap();
       if (!map.containsKey(key)) {
@@ -885,34 +956,34 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder clearAttributes() {
-      internalGetMutableAttributes().getMutableMap()
-          .clear();
+      internalGetMutableAttributes().getMutableMap().clear();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Optional attributes that can be used for message metadata/headers.
      * </pre>
      *
      * <code>map&lt;string, .google.cloud.pubsublite.v1.AttributeValues&gt; attributes = 3;</code>
      */
-
-    public Builder removeAttributes(
-        java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
-      internalGetMutableAttributes().getMutableMap()
-          .remove(key);
+    public Builder removeAttributes(java.lang.String key) {
+      if (key == null) {
+        throw new java.lang.NullPointerException();
+      }
+      internalGetMutableAttributes().getMutableMap().remove(key);
       return this;
     }
-    /**
-     * Use alternate mutation accessors instead.
-     */
+    /** Use alternate mutation accessors instead. */
     @java.lang.Deprecated
     public java.util.Map<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
-    getMutableAttributes() {
+        getMutableAttributes() {
       return internalGetMutableAttributes().getMutableMap();
     }
     /**
+     *
+     *
      * <pre>
      * Optional attributes that can be used for message metadata/headers.
      * </pre>
@@ -920,49 +991,60 @@ private static final long serialVersionUID = 0L;
      * <code>map&lt;string, .google.cloud.pubsublite.v1.AttributeValues&gt; attributes = 3;</code>
      */
     public Builder putAttributes(
-        java.lang.String key,
-        com.google.cloud.pubsublite.proto.AttributeValues value) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
-      if (value == null) { throw new java.lang.NullPointerException(); }
-      internalGetMutableAttributes().getMutableMap()
-          .put(key, value);
+        java.lang.String key, com.google.cloud.pubsublite.proto.AttributeValues value) {
+      if (key == null) {
+        throw new java.lang.NullPointerException();
+      }
+      if (value == null) {
+        throw new java.lang.NullPointerException();
+      }
+      internalGetMutableAttributes().getMutableMap().put(key, value);
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Optional attributes that can be used for message metadata/headers.
      * </pre>
      *
      * <code>map&lt;string, .google.cloud.pubsublite.v1.AttributeValues&gt; attributes = 3;</code>
      */
-
     public Builder putAllAttributes(
         java.util.Map<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues> values) {
-      internalGetMutableAttributes().getMutableMap()
-          .putAll(values);
+      internalGetMutableAttributes().getMutableMap().putAll(values);
       return this;
     }
 
     private com.google.protobuf.Timestamp eventTime_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> eventTimeBuilder_;
+            com.google.protobuf.Timestamp,
+            com.google.protobuf.Timestamp.Builder,
+            com.google.protobuf.TimestampOrBuilder>
+        eventTimeBuilder_;
     /**
+     *
+     *
      * <pre>
      * An optional, user-specified event time.
      * </pre>
      *
      * <code>.google.protobuf.Timestamp event_time = 4;</code>
+     *
      * @return Whether the eventTime field is set.
      */
     public boolean hasEventTime() {
       return eventTimeBuilder_ != null || eventTime_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * An optional, user-specified event time.
      * </pre>
      *
      * <code>.google.protobuf.Timestamp event_time = 4;</code>
+     *
      * @return The eventTime.
      */
     public com.google.protobuf.Timestamp getEventTime() {
@@ -973,6 +1055,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * An optional, user-specified event time.
      * </pre>
@@ -993,14 +1077,15 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * An optional, user-specified event time.
      * </pre>
      *
      * <code>.google.protobuf.Timestamp event_time = 4;</code>
      */
-    public Builder setEventTime(
-        com.google.protobuf.Timestamp.Builder builderForValue) {
+    public Builder setEventTime(com.google.protobuf.Timestamp.Builder builderForValue) {
       if (eventTimeBuilder_ == null) {
         eventTime_ = builderForValue.build();
         onChanged();
@@ -1011,6 +1096,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * An optional, user-specified event time.
      * </pre>
@@ -1021,7 +1108,7 @@ private static final long serialVersionUID = 0L;
       if (eventTimeBuilder_ == null) {
         if (eventTime_ != null) {
           eventTime_ =
-            com.google.protobuf.Timestamp.newBuilder(eventTime_).mergeFrom(value).buildPartial();
+              com.google.protobuf.Timestamp.newBuilder(eventTime_).mergeFrom(value).buildPartial();
         } else {
           eventTime_ = value;
         }
@@ -1033,6 +1120,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * An optional, user-specified event time.
      * </pre>
@@ -1051,6 +1140,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * An optional, user-specified event time.
      * </pre>
@@ -1058,11 +1149,13 @@ private static final long serialVersionUID = 0L;
      * <code>.google.protobuf.Timestamp event_time = 4;</code>
      */
     public com.google.protobuf.Timestamp.Builder getEventTimeBuilder() {
-      
+
       onChanged();
       return getEventTimeFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * An optional, user-specified event time.
      * </pre>
@@ -1073,11 +1166,12 @@ private static final long serialVersionUID = 0L;
       if (eventTimeBuilder_ != null) {
         return eventTimeBuilder_.getMessageOrBuilder();
       } else {
-        return eventTime_ == null ?
-            com.google.protobuf.Timestamp.getDefaultInstance() : eventTime_;
+        return eventTime_ == null ? com.google.protobuf.Timestamp.getDefaultInstance() : eventTime_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * An optional, user-specified event time.
      * </pre>
@@ -1085,21 +1179,24 @@ private static final long serialVersionUID = 0L;
      * <code>.google.protobuf.Timestamp event_time = 4;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
+            com.google.protobuf.Timestamp,
+            com.google.protobuf.Timestamp.Builder,
+            com.google.protobuf.TimestampOrBuilder>
         getEventTimeFieldBuilder() {
       if (eventTimeBuilder_ == null) {
-        eventTimeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder>(
-                getEventTime(),
-                getParentForChildren(),
-                isClean());
+        eventTimeBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.protobuf.Timestamp,
+                com.google.protobuf.Timestamp.Builder,
+                com.google.protobuf.TimestampOrBuilder>(
+                getEventTime(), getParentForChildren(), isClean());
         eventTime_ = null;
       }
       return eventTimeBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -1109,12 +1206,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.PubSubMessage)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.PubSubMessage)
   private static final com.google.cloud.pubsublite.proto.PubSubMessage DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.PubSubMessage();
   }
@@ -1123,16 +1220,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<PubSubMessage>
-      PARSER = new com.google.protobuf.AbstractParser<PubSubMessage>() {
-    @java.lang.Override
-    public PubSubMessage parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new PubSubMessage(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<PubSubMessage> PARSER =
+      new com.google.protobuf.AbstractParser<PubSubMessage>() {
+        @java.lang.Override
+        public PubSubMessage parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new PubSubMessage(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<PubSubMessage> parser() {
     return PARSER;
@@ -1147,6 +1244,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.PubSubMessage getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PubSubMessageOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PubSubMessageOrBuilder.java
@@ -3,11 +3,14 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface PubSubMessageOrBuilder extends
+public interface PubSubMessageOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.PubSubMessage)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The key used for routing messages to partitions or for compaction (e.g.,
    * keep the last N messages per key). If the key is empty, the message is
@@ -15,21 +18,27 @@ public interface PubSubMessageOrBuilder extends
    * </pre>
    *
    * <code>bytes key = 1;</code>
+   *
    * @return The key.
    */
   com.google.protobuf.ByteString getKey();
 
   /**
+   *
+   *
    * <pre>
    * The payload of the message.
    * </pre>
    *
    * <code>bytes data = 2;</code>
+   *
    * @return The data.
    */
   com.google.protobuf.ByteString getData();
 
   /**
+   *
+   *
    * <pre>
    * Optional attributes that can be used for message metadata/headers.
    * </pre>
@@ -38,21 +47,22 @@ public interface PubSubMessageOrBuilder extends
    */
   int getAttributesCount();
   /**
+   *
+   *
    * <pre>
    * Optional attributes that can be used for message metadata/headers.
    * </pre>
    *
    * <code>map&lt;string, .google.cloud.pubsublite.v1.AttributeValues&gt; attributes = 3;</code>
    */
-  boolean containsAttributes(
-      java.lang.String key);
-  /**
-   * Use {@link #getAttributesMap()} instead.
-   */
+  boolean containsAttributes(java.lang.String key);
+  /** Use {@link #getAttributesMap()} instead. */
   @java.lang.Deprecated
   java.util.Map<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
-  getAttributes();
+      getAttributes();
   /**
+   *
+   *
    * <pre>
    * Optional attributes that can be used for message metadata/headers.
    * </pre>
@@ -60,48 +70,56 @@ public interface PubSubMessageOrBuilder extends
    * <code>map&lt;string, .google.cloud.pubsublite.v1.AttributeValues&gt; attributes = 3;</code>
    */
   java.util.Map<java.lang.String, com.google.cloud.pubsublite.proto.AttributeValues>
-  getAttributesMap();
+      getAttributesMap();
   /**
+   *
+   *
    * <pre>
    * Optional attributes that can be used for message metadata/headers.
    * </pre>
    *
    * <code>map&lt;string, .google.cloud.pubsublite.v1.AttributeValues&gt; attributes = 3;</code>
    */
-
   com.google.cloud.pubsublite.proto.AttributeValues getAttributesOrDefault(
-      java.lang.String key,
-      com.google.cloud.pubsublite.proto.AttributeValues defaultValue);
+      java.lang.String key, com.google.cloud.pubsublite.proto.AttributeValues defaultValue);
   /**
+   *
+   *
    * <pre>
    * Optional attributes that can be used for message metadata/headers.
    * </pre>
    *
    * <code>map&lt;string, .google.cloud.pubsublite.v1.AttributeValues&gt; attributes = 3;</code>
    */
-
-  com.google.cloud.pubsublite.proto.AttributeValues getAttributesOrThrow(
-      java.lang.String key);
+  com.google.cloud.pubsublite.proto.AttributeValues getAttributesOrThrow(java.lang.String key);
 
   /**
+   *
+   *
    * <pre>
    * An optional, user-specified event time.
    * </pre>
    *
    * <code>.google.protobuf.Timestamp event_time = 4;</code>
+   *
    * @return Whether the eventTime field is set.
    */
   boolean hasEventTime();
   /**
+   *
+   *
    * <pre>
    * An optional, user-specified event time.
    * </pre>
    *
    * <code>.google.protobuf.Timestamp event_time = 4;</code>
+   *
    * @return The eventTime.
    */
   com.google.protobuf.Timestamp getEventTime();
   /**
+   *
+   *
    * <pre>
    * An optional, user-specified event time.
    * </pre>

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PublishRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PublishRequest.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request sent from the client to the server on a stream.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.PublishRequest}
  */
-public  final class PublishRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class PublishRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.PublishRequest)
     PublishRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use PublishRequest.newBuilder() to construct.
   private PublishRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private PublishRequest() {
-  }
+
+  private PublishRequest() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new PublishRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private PublishRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,75 +53,92 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            com.google.cloud.pubsublite.proto.InitialPublishRequest.Builder subBuilder = null;
-            if (requestTypeCase_ == 1) {
-              subBuilder = ((com.google.cloud.pubsublite.proto.InitialPublishRequest) requestType_).toBuilder();
+          case 10:
+            {
+              com.google.cloud.pubsublite.proto.InitialPublishRequest.Builder subBuilder = null;
+              if (requestTypeCase_ == 1) {
+                subBuilder =
+                    ((com.google.cloud.pubsublite.proto.InitialPublishRequest) requestType_)
+                        .toBuilder();
+              }
+              requestType_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.InitialPublishRequest.parser(),
+                      extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(
+                    (com.google.cloud.pubsublite.proto.InitialPublishRequest) requestType_);
+                requestType_ = subBuilder.buildPartial();
+              }
+              requestTypeCase_ = 1;
+              break;
             }
-            requestType_ =
-                input.readMessage(com.google.cloud.pubsublite.proto.InitialPublishRequest.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.InitialPublishRequest) requestType_);
-              requestType_ = subBuilder.buildPartial();
+          case 18:
+            {
+              com.google.cloud.pubsublite.proto.MessagePublishRequest.Builder subBuilder = null;
+              if (requestTypeCase_ == 2) {
+                subBuilder =
+                    ((com.google.cloud.pubsublite.proto.MessagePublishRequest) requestType_)
+                        .toBuilder();
+              }
+              requestType_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.MessagePublishRequest.parser(),
+                      extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(
+                    (com.google.cloud.pubsublite.proto.MessagePublishRequest) requestType_);
+                requestType_ = subBuilder.buildPartial();
+              }
+              requestTypeCase_ = 2;
+              break;
             }
-            requestTypeCase_ = 1;
-            break;
-          }
-          case 18: {
-            com.google.cloud.pubsublite.proto.MessagePublishRequest.Builder subBuilder = null;
-            if (requestTypeCase_ == 2) {
-              subBuilder = ((com.google.cloud.pubsublite.proto.MessagePublishRequest) requestType_).toBuilder();
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
             }
-            requestType_ =
-                input.readMessage(com.google.cloud.pubsublite.proto.MessagePublishRequest.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.MessagePublishRequest) requestType_);
-              requestType_ = subBuilder.buildPartial();
-            }
-            requestTypeCase_ = 2;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_PublishRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.PublisherProto
+        .internal_static_google_cloud_pubsublite_v1_PublishRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_PublishRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.PublisherProto
+        .internal_static_google_cloud_pubsublite_v1_PublishRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.PublishRequest.class, com.google.cloud.pubsublite.proto.PublishRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.PublishRequest.class,
+            com.google.cloud.pubsublite.proto.PublishRequest.Builder.class);
   }
 
   private int requestTypeCase_ = 0;
   private java.lang.Object requestType_;
+
   public enum RequestTypeCase
-      implements com.google.protobuf.Internal.EnumLite,
+      implements
+          com.google.protobuf.Internal.EnumLite,
           com.google.protobuf.AbstractMessage.InternalOneOfEnum {
     INITIAL_REQUEST(1),
     MESSAGE_PUBLISH_REQUEST(2),
     REQUESTTYPE_NOT_SET(0);
     private final int value;
+
     private RequestTypeCase(int value) {
       this.value = value;
     }
@@ -136,104 +154,126 @@ private static final long serialVersionUID = 0L;
 
     public static RequestTypeCase forNumber(int value) {
       switch (value) {
-        case 1: return INITIAL_REQUEST;
-        case 2: return MESSAGE_PUBLISH_REQUEST;
-        case 0: return REQUESTTYPE_NOT_SET;
-        default: return null;
+        case 1:
+          return INITIAL_REQUEST;
+        case 2:
+          return MESSAGE_PUBLISH_REQUEST;
+        case 0:
+          return REQUESTTYPE_NOT_SET;
+        default:
+          return null;
       }
     }
+
     public int getNumber() {
       return this.value;
     }
   };
 
-  public RequestTypeCase
-  getRequestTypeCase() {
-    return RequestTypeCase.forNumber(
-        requestTypeCase_);
+  public RequestTypeCase getRequestTypeCase() {
+    return RequestTypeCase.forNumber(requestTypeCase_);
   }
 
   public static final int INITIAL_REQUEST_FIELD_NUMBER = 1;
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialPublishRequest initial_request = 1;</code>
+   *
    * @return Whether the initialRequest field is set.
    */
   public boolean hasInitialRequest() {
     return requestTypeCase_ == 1;
   }
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialPublishRequest initial_request = 1;</code>
+   *
    * @return The initialRequest.
    */
   public com.google.cloud.pubsublite.proto.InitialPublishRequest getInitialRequest() {
     if (requestTypeCase_ == 1) {
-       return (com.google.cloud.pubsublite.proto.InitialPublishRequest) requestType_;
+      return (com.google.cloud.pubsublite.proto.InitialPublishRequest) requestType_;
     }
     return com.google.cloud.pubsublite.proto.InitialPublishRequest.getDefaultInstance();
   }
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialPublishRequest initial_request = 1;</code>
    */
-  public com.google.cloud.pubsublite.proto.InitialPublishRequestOrBuilder getInitialRequestOrBuilder() {
+  public com.google.cloud.pubsublite.proto.InitialPublishRequestOrBuilder
+      getInitialRequestOrBuilder() {
     if (requestTypeCase_ == 1) {
-       return (com.google.cloud.pubsublite.proto.InitialPublishRequest) requestType_;
+      return (com.google.cloud.pubsublite.proto.InitialPublishRequest) requestType_;
     }
     return com.google.cloud.pubsublite.proto.InitialPublishRequest.getDefaultInstance();
   }
 
   public static final int MESSAGE_PUBLISH_REQUEST_FIELD_NUMBER = 2;
   /**
+   *
+   *
    * <pre>
    * Request to publish messages.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.MessagePublishRequest message_publish_request = 2;</code>
+   *
    * @return Whether the messagePublishRequest field is set.
    */
   public boolean hasMessagePublishRequest() {
     return requestTypeCase_ == 2;
   }
   /**
+   *
+   *
    * <pre>
    * Request to publish messages.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.MessagePublishRequest message_publish_request = 2;</code>
+   *
    * @return The messagePublishRequest.
    */
   public com.google.cloud.pubsublite.proto.MessagePublishRequest getMessagePublishRequest() {
     if (requestTypeCase_ == 2) {
-       return (com.google.cloud.pubsublite.proto.MessagePublishRequest) requestType_;
+      return (com.google.cloud.pubsublite.proto.MessagePublishRequest) requestType_;
     }
     return com.google.cloud.pubsublite.proto.MessagePublishRequest.getDefaultInstance();
   }
   /**
+   *
+   *
    * <pre>
    * Request to publish messages.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.MessagePublishRequest message_publish_request = 2;</code>
    */
-  public com.google.cloud.pubsublite.proto.MessagePublishRequestOrBuilder getMessagePublishRequestOrBuilder() {
+  public com.google.cloud.pubsublite.proto.MessagePublishRequestOrBuilder
+      getMessagePublishRequestOrBuilder() {
     if (requestTypeCase_ == 2) {
-       return (com.google.cloud.pubsublite.proto.MessagePublishRequest) requestType_;
+      return (com.google.cloud.pubsublite.proto.MessagePublishRequest) requestType_;
     }
     return com.google.cloud.pubsublite.proto.MessagePublishRequest.getDefaultInstance();
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -245,13 +285,14 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (requestTypeCase_ == 1) {
-      output.writeMessage(1, (com.google.cloud.pubsublite.proto.InitialPublishRequest) requestType_);
+      output.writeMessage(
+          1, (com.google.cloud.pubsublite.proto.InitialPublishRequest) requestType_);
     }
     if (requestTypeCase_ == 2) {
-      output.writeMessage(2, (com.google.cloud.pubsublite.proto.MessagePublishRequest) requestType_);
+      output.writeMessage(
+          2, (com.google.cloud.pubsublite.proto.MessagePublishRequest) requestType_);
     }
     unknownFields.writeTo(output);
   }
@@ -263,12 +304,14 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (requestTypeCase_ == 1) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, (com.google.cloud.pubsublite.proto.InitialPublishRequest) requestType_);
+      size +=
+          com.google.protobuf.CodedOutputStream.computeMessageSize(
+              1, (com.google.cloud.pubsublite.proto.InitialPublishRequest) requestType_);
     }
     if (requestTypeCase_ == 2) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, (com.google.cloud.pubsublite.proto.MessagePublishRequest) requestType_);
+      size +=
+          com.google.protobuf.CodedOutputStream.computeMessageSize(
+              2, (com.google.cloud.pubsublite.proto.MessagePublishRequest) requestType_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -278,22 +321,21 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.PublishRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.PublishRequest other = (com.google.cloud.pubsublite.proto.PublishRequest) obj;
+    com.google.cloud.pubsublite.proto.PublishRequest other =
+        (com.google.cloud.pubsublite.proto.PublishRequest) obj;
 
     if (!getRequestTypeCase().equals(other.getRequestTypeCase())) return false;
     switch (requestTypeCase_) {
       case 1:
-        if (!getInitialRequest()
-            .equals(other.getInitialRequest())) return false;
+        if (!getInitialRequest().equals(other.getInitialRequest())) return false;
         break;
       case 2:
-        if (!getMessagePublishRequest()
-            .equals(other.getMessagePublishRequest())) return false;
+        if (!getMessagePublishRequest().equals(other.getMessagePublishRequest())) return false;
         break;
       case 0:
       default:
@@ -326,118 +368,127 @@ private static final long serialVersionUID = 0L;
     return hash;
   }
 
-  public static com.google.cloud.pubsublite.proto.PublishRequest parseFrom(
-      java.nio.ByteBuffer data)
+  public static com.google.cloud.pubsublite.proto.PublishRequest parseFrom(java.nio.ByteBuffer data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.PublishRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.PublishRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.PublishRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.PublishRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.PublishRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.PublishRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.PublishRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.PublishRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.PublishRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.PublishRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.PublishRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.PublishRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.PublishRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.PublishRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request sent from the client to the server on a stream.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.PublishRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.PublishRequest)
       com.google.cloud.pubsublite.proto.PublishRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_PublishRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_PublishRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_PublishRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_PublishRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.PublishRequest.class, com.google.cloud.pubsublite.proto.PublishRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.PublishRequest.class,
+              com.google.cloud.pubsublite.proto.PublishRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.PublishRequest.newBuilder()
@@ -445,16 +496,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -464,9 +514,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_PublishRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_PublishRequest_descriptor;
     }
 
     @java.lang.Override
@@ -485,7 +535,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.PublishRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.PublishRequest result = new com.google.cloud.pubsublite.proto.PublishRequest(this);
+      com.google.cloud.pubsublite.proto.PublishRequest result =
+          new com.google.cloud.pubsublite.proto.PublishRequest(this);
       if (requestTypeCase_ == 1) {
         if (initialRequestBuilder_ == null) {
           result.requestType_ = requestType_;
@@ -509,38 +560,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.PublishRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.PublishRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.PublishRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -548,19 +600,23 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.PublishRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.PublishRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.PublishRequest.getDefaultInstance())
+        return this;
       switch (other.getRequestTypeCase()) {
-        case INITIAL_REQUEST: {
-          mergeInitialRequest(other.getInitialRequest());
-          break;
-        }
-        case MESSAGE_PUBLISH_REQUEST: {
-          mergeMessagePublishRequest(other.getMessagePublishRequest());
-          break;
-        }
-        case REQUESTTYPE_NOT_SET: {
-          break;
-        }
+        case INITIAL_REQUEST:
+          {
+            mergeInitialRequest(other.getInitialRequest());
+            break;
+          }
+        case MESSAGE_PUBLISH_REQUEST:
+          {
+            mergeMessagePublishRequest(other.getMessagePublishRequest());
+            break;
+          }
+        case REQUESTTYPE_NOT_SET:
+          {
+            break;
+          }
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -590,12 +646,12 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     private int requestTypeCase_ = 0;
     private java.lang.Object requestType_;
-    public RequestTypeCase
-        getRequestTypeCase() {
-      return RequestTypeCase.forNumber(
-          requestTypeCase_);
+
+    public RequestTypeCase getRequestTypeCase() {
+      return RequestTypeCase.forNumber(requestTypeCase_);
     }
 
     public Builder clearRequestType() {
@@ -605,26 +661,34 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.InitialPublishRequest, com.google.cloud.pubsublite.proto.InitialPublishRequest.Builder, com.google.cloud.pubsublite.proto.InitialPublishRequestOrBuilder> initialRequestBuilder_;
+            com.google.cloud.pubsublite.proto.InitialPublishRequest,
+            com.google.cloud.pubsublite.proto.InitialPublishRequest.Builder,
+            com.google.cloud.pubsublite.proto.InitialPublishRequestOrBuilder>
+        initialRequestBuilder_;
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialPublishRequest initial_request = 1;</code>
+     *
      * @return Whether the initialRequest field is set.
      */
     public boolean hasInitialRequest() {
       return requestTypeCase_ == 1;
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialPublishRequest initial_request = 1;</code>
+     *
      * @return The initialRequest.
      */
     public com.google.cloud.pubsublite.proto.InitialPublishRequest getInitialRequest() {
@@ -641,13 +705,16 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialPublishRequest initial_request = 1;</code>
      */
-    public Builder setInitialRequest(com.google.cloud.pubsublite.proto.InitialPublishRequest value) {
+    public Builder setInitialRequest(
+        com.google.cloud.pubsublite.proto.InitialPublishRequest value) {
       if (initialRequestBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
@@ -661,6 +728,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
@@ -679,18 +748,25 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialPublishRequest initial_request = 1;</code>
      */
-    public Builder mergeInitialRequest(com.google.cloud.pubsublite.proto.InitialPublishRequest value) {
+    public Builder mergeInitialRequest(
+        com.google.cloud.pubsublite.proto.InitialPublishRequest value) {
       if (initialRequestBuilder_ == null) {
-        if (requestTypeCase_ == 1 &&
-            requestType_ != com.google.cloud.pubsublite.proto.InitialPublishRequest.getDefaultInstance()) {
-          requestType_ = com.google.cloud.pubsublite.proto.InitialPublishRequest.newBuilder((com.google.cloud.pubsublite.proto.InitialPublishRequest) requestType_)
-              .mergeFrom(value).buildPartial();
+        if (requestTypeCase_ == 1
+            && requestType_
+                != com.google.cloud.pubsublite.proto.InitialPublishRequest.getDefaultInstance()) {
+          requestType_ =
+              com.google.cloud.pubsublite.proto.InitialPublishRequest.newBuilder(
+                      (com.google.cloud.pubsublite.proto.InitialPublishRequest) requestType_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           requestType_ = value;
         }
@@ -705,6 +781,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
@@ -728,23 +806,29 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialPublishRequest initial_request = 1;</code>
      */
-    public com.google.cloud.pubsublite.proto.InitialPublishRequest.Builder getInitialRequestBuilder() {
+    public com.google.cloud.pubsublite.proto.InitialPublishRequest.Builder
+        getInitialRequestBuilder() {
       return getInitialRequestFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialPublishRequest initial_request = 1;</code>
      */
-    public com.google.cloud.pubsublite.proto.InitialPublishRequestOrBuilder getInitialRequestOrBuilder() {
+    public com.google.cloud.pubsublite.proto.InitialPublishRequestOrBuilder
+        getInitialRequestOrBuilder() {
       if ((requestTypeCase_ == 1) && (initialRequestBuilder_ != null)) {
         return initialRequestBuilder_.getMessageOrBuilder();
       } else {
@@ -755,6 +839,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
@@ -762,43 +848,59 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.InitialPublishRequest initial_request = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.InitialPublishRequest, com.google.cloud.pubsublite.proto.InitialPublishRequest.Builder, com.google.cloud.pubsublite.proto.InitialPublishRequestOrBuilder> 
+            com.google.cloud.pubsublite.proto.InitialPublishRequest,
+            com.google.cloud.pubsublite.proto.InitialPublishRequest.Builder,
+            com.google.cloud.pubsublite.proto.InitialPublishRequestOrBuilder>
         getInitialRequestFieldBuilder() {
       if (initialRequestBuilder_ == null) {
         if (!(requestTypeCase_ == 1)) {
-          requestType_ = com.google.cloud.pubsublite.proto.InitialPublishRequest.getDefaultInstance();
+          requestType_ =
+              com.google.cloud.pubsublite.proto.InitialPublishRequest.getDefaultInstance();
         }
-        initialRequestBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.InitialPublishRequest, com.google.cloud.pubsublite.proto.InitialPublishRequest.Builder, com.google.cloud.pubsublite.proto.InitialPublishRequestOrBuilder>(
+        initialRequestBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.InitialPublishRequest,
+                com.google.cloud.pubsublite.proto.InitialPublishRequest.Builder,
+                com.google.cloud.pubsublite.proto.InitialPublishRequestOrBuilder>(
                 (com.google.cloud.pubsublite.proto.InitialPublishRequest) requestType_,
                 getParentForChildren(),
                 isClean());
         requestType_ = null;
       }
       requestTypeCase_ = 1;
-      onChanged();;
+      onChanged();
+      ;
       return initialRequestBuilder_;
     }
 
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.MessagePublishRequest, com.google.cloud.pubsublite.proto.MessagePublishRequest.Builder, com.google.cloud.pubsublite.proto.MessagePublishRequestOrBuilder> messagePublishRequestBuilder_;
+            com.google.cloud.pubsublite.proto.MessagePublishRequest,
+            com.google.cloud.pubsublite.proto.MessagePublishRequest.Builder,
+            com.google.cloud.pubsublite.proto.MessagePublishRequestOrBuilder>
+        messagePublishRequestBuilder_;
     /**
+     *
+     *
      * <pre>
      * Request to publish messages.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.MessagePublishRequest message_publish_request = 2;</code>
+     *
      * @return Whether the messagePublishRequest field is set.
      */
     public boolean hasMessagePublishRequest() {
       return requestTypeCase_ == 2;
     }
     /**
+     *
+     *
      * <pre>
      * Request to publish messages.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.MessagePublishRequest message_publish_request = 2;</code>
+     *
      * @return The messagePublishRequest.
      */
     public com.google.cloud.pubsublite.proto.MessagePublishRequest getMessagePublishRequest() {
@@ -815,13 +917,16 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Request to publish messages.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.MessagePublishRequest message_publish_request = 2;</code>
      */
-    public Builder setMessagePublishRequest(com.google.cloud.pubsublite.proto.MessagePublishRequest value) {
+    public Builder setMessagePublishRequest(
+        com.google.cloud.pubsublite.proto.MessagePublishRequest value) {
       if (messagePublishRequestBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
@@ -835,6 +940,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Request to publish messages.
      * </pre>
@@ -853,18 +960,25 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Request to publish messages.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.MessagePublishRequest message_publish_request = 2;</code>
      */
-    public Builder mergeMessagePublishRequest(com.google.cloud.pubsublite.proto.MessagePublishRequest value) {
+    public Builder mergeMessagePublishRequest(
+        com.google.cloud.pubsublite.proto.MessagePublishRequest value) {
       if (messagePublishRequestBuilder_ == null) {
-        if (requestTypeCase_ == 2 &&
-            requestType_ != com.google.cloud.pubsublite.proto.MessagePublishRequest.getDefaultInstance()) {
-          requestType_ = com.google.cloud.pubsublite.proto.MessagePublishRequest.newBuilder((com.google.cloud.pubsublite.proto.MessagePublishRequest) requestType_)
-              .mergeFrom(value).buildPartial();
+        if (requestTypeCase_ == 2
+            && requestType_
+                != com.google.cloud.pubsublite.proto.MessagePublishRequest.getDefaultInstance()) {
+          requestType_ =
+              com.google.cloud.pubsublite.proto.MessagePublishRequest.newBuilder(
+                      (com.google.cloud.pubsublite.proto.MessagePublishRequest) requestType_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           requestType_ = value;
         }
@@ -879,6 +993,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Request to publish messages.
      * </pre>
@@ -902,23 +1018,29 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Request to publish messages.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.MessagePublishRequest message_publish_request = 2;</code>
      */
-    public com.google.cloud.pubsublite.proto.MessagePublishRequest.Builder getMessagePublishRequestBuilder() {
+    public com.google.cloud.pubsublite.proto.MessagePublishRequest.Builder
+        getMessagePublishRequestBuilder() {
       return getMessagePublishRequestFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * Request to publish messages.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.MessagePublishRequest message_publish_request = 2;</code>
      */
-    public com.google.cloud.pubsublite.proto.MessagePublishRequestOrBuilder getMessagePublishRequestOrBuilder() {
+    public com.google.cloud.pubsublite.proto.MessagePublishRequestOrBuilder
+        getMessagePublishRequestOrBuilder() {
       if ((requestTypeCase_ == 2) && (messagePublishRequestBuilder_ != null)) {
         return messagePublishRequestBuilder_.getMessageOrBuilder();
       } else {
@@ -929,6 +1051,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Request to publish messages.
      * </pre>
@@ -936,26 +1060,33 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.MessagePublishRequest message_publish_request = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.MessagePublishRequest, com.google.cloud.pubsublite.proto.MessagePublishRequest.Builder, com.google.cloud.pubsublite.proto.MessagePublishRequestOrBuilder> 
+            com.google.cloud.pubsublite.proto.MessagePublishRequest,
+            com.google.cloud.pubsublite.proto.MessagePublishRequest.Builder,
+            com.google.cloud.pubsublite.proto.MessagePublishRequestOrBuilder>
         getMessagePublishRequestFieldBuilder() {
       if (messagePublishRequestBuilder_ == null) {
         if (!(requestTypeCase_ == 2)) {
-          requestType_ = com.google.cloud.pubsublite.proto.MessagePublishRequest.getDefaultInstance();
+          requestType_ =
+              com.google.cloud.pubsublite.proto.MessagePublishRequest.getDefaultInstance();
         }
-        messagePublishRequestBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.MessagePublishRequest, com.google.cloud.pubsublite.proto.MessagePublishRequest.Builder, com.google.cloud.pubsublite.proto.MessagePublishRequestOrBuilder>(
+        messagePublishRequestBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.MessagePublishRequest,
+                com.google.cloud.pubsublite.proto.MessagePublishRequest.Builder,
+                com.google.cloud.pubsublite.proto.MessagePublishRequestOrBuilder>(
                 (com.google.cloud.pubsublite.proto.MessagePublishRequest) requestType_,
                 getParentForChildren(),
                 isClean());
         requestType_ = null;
       }
       requestTypeCase_ = 2;
-      onChanged();;
+      onChanged();
+      ;
       return messagePublishRequestBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -965,12 +1096,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.PublishRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.PublishRequest)
   private static final com.google.cloud.pubsublite.proto.PublishRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.PublishRequest();
   }
@@ -979,16 +1110,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<PublishRequest>
-      PARSER = new com.google.protobuf.AbstractParser<PublishRequest>() {
-    @java.lang.Override
-    public PublishRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new PublishRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<PublishRequest> PARSER =
+      new com.google.protobuf.AbstractParser<PublishRequest>() {
+        @java.lang.Override
+        public PublishRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new PublishRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<PublishRequest> parser() {
     return PARSER;
@@ -1003,6 +1134,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.PublishRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PublishRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PublishRequestOrBuilder.java
@@ -3,29 +3,38 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface PublishRequestOrBuilder extends
+public interface PublishRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.PublishRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialPublishRequest initial_request = 1;</code>
+   *
    * @return Whether the initialRequest field is set.
    */
   boolean hasInitialRequest();
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialPublishRequest initial_request = 1;</code>
+   *
    * @return The initialRequest.
    */
   com.google.cloud.pubsublite.proto.InitialPublishRequest getInitialRequest();
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
@@ -35,31 +44,40 @@ public interface PublishRequestOrBuilder extends
   com.google.cloud.pubsublite.proto.InitialPublishRequestOrBuilder getInitialRequestOrBuilder();
 
   /**
+   *
+   *
    * <pre>
    * Request to publish messages.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.MessagePublishRequest message_publish_request = 2;</code>
+   *
    * @return Whether the messagePublishRequest field is set.
    */
   boolean hasMessagePublishRequest();
   /**
+   *
+   *
    * <pre>
    * Request to publish messages.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.MessagePublishRequest message_publish_request = 2;</code>
+   *
    * @return The messagePublishRequest.
    */
   com.google.cloud.pubsublite.proto.MessagePublishRequest getMessagePublishRequest();
   /**
+   *
+   *
    * <pre>
    * Request to publish messages.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.MessagePublishRequest message_publish_request = 2;</code>
    */
-  com.google.cloud.pubsublite.proto.MessagePublishRequestOrBuilder getMessagePublishRequestOrBuilder();
+  com.google.cloud.pubsublite.proto.MessagePublishRequestOrBuilder
+      getMessagePublishRequestOrBuilder();
 
   public com.google.cloud.pubsublite.proto.PublishRequest.RequestTypeCase getRequestTypeCase();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PublishResponse.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PublishResponse.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Response to a PublishRequest.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.PublishResponse}
  */
-public  final class PublishResponse extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class PublishResponse extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.PublishResponse)
     PublishResponseOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use PublishResponse.newBuilder() to construct.
   private PublishResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private PublishResponse() {
-  }
+
+  private PublishResponse() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new PublishResponse();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private PublishResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,75 +53,92 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            com.google.cloud.pubsublite.proto.InitialPublishResponse.Builder subBuilder = null;
-            if (responseTypeCase_ == 1) {
-              subBuilder = ((com.google.cloud.pubsublite.proto.InitialPublishResponse) responseType_).toBuilder();
+          case 10:
+            {
+              com.google.cloud.pubsublite.proto.InitialPublishResponse.Builder subBuilder = null;
+              if (responseTypeCase_ == 1) {
+                subBuilder =
+                    ((com.google.cloud.pubsublite.proto.InitialPublishResponse) responseType_)
+                        .toBuilder();
+              }
+              responseType_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.InitialPublishResponse.parser(),
+                      extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(
+                    (com.google.cloud.pubsublite.proto.InitialPublishResponse) responseType_);
+                responseType_ = subBuilder.buildPartial();
+              }
+              responseTypeCase_ = 1;
+              break;
             }
-            responseType_ =
-                input.readMessage(com.google.cloud.pubsublite.proto.InitialPublishResponse.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.InitialPublishResponse) responseType_);
-              responseType_ = subBuilder.buildPartial();
+          case 18:
+            {
+              com.google.cloud.pubsublite.proto.MessagePublishResponse.Builder subBuilder = null;
+              if (responseTypeCase_ == 2) {
+                subBuilder =
+                    ((com.google.cloud.pubsublite.proto.MessagePublishResponse) responseType_)
+                        .toBuilder();
+              }
+              responseType_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.MessagePublishResponse.parser(),
+                      extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(
+                    (com.google.cloud.pubsublite.proto.MessagePublishResponse) responseType_);
+                responseType_ = subBuilder.buildPartial();
+              }
+              responseTypeCase_ = 2;
+              break;
             }
-            responseTypeCase_ = 1;
-            break;
-          }
-          case 18: {
-            com.google.cloud.pubsublite.proto.MessagePublishResponse.Builder subBuilder = null;
-            if (responseTypeCase_ == 2) {
-              subBuilder = ((com.google.cloud.pubsublite.proto.MessagePublishResponse) responseType_).toBuilder();
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
             }
-            responseType_ =
-                input.readMessage(com.google.cloud.pubsublite.proto.MessagePublishResponse.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.MessagePublishResponse) responseType_);
-              responseType_ = subBuilder.buildPartial();
-            }
-            responseTypeCase_ = 2;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_PublishResponse_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.PublisherProto
+        .internal_static_google_cloud_pubsublite_v1_PublishResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_PublishResponse_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.PublisherProto
+        .internal_static_google_cloud_pubsublite_v1_PublishResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.PublishResponse.class, com.google.cloud.pubsublite.proto.PublishResponse.Builder.class);
+            com.google.cloud.pubsublite.proto.PublishResponse.class,
+            com.google.cloud.pubsublite.proto.PublishResponse.Builder.class);
   }
 
   private int responseTypeCase_ = 0;
   private java.lang.Object responseType_;
+
   public enum ResponseTypeCase
-      implements com.google.protobuf.Internal.EnumLite,
+      implements
+          com.google.protobuf.Internal.EnumLite,
           com.google.protobuf.AbstractMessage.InternalOneOfEnum {
     INITIAL_RESPONSE(1),
     MESSAGE_RESPONSE(2),
     RESPONSETYPE_NOT_SET(0);
     private final int value;
+
     private ResponseTypeCase(int value) {
       this.value = value;
     }
@@ -136,104 +154,126 @@ private static final long serialVersionUID = 0L;
 
     public static ResponseTypeCase forNumber(int value) {
       switch (value) {
-        case 1: return INITIAL_RESPONSE;
-        case 2: return MESSAGE_RESPONSE;
-        case 0: return RESPONSETYPE_NOT_SET;
-        default: return null;
+        case 1:
+          return INITIAL_RESPONSE;
+        case 2:
+          return MESSAGE_RESPONSE;
+        case 0:
+          return RESPONSETYPE_NOT_SET;
+        default:
+          return null;
       }
     }
+
     public int getNumber() {
       return this.value;
     }
   };
 
-  public ResponseTypeCase
-  getResponseTypeCase() {
-    return ResponseTypeCase.forNumber(
-        responseTypeCase_);
+  public ResponseTypeCase getResponseTypeCase() {
+    return ResponseTypeCase.forNumber(responseTypeCase_);
   }
 
   public static final int INITIAL_RESPONSE_FIELD_NUMBER = 1;
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialPublishResponse initial_response = 1;</code>
+   *
    * @return Whether the initialResponse field is set.
    */
   public boolean hasInitialResponse() {
     return responseTypeCase_ == 1;
   }
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialPublishResponse initial_response = 1;</code>
+   *
    * @return The initialResponse.
    */
   public com.google.cloud.pubsublite.proto.InitialPublishResponse getInitialResponse() {
     if (responseTypeCase_ == 1) {
-       return (com.google.cloud.pubsublite.proto.InitialPublishResponse) responseType_;
+      return (com.google.cloud.pubsublite.proto.InitialPublishResponse) responseType_;
     }
     return com.google.cloud.pubsublite.proto.InitialPublishResponse.getDefaultInstance();
   }
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialPublishResponse initial_response = 1;</code>
    */
-  public com.google.cloud.pubsublite.proto.InitialPublishResponseOrBuilder getInitialResponseOrBuilder() {
+  public com.google.cloud.pubsublite.proto.InitialPublishResponseOrBuilder
+      getInitialResponseOrBuilder() {
     if (responseTypeCase_ == 1) {
-       return (com.google.cloud.pubsublite.proto.InitialPublishResponse) responseType_;
+      return (com.google.cloud.pubsublite.proto.InitialPublishResponse) responseType_;
     }
     return com.google.cloud.pubsublite.proto.InitialPublishResponse.getDefaultInstance();
   }
 
   public static final int MESSAGE_RESPONSE_FIELD_NUMBER = 2;
   /**
+   *
+   *
    * <pre>
    * Response to publishing messages.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.MessagePublishResponse message_response = 2;</code>
+   *
    * @return Whether the messageResponse field is set.
    */
   public boolean hasMessageResponse() {
     return responseTypeCase_ == 2;
   }
   /**
+   *
+   *
    * <pre>
    * Response to publishing messages.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.MessagePublishResponse message_response = 2;</code>
+   *
    * @return The messageResponse.
    */
   public com.google.cloud.pubsublite.proto.MessagePublishResponse getMessageResponse() {
     if (responseTypeCase_ == 2) {
-       return (com.google.cloud.pubsublite.proto.MessagePublishResponse) responseType_;
+      return (com.google.cloud.pubsublite.proto.MessagePublishResponse) responseType_;
     }
     return com.google.cloud.pubsublite.proto.MessagePublishResponse.getDefaultInstance();
   }
   /**
+   *
+   *
    * <pre>
    * Response to publishing messages.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.MessagePublishResponse message_response = 2;</code>
    */
-  public com.google.cloud.pubsublite.proto.MessagePublishResponseOrBuilder getMessageResponseOrBuilder() {
+  public com.google.cloud.pubsublite.proto.MessagePublishResponseOrBuilder
+      getMessageResponseOrBuilder() {
     if (responseTypeCase_ == 2) {
-       return (com.google.cloud.pubsublite.proto.MessagePublishResponse) responseType_;
+      return (com.google.cloud.pubsublite.proto.MessagePublishResponse) responseType_;
     }
     return com.google.cloud.pubsublite.proto.MessagePublishResponse.getDefaultInstance();
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -245,13 +285,14 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (responseTypeCase_ == 1) {
-      output.writeMessage(1, (com.google.cloud.pubsublite.proto.InitialPublishResponse) responseType_);
+      output.writeMessage(
+          1, (com.google.cloud.pubsublite.proto.InitialPublishResponse) responseType_);
     }
     if (responseTypeCase_ == 2) {
-      output.writeMessage(2, (com.google.cloud.pubsublite.proto.MessagePublishResponse) responseType_);
+      output.writeMessage(
+          2, (com.google.cloud.pubsublite.proto.MessagePublishResponse) responseType_);
     }
     unknownFields.writeTo(output);
   }
@@ -263,12 +304,14 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (responseTypeCase_ == 1) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, (com.google.cloud.pubsublite.proto.InitialPublishResponse) responseType_);
+      size +=
+          com.google.protobuf.CodedOutputStream.computeMessageSize(
+              1, (com.google.cloud.pubsublite.proto.InitialPublishResponse) responseType_);
     }
     if (responseTypeCase_ == 2) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, (com.google.cloud.pubsublite.proto.MessagePublishResponse) responseType_);
+      size +=
+          com.google.protobuf.CodedOutputStream.computeMessageSize(
+              2, (com.google.cloud.pubsublite.proto.MessagePublishResponse) responseType_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -278,22 +321,21 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.PublishResponse)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.PublishResponse other = (com.google.cloud.pubsublite.proto.PublishResponse) obj;
+    com.google.cloud.pubsublite.proto.PublishResponse other =
+        (com.google.cloud.pubsublite.proto.PublishResponse) obj;
 
     if (!getResponseTypeCase().equals(other.getResponseTypeCase())) return false;
     switch (responseTypeCase_) {
       case 1:
-        if (!getInitialResponse()
-            .equals(other.getInitialResponse())) return false;
+        if (!getInitialResponse().equals(other.getInitialResponse())) return false;
         break;
       case 2:
-        if (!getMessageResponse()
-            .equals(other.getMessageResponse())) return false;
+        if (!getMessageResponse().equals(other.getMessageResponse())) return false;
         break;
       case 0:
       default:
@@ -327,117 +369,126 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.PublishResponse parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.PublishResponse parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.PublishResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.PublishResponse parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.PublishResponse parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.PublishResponse parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.PublishResponse parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.PublishResponse parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.PublishResponse parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.PublishResponse parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.PublishResponse parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.PublishResponse parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.PublishResponse parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.PublishResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.PublishResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Response to a PublishRequest.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.PublishResponse}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.PublishResponse)
       com.google.cloud.pubsublite.proto.PublishResponseOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_PublishResponse_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_PublishResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_PublishResponse_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_PublishResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.PublishResponse.class, com.google.cloud.pubsublite.proto.PublishResponse.Builder.class);
+              com.google.cloud.pubsublite.proto.PublishResponse.class,
+              com.google.cloud.pubsublite.proto.PublishResponse.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.PublishResponse.newBuilder()
@@ -445,16 +496,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -464,9 +514,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.PublisherProto.internal_static_google_cloud_pubsublite_v1_PublishResponse_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.PublisherProto
+          .internal_static_google_cloud_pubsublite_v1_PublishResponse_descriptor;
     }
 
     @java.lang.Override
@@ -485,7 +535,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.PublishResponse buildPartial() {
-      com.google.cloud.pubsublite.proto.PublishResponse result = new com.google.cloud.pubsublite.proto.PublishResponse(this);
+      com.google.cloud.pubsublite.proto.PublishResponse result =
+          new com.google.cloud.pubsublite.proto.PublishResponse(this);
       if (responseTypeCase_ == 1) {
         if (initialResponseBuilder_ == null) {
           result.responseType_ = responseType_;
@@ -509,38 +560,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.PublishResponse) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.PublishResponse)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.PublishResponse) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -548,19 +600,23 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.PublishResponse other) {
-      if (other == com.google.cloud.pubsublite.proto.PublishResponse.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.PublishResponse.getDefaultInstance())
+        return this;
       switch (other.getResponseTypeCase()) {
-        case INITIAL_RESPONSE: {
-          mergeInitialResponse(other.getInitialResponse());
-          break;
-        }
-        case MESSAGE_RESPONSE: {
-          mergeMessageResponse(other.getMessageResponse());
-          break;
-        }
-        case RESPONSETYPE_NOT_SET: {
-          break;
-        }
+        case INITIAL_RESPONSE:
+          {
+            mergeInitialResponse(other.getInitialResponse());
+            break;
+          }
+        case MESSAGE_RESPONSE:
+          {
+            mergeMessageResponse(other.getMessageResponse());
+            break;
+          }
+        case RESPONSETYPE_NOT_SET:
+          {
+            break;
+          }
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -581,7 +637,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.PublishResponse) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.PublishResponse) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -590,12 +647,12 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     private int responseTypeCase_ = 0;
     private java.lang.Object responseType_;
-    public ResponseTypeCase
-        getResponseTypeCase() {
-      return ResponseTypeCase.forNumber(
-          responseTypeCase_);
+
+    public ResponseTypeCase getResponseTypeCase() {
+      return ResponseTypeCase.forNumber(responseTypeCase_);
     }
 
     public Builder clearResponseType() {
@@ -605,26 +662,34 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.InitialPublishResponse, com.google.cloud.pubsublite.proto.InitialPublishResponse.Builder, com.google.cloud.pubsublite.proto.InitialPublishResponseOrBuilder> initialResponseBuilder_;
+            com.google.cloud.pubsublite.proto.InitialPublishResponse,
+            com.google.cloud.pubsublite.proto.InitialPublishResponse.Builder,
+            com.google.cloud.pubsublite.proto.InitialPublishResponseOrBuilder>
+        initialResponseBuilder_;
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialPublishResponse initial_response = 1;</code>
+     *
      * @return Whether the initialResponse field is set.
      */
     public boolean hasInitialResponse() {
       return responseTypeCase_ == 1;
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialPublishResponse initial_response = 1;</code>
+     *
      * @return The initialResponse.
      */
     public com.google.cloud.pubsublite.proto.InitialPublishResponse getInitialResponse() {
@@ -641,13 +706,16 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialPublishResponse initial_response = 1;</code>
      */
-    public Builder setInitialResponse(com.google.cloud.pubsublite.proto.InitialPublishResponse value) {
+    public Builder setInitialResponse(
+        com.google.cloud.pubsublite.proto.InitialPublishResponse value) {
       if (initialResponseBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
@@ -661,6 +729,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
@@ -679,18 +749,25 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialPublishResponse initial_response = 1;</code>
      */
-    public Builder mergeInitialResponse(com.google.cloud.pubsublite.proto.InitialPublishResponse value) {
+    public Builder mergeInitialResponse(
+        com.google.cloud.pubsublite.proto.InitialPublishResponse value) {
       if (initialResponseBuilder_ == null) {
-        if (responseTypeCase_ == 1 &&
-            responseType_ != com.google.cloud.pubsublite.proto.InitialPublishResponse.getDefaultInstance()) {
-          responseType_ = com.google.cloud.pubsublite.proto.InitialPublishResponse.newBuilder((com.google.cloud.pubsublite.proto.InitialPublishResponse) responseType_)
-              .mergeFrom(value).buildPartial();
+        if (responseTypeCase_ == 1
+            && responseType_
+                != com.google.cloud.pubsublite.proto.InitialPublishResponse.getDefaultInstance()) {
+          responseType_ =
+              com.google.cloud.pubsublite.proto.InitialPublishResponse.newBuilder(
+                      (com.google.cloud.pubsublite.proto.InitialPublishResponse) responseType_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           responseType_ = value;
         }
@@ -705,6 +782,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
@@ -728,23 +807,29 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialPublishResponse initial_response = 1;</code>
      */
-    public com.google.cloud.pubsublite.proto.InitialPublishResponse.Builder getInitialResponseBuilder() {
+    public com.google.cloud.pubsublite.proto.InitialPublishResponse.Builder
+        getInitialResponseBuilder() {
       return getInitialResponseFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialPublishResponse initial_response = 1;</code>
      */
-    public com.google.cloud.pubsublite.proto.InitialPublishResponseOrBuilder getInitialResponseOrBuilder() {
+    public com.google.cloud.pubsublite.proto.InitialPublishResponseOrBuilder
+        getInitialResponseOrBuilder() {
       if ((responseTypeCase_ == 1) && (initialResponseBuilder_ != null)) {
         return initialResponseBuilder_.getMessageOrBuilder();
       } else {
@@ -755,6 +840,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
@@ -762,43 +849,59 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.InitialPublishResponse initial_response = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.InitialPublishResponse, com.google.cloud.pubsublite.proto.InitialPublishResponse.Builder, com.google.cloud.pubsublite.proto.InitialPublishResponseOrBuilder> 
+            com.google.cloud.pubsublite.proto.InitialPublishResponse,
+            com.google.cloud.pubsublite.proto.InitialPublishResponse.Builder,
+            com.google.cloud.pubsublite.proto.InitialPublishResponseOrBuilder>
         getInitialResponseFieldBuilder() {
       if (initialResponseBuilder_ == null) {
         if (!(responseTypeCase_ == 1)) {
-          responseType_ = com.google.cloud.pubsublite.proto.InitialPublishResponse.getDefaultInstance();
+          responseType_ =
+              com.google.cloud.pubsublite.proto.InitialPublishResponse.getDefaultInstance();
         }
-        initialResponseBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.InitialPublishResponse, com.google.cloud.pubsublite.proto.InitialPublishResponse.Builder, com.google.cloud.pubsublite.proto.InitialPublishResponseOrBuilder>(
+        initialResponseBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.InitialPublishResponse,
+                com.google.cloud.pubsublite.proto.InitialPublishResponse.Builder,
+                com.google.cloud.pubsublite.proto.InitialPublishResponseOrBuilder>(
                 (com.google.cloud.pubsublite.proto.InitialPublishResponse) responseType_,
                 getParentForChildren(),
                 isClean());
         responseType_ = null;
       }
       responseTypeCase_ = 1;
-      onChanged();;
+      onChanged();
+      ;
       return initialResponseBuilder_;
     }
 
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.MessagePublishResponse, com.google.cloud.pubsublite.proto.MessagePublishResponse.Builder, com.google.cloud.pubsublite.proto.MessagePublishResponseOrBuilder> messageResponseBuilder_;
+            com.google.cloud.pubsublite.proto.MessagePublishResponse,
+            com.google.cloud.pubsublite.proto.MessagePublishResponse.Builder,
+            com.google.cloud.pubsublite.proto.MessagePublishResponseOrBuilder>
+        messageResponseBuilder_;
     /**
+     *
+     *
      * <pre>
      * Response to publishing messages.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.MessagePublishResponse message_response = 2;</code>
+     *
      * @return Whether the messageResponse field is set.
      */
     public boolean hasMessageResponse() {
       return responseTypeCase_ == 2;
     }
     /**
+     *
+     *
      * <pre>
      * Response to publishing messages.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.MessagePublishResponse message_response = 2;</code>
+     *
      * @return The messageResponse.
      */
     public com.google.cloud.pubsublite.proto.MessagePublishResponse getMessageResponse() {
@@ -815,13 +918,16 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Response to publishing messages.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.MessagePublishResponse message_response = 2;</code>
      */
-    public Builder setMessageResponse(com.google.cloud.pubsublite.proto.MessagePublishResponse value) {
+    public Builder setMessageResponse(
+        com.google.cloud.pubsublite.proto.MessagePublishResponse value) {
       if (messageResponseBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
@@ -835,6 +941,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Response to publishing messages.
      * </pre>
@@ -853,18 +961,25 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Response to publishing messages.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.MessagePublishResponse message_response = 2;</code>
      */
-    public Builder mergeMessageResponse(com.google.cloud.pubsublite.proto.MessagePublishResponse value) {
+    public Builder mergeMessageResponse(
+        com.google.cloud.pubsublite.proto.MessagePublishResponse value) {
       if (messageResponseBuilder_ == null) {
-        if (responseTypeCase_ == 2 &&
-            responseType_ != com.google.cloud.pubsublite.proto.MessagePublishResponse.getDefaultInstance()) {
-          responseType_ = com.google.cloud.pubsublite.proto.MessagePublishResponse.newBuilder((com.google.cloud.pubsublite.proto.MessagePublishResponse) responseType_)
-              .mergeFrom(value).buildPartial();
+        if (responseTypeCase_ == 2
+            && responseType_
+                != com.google.cloud.pubsublite.proto.MessagePublishResponse.getDefaultInstance()) {
+          responseType_ =
+              com.google.cloud.pubsublite.proto.MessagePublishResponse.newBuilder(
+                      (com.google.cloud.pubsublite.proto.MessagePublishResponse) responseType_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           responseType_ = value;
         }
@@ -879,6 +994,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Response to publishing messages.
      * </pre>
@@ -902,23 +1019,29 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Response to publishing messages.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.MessagePublishResponse message_response = 2;</code>
      */
-    public com.google.cloud.pubsublite.proto.MessagePublishResponse.Builder getMessageResponseBuilder() {
+    public com.google.cloud.pubsublite.proto.MessagePublishResponse.Builder
+        getMessageResponseBuilder() {
       return getMessageResponseFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * Response to publishing messages.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.MessagePublishResponse message_response = 2;</code>
      */
-    public com.google.cloud.pubsublite.proto.MessagePublishResponseOrBuilder getMessageResponseOrBuilder() {
+    public com.google.cloud.pubsublite.proto.MessagePublishResponseOrBuilder
+        getMessageResponseOrBuilder() {
       if ((responseTypeCase_ == 2) && (messageResponseBuilder_ != null)) {
         return messageResponseBuilder_.getMessageOrBuilder();
       } else {
@@ -929,6 +1052,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Response to publishing messages.
      * </pre>
@@ -936,26 +1061,33 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.MessagePublishResponse message_response = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.MessagePublishResponse, com.google.cloud.pubsublite.proto.MessagePublishResponse.Builder, com.google.cloud.pubsublite.proto.MessagePublishResponseOrBuilder> 
+            com.google.cloud.pubsublite.proto.MessagePublishResponse,
+            com.google.cloud.pubsublite.proto.MessagePublishResponse.Builder,
+            com.google.cloud.pubsublite.proto.MessagePublishResponseOrBuilder>
         getMessageResponseFieldBuilder() {
       if (messageResponseBuilder_ == null) {
         if (!(responseTypeCase_ == 2)) {
-          responseType_ = com.google.cloud.pubsublite.proto.MessagePublishResponse.getDefaultInstance();
+          responseType_ =
+              com.google.cloud.pubsublite.proto.MessagePublishResponse.getDefaultInstance();
         }
-        messageResponseBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.MessagePublishResponse, com.google.cloud.pubsublite.proto.MessagePublishResponse.Builder, com.google.cloud.pubsublite.proto.MessagePublishResponseOrBuilder>(
+        messageResponseBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.MessagePublishResponse,
+                com.google.cloud.pubsublite.proto.MessagePublishResponse.Builder,
+                com.google.cloud.pubsublite.proto.MessagePublishResponseOrBuilder>(
                 (com.google.cloud.pubsublite.proto.MessagePublishResponse) responseType_,
                 getParentForChildren(),
                 isClean());
         responseType_ = null;
       }
       responseTypeCase_ = 2;
-      onChanged();;
+      onChanged();
+      ;
       return messageResponseBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -965,12 +1097,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.PublishResponse)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.PublishResponse)
   private static final com.google.cloud.pubsublite.proto.PublishResponse DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.PublishResponse();
   }
@@ -979,16 +1111,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<PublishResponse>
-      PARSER = new com.google.protobuf.AbstractParser<PublishResponse>() {
-    @java.lang.Override
-    public PublishResponse parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new PublishResponse(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<PublishResponse> PARSER =
+      new com.google.protobuf.AbstractParser<PublishResponse>() {
+        @java.lang.Override
+        public PublishResponse parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new PublishResponse(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<PublishResponse> parser() {
     return PARSER;
@@ -1003,6 +1135,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.PublishResponse getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PublishResponseOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PublishResponseOrBuilder.java
@@ -3,29 +3,38 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface PublishResponseOrBuilder extends
+public interface PublishResponseOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.PublishResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialPublishResponse initial_response = 1;</code>
+   *
    * @return Whether the initialResponse field is set.
    */
   boolean hasInitialResponse();
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialPublishResponse initial_response = 1;</code>
+   *
    * @return The initialResponse.
    */
   com.google.cloud.pubsublite.proto.InitialPublishResponse getInitialResponse();
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
@@ -35,24 +44,32 @@ public interface PublishResponseOrBuilder extends
   com.google.cloud.pubsublite.proto.InitialPublishResponseOrBuilder getInitialResponseOrBuilder();
 
   /**
+   *
+   *
    * <pre>
    * Response to publishing messages.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.MessagePublishResponse message_response = 2;</code>
+   *
    * @return Whether the messageResponse field is set.
    */
   boolean hasMessageResponse();
   /**
+   *
+   *
    * <pre>
    * Response to publishing messages.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.MessagePublishResponse message_response = 2;</code>
+   *
    * @return The messageResponse.
    */
   com.google.cloud.pubsublite.proto.MessagePublishResponse getMessageResponse();
   /**
+   *
+   *
    * <pre>
    * Response to publishing messages.
    * </pre>

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PublisherProto.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/PublisherProto.java
@@ -5,120 +5,123 @@ package com.google.cloud.pubsublite.proto;
 
 public final class PublisherProto {
   private PublisherProto() {}
-  public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistryLite registry) {
+
+  public static void registerAllExtensions(com.google.protobuf.ExtensionRegistryLite registry) {}
+
+  public static void registerAllExtensions(com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions((com.google.protobuf.ExtensionRegistryLite) registry);
   }
 
-  public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
-    registerAllExtensions(
-        (com.google.protobuf.ExtensionRegistryLite) registry);
-  }
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_PublishRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_PublishRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_PublishRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_PublishResponse_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_PublishResponse_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_PublishResponse_fieldAccessorTable;
 
-  public static com.google.protobuf.Descriptors.FileDescriptor
-      getDescriptor() {
+  public static com.google.protobuf.Descriptors.FileDescriptor getDescriptor() {
     return descriptor;
   }
-  private static  com.google.protobuf.Descriptors.FileDescriptor
-      descriptor;
+
+  private static com.google.protobuf.Descriptors.FileDescriptor descriptor;
+
   static {
     java.lang.String[] descriptorData = {
-      "\n*google/cloud/pubsublite/v1/publisher.p" +
-      "roto\022\032google.cloud.pubsublite.v1\032\'google" +
-      "/cloud/pubsublite/v1/common.proto\"9\n\025Ini" +
-      "tialPublishRequest\022\r\n\005topic\030\001 \001(\t\022\021\n\tpar" +
-      "tition\030\002 \001(\003\"\030\n\026InitialPublishResponse\"T" +
-      "\n\025MessagePublishRequest\022;\n\010messages\030\001 \003(" +
-      "\0132).google.cloud.pubsublite.v1.PubSubMes" +
-      "sage\"R\n\026MessagePublishResponse\0228\n\014start_" +
-      "cursor\030\001 \001(\0132\".google.cloud.pubsublite.v" +
-      "1.Cursor\"\304\001\n\016PublishRequest\022L\n\017initial_r" +
-      "equest\030\001 \001(\01321.google.cloud.pubsublite.v" +
-      "1.InitialPublishRequestH\000\022T\n\027message_pub" +
-      "lish_request\030\002 \001(\01321.google.cloud.pubsub" +
-      "lite.v1.MessagePublishRequestH\000B\016\n\014reque" +
-      "st_type\"\302\001\n\017PublishResponse\022N\n\020initial_r" +
-      "esponse\030\001 \001(\01322.google.cloud.pubsublite." +
-      "v1.InitialPublishResponseH\000\022N\n\020message_r" +
-      "esponse\030\002 \001(\01322.google.cloud.pubsublite." +
-      "v1.MessagePublishResponseH\000B\017\n\rresponse_" +
-      "type2|\n\020PublisherService\022h\n\007Publish\022*.go" +
-      "ogle.cloud.pubsublite.v1.PublishRequest\032" +
-      "+.google.cloud.pubsublite.v1.PublishResp" +
-      "onse\"\000(\0010\001B8\n!com.google.cloud.pubsublit" +
-      "e.protoB\016PublisherProtoP\001\370\001\001b\006proto3"
+      "\n*google/cloud/pubsublite/v1/publisher.p"
+          + "roto\022\032google.cloud.pubsublite.v1\032\'google"
+          + "/cloud/pubsublite/v1/common.proto\"9\n\025Ini"
+          + "tialPublishRequest\022\r\n\005topic\030\001 \001(\t\022\021\n\tpar"
+          + "tition\030\002 \001(\003\"\030\n\026InitialPublishResponse\"T"
+          + "\n\025MessagePublishRequest\022;\n\010messages\030\001 \003("
+          + "\0132).google.cloud.pubsublite.v1.PubSubMes"
+          + "sage\"R\n\026MessagePublishResponse\0228\n\014start_"
+          + "cursor\030\001 \001(\0132\".google.cloud.pubsublite.v"
+          + "1.Cursor\"\304\001\n\016PublishRequest\022L\n\017initial_r"
+          + "equest\030\001 \001(\01321.google.cloud.pubsublite.v"
+          + "1.InitialPublishRequestH\000\022T\n\027message_pub"
+          + "lish_request\030\002 \001(\01321.google.cloud.pubsub"
+          + "lite.v1.MessagePublishRequestH\000B\016\n\014reque"
+          + "st_type\"\302\001\n\017PublishResponse\022N\n\020initial_r"
+          + "esponse\030\001 \001(\01322.google.cloud.pubsublite."
+          + "v1.InitialPublishResponseH\000\022N\n\020message_r"
+          + "esponse\030\002 \001(\01322.google.cloud.pubsublite."
+          + "v1.MessagePublishResponseH\000B\017\n\rresponse_"
+          + "type2|\n\020PublisherService\022h\n\007Publish\022*.go"
+          + "ogle.cloud.pubsublite.v1.PublishRequest\032"
+          + "+.google.cloud.pubsublite.v1.PublishResp"
+          + "onse\"\000(\0010\001B8\n!com.google.cloud.pubsublit"
+          + "e.protoB\016PublisherProtoP\001\370\001\001b\006proto3"
     };
-    descriptor = com.google.protobuf.Descriptors.FileDescriptor
-      .internalBuildGeneratedFileFrom(descriptorData,
-        new com.google.protobuf.Descriptors.FileDescriptor[] {
-          com.google.cloud.pubsublite.proto.CommonProto.getDescriptor(),
-        });
+    descriptor =
+        com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
+            descriptorData,
+            new com.google.protobuf.Descriptors.FileDescriptor[] {
+              com.google.cloud.pubsublite.proto.CommonProto.getDescriptor(),
+            });
     internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_descriptor =
-      getDescriptor().getMessageTypes().get(0);
-    internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_descriptor,
-        new java.lang.String[] { "Topic", "Partition", });
+        getDescriptor().getMessageTypes().get(0);
+    internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_InitialPublishRequest_descriptor,
+            new java.lang.String[] {
+              "Topic", "Partition",
+            });
     internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_descriptor =
-      getDescriptor().getMessageTypes().get(1);
-    internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_descriptor,
-        new java.lang.String[] { });
+        getDescriptor().getMessageTypes().get(1);
+    internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_InitialPublishResponse_descriptor,
+            new java.lang.String[] {});
     internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_descriptor =
-      getDescriptor().getMessageTypes().get(2);
-    internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_descriptor,
-        new java.lang.String[] { "Messages", });
+        getDescriptor().getMessageTypes().get(2);
+    internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_MessagePublishRequest_descriptor,
+            new java.lang.String[] {
+              "Messages",
+            });
     internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_descriptor =
-      getDescriptor().getMessageTypes().get(3);
-    internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_descriptor,
-        new java.lang.String[] { "StartCursor", });
+        getDescriptor().getMessageTypes().get(3);
+    internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_MessagePublishResponse_descriptor,
+            new java.lang.String[] {
+              "StartCursor",
+            });
     internal_static_google_cloud_pubsublite_v1_PublishRequest_descriptor =
-      getDescriptor().getMessageTypes().get(4);
-    internal_static_google_cloud_pubsublite_v1_PublishRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_PublishRequest_descriptor,
-        new java.lang.String[] { "InitialRequest", "MessagePublishRequest", "RequestType", });
+        getDescriptor().getMessageTypes().get(4);
+    internal_static_google_cloud_pubsublite_v1_PublishRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_PublishRequest_descriptor,
+            new java.lang.String[] {
+              "InitialRequest", "MessagePublishRequest", "RequestType",
+            });
     internal_static_google_cloud_pubsublite_v1_PublishResponse_descriptor =
-      getDescriptor().getMessageTypes().get(5);
-    internal_static_google_cloud_pubsublite_v1_PublishResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_PublishResponse_descriptor,
-        new java.lang.String[] { "InitialResponse", "MessageResponse", "ResponseType", });
+        getDescriptor().getMessageTypes().get(5);
+    internal_static_google_cloud_pubsublite_v1_PublishResponse_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_PublishResponse_descriptor,
+            new java.lang.String[] {
+              "InitialResponse", "MessageResponse", "ResponseType",
+            });
     com.google.cloud.pubsublite.proto.CommonProto.getDescriptor();
   }
 

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SeekRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SeekRequest.java
@@ -4,6 +4,8 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request to update the stream's delivery cursor based on the given target.
  * Resets the server available tokens to 0. SeekRequests may not be sent while
@@ -13,30 +15,29 @@ package com.google.cloud.pubsublite.proto;
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.SeekRequest}
  */
-public  final class SeekRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class SeekRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.SeekRequest)
     SeekRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use SeekRequest.newBuilder() to construct.
   private SeekRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private SeekRequest() {
-  }
+
+  private SeekRequest() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new SeekRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private SeekRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -55,68 +56,76 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 8: {
-            int rawValue = input.readEnum();
-            targetCase_ = 1;
-            target_ = rawValue;
-            break;
-          }
-          case 18: {
-            com.google.cloud.pubsublite.proto.Cursor.Builder subBuilder = null;
-            if (targetCase_ == 2) {
-              subBuilder = ((com.google.cloud.pubsublite.proto.Cursor) target_).toBuilder();
+          case 8:
+            {
+              int rawValue = input.readEnum();
+              targetCase_ = 1;
+              target_ = rawValue;
+              break;
             }
-            target_ =
-                input.readMessage(com.google.cloud.pubsublite.proto.Cursor.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.Cursor) target_);
-              target_ = subBuilder.buildPartial();
+          case 18:
+            {
+              com.google.cloud.pubsublite.proto.Cursor.Builder subBuilder = null;
+              if (targetCase_ == 2) {
+                subBuilder = ((com.google.cloud.pubsublite.proto.Cursor) target_).toBuilder();
+              }
+              target_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Cursor.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.Cursor) target_);
+                target_ = subBuilder.buildPartial();
+              }
+              targetCase_ = 2;
+              break;
             }
-            targetCase_ = 2;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
             }
-            break;
-          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SeekRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.SubscriberProto
+        .internal_static_google_cloud_pubsublite_v1_SeekRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SeekRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.SubscriberProto
+        .internal_static_google_cloud_pubsublite_v1_SeekRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.SeekRequest.class, com.google.cloud.pubsublite.proto.SeekRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.SeekRequest.class,
+            com.google.cloud.pubsublite.proto.SeekRequest.Builder.class);
   }
 
   /**
+   *
+   *
    * <pre>
    * A special target in the partition that takes no other parameters.
    * </pre>
    *
    * Protobuf enum {@code google.cloud.pubsublite.v1.SeekRequest.NamedTarget}
    */
-  public enum NamedTarget
-      implements com.google.protobuf.ProtocolMessageEnum {
+  public enum NamedTarget implements com.google.protobuf.ProtocolMessageEnum {
     /**
+     *
+     *
      * <pre>
      * Default value. This value is unused.
      * </pre>
@@ -125,6 +134,8 @@ private static final long serialVersionUID = 0L;
      */
     NAMED_TARGET_UNSPECIFIED(0),
     /**
+     *
+     *
      * <pre>
      * A target corresponding to the most recently published message in the
      * partition.
@@ -134,6 +145,8 @@ private static final long serialVersionUID = 0L;
      */
     HEAD(1),
     /**
+     *
+     *
      * <pre>
      * A target corresponding to the committed cursor for the given subscription
      * and topic partition.
@@ -146,6 +159,8 @@ private static final long serialVersionUID = 0L;
     ;
 
     /**
+     *
+     *
      * <pre>
      * Default value. This value is unused.
      * </pre>
@@ -154,6 +169,8 @@ private static final long serialVersionUID = 0L;
      */
     public static final int NAMED_TARGET_UNSPECIFIED_VALUE = 0;
     /**
+     *
+     *
      * <pre>
      * A target corresponding to the most recently published message in the
      * partition.
@@ -163,6 +180,8 @@ private static final long serialVersionUID = 0L;
      */
     public static final int HEAD_VALUE = 1;
     /**
+     *
+     *
      * <pre>
      * A target corresponding to the committed cursor for the given subscription
      * and topic partition.
@@ -171,7 +190,6 @@ private static final long serialVersionUID = 0L;
      * <code>COMMITTED_CURSOR = 2;</code>
      */
     public static final int COMMITTED_CURSOR_VALUE = 2;
-
 
     public final int getNumber() {
       if (this == UNRECOGNIZED) {
@@ -197,45 +215,45 @@ private static final long serialVersionUID = 0L;
      */
     public static NamedTarget forNumber(int value) {
       switch (value) {
-        case 0: return NAMED_TARGET_UNSPECIFIED;
-        case 1: return HEAD;
-        case 2: return COMMITTED_CURSOR;
-        default: return null;
+        case 0:
+          return NAMED_TARGET_UNSPECIFIED;
+        case 1:
+          return HEAD;
+        case 2:
+          return COMMITTED_CURSOR;
+        default:
+          return null;
       }
     }
 
-    public static com.google.protobuf.Internal.EnumLiteMap<NamedTarget>
-        internalGetValueMap() {
+    public static com.google.protobuf.Internal.EnumLiteMap<NamedTarget> internalGetValueMap() {
       return internalValueMap;
     }
-    private static final com.google.protobuf.Internal.EnumLiteMap<
-        NamedTarget> internalValueMap =
-          new com.google.protobuf.Internal.EnumLiteMap<NamedTarget>() {
-            public NamedTarget findValueByNumber(int number) {
-              return NamedTarget.forNumber(number);
-            }
-          };
 
-    public final com.google.protobuf.Descriptors.EnumValueDescriptor
-        getValueDescriptor() {
+    private static final com.google.protobuf.Internal.EnumLiteMap<NamedTarget> internalValueMap =
+        new com.google.protobuf.Internal.EnumLiteMap<NamedTarget>() {
+          public NamedTarget findValueByNumber(int number) {
+            return NamedTarget.forNumber(number);
+          }
+        };
+
+    public final com.google.protobuf.Descriptors.EnumValueDescriptor getValueDescriptor() {
       return getDescriptor().getValues().get(ordinal());
     }
-    public final com.google.protobuf.Descriptors.EnumDescriptor
-        getDescriptorForType() {
+
+    public final com.google.protobuf.Descriptors.EnumDescriptor getDescriptorForType() {
       return getDescriptor();
     }
-    public static final com.google.protobuf.Descriptors.EnumDescriptor
-        getDescriptor() {
+
+    public static final com.google.protobuf.Descriptors.EnumDescriptor getDescriptor() {
       return com.google.cloud.pubsublite.proto.SeekRequest.getDescriptor().getEnumTypes().get(0);
     }
 
     private static final NamedTarget[] VALUES = values();
 
-    public static NamedTarget valueOf(
-        com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+    public static NamedTarget valueOf(com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
       if (desc.getType() != getDescriptor()) {
-        throw new java.lang.IllegalArgumentException(
-          "EnumValueDescriptor is not for this type.");
+        throw new java.lang.IllegalArgumentException("EnumValueDescriptor is not for this type.");
       }
       if (desc.getIndex() == -1) {
         return UNRECOGNIZED;
@@ -254,13 +272,16 @@ private static final long serialVersionUID = 0L;
 
   private int targetCase_ = 0;
   private java.lang.Object target_;
+
   public enum TargetCase
-      implements com.google.protobuf.Internal.EnumLite,
+      implements
+          com.google.protobuf.Internal.EnumLite,
           com.google.protobuf.AbstractMessage.InternalOneOfEnum {
     NAMED_TARGET(1),
     CURSOR(2),
     TARGET_NOT_SET(0);
     private final int value;
+
     private TargetCase(int value) {
       this.value = value;
     }
@@ -276,30 +297,36 @@ private static final long serialVersionUID = 0L;
 
     public static TargetCase forNumber(int value) {
       switch (value) {
-        case 1: return NAMED_TARGET;
-        case 2: return CURSOR;
-        case 0: return TARGET_NOT_SET;
-        default: return null;
+        case 1:
+          return NAMED_TARGET;
+        case 2:
+          return CURSOR;
+        case 0:
+          return TARGET_NOT_SET;
+        default:
+          return null;
       }
     }
+
     public int getNumber() {
       return this.value;
     }
   };
 
-  public TargetCase
-  getTargetCase() {
-    return TargetCase.forNumber(
-        targetCase_);
+  public TargetCase getTargetCase() {
+    return TargetCase.forNumber(targetCase_);
   }
 
   public static final int NAMED_TARGET_FIELD_NUMBER = 1;
   /**
+   *
+   *
    * <pre>
    * A named target.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SeekRequest.NamedTarget named_target = 1;</code>
+   *
    * @return The enum numeric value on the wire for namedTarget.
    */
   public int getNamedTargetValue() {
@@ -309,52 +336,66 @@ private static final long serialVersionUID = 0L;
     return 0;
   }
   /**
+   *
+   *
    * <pre>
    * A named target.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SeekRequest.NamedTarget named_target = 1;</code>
+   *
    * @return The namedTarget.
    */
   public com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget getNamedTarget() {
     if (targetCase_ == 1) {
       @SuppressWarnings("deprecation")
-      com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget result = com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget.valueOf(
-          (java.lang.Integer) target_);
-      return result == null ? com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget.UNRECOGNIZED : result;
+      com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget result =
+          com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget.valueOf(
+              (java.lang.Integer) target_);
+      return result == null
+          ? com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget.UNRECOGNIZED
+          : result;
     }
     return com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget.NAMED_TARGET_UNSPECIFIED;
   }
 
   public static final int CURSOR_FIELD_NUMBER = 2;
   /**
+   *
+   *
    * <pre>
    * A target corresponding to the cursor, pointing to anywhere in the
    * topic partition.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
+   *
    * @return Whether the cursor field is set.
    */
   public boolean hasCursor() {
     return targetCase_ == 2;
   }
   /**
+   *
+   *
    * <pre>
    * A target corresponding to the cursor, pointing to anywhere in the
    * topic partition.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
+   *
    * @return The cursor.
    */
   public com.google.cloud.pubsublite.proto.Cursor getCursor() {
     if (targetCase_ == 2) {
-       return (com.google.cloud.pubsublite.proto.Cursor) target_;
+      return (com.google.cloud.pubsublite.proto.Cursor) target_;
     }
     return com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance();
   }
   /**
+   *
+   *
    * <pre>
    * A target corresponding to the cursor, pointing to anywhere in the
    * topic partition.
@@ -364,12 +405,13 @@ private static final long serialVersionUID = 0L;
    */
   public com.google.cloud.pubsublite.proto.CursorOrBuilder getCursorOrBuilder() {
     if (targetCase_ == 2) {
-       return (com.google.cloud.pubsublite.proto.Cursor) target_;
+      return (com.google.cloud.pubsublite.proto.Cursor) target_;
     }
     return com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance();
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -381,8 +423,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (targetCase_ == 1) {
       output.writeEnum(1, ((java.lang.Integer) target_));
     }
@@ -399,12 +440,13 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (targetCase_ == 1) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeEnumSize(1, ((java.lang.Integer) target_));
+      size +=
+          com.google.protobuf.CodedOutputStream.computeEnumSize(1, ((java.lang.Integer) target_));
     }
     if (targetCase_ == 2) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, (com.google.cloud.pubsublite.proto.Cursor) target_);
+      size +=
+          com.google.protobuf.CodedOutputStream.computeMessageSize(
+              2, (com.google.cloud.pubsublite.proto.Cursor) target_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -414,22 +456,21 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.SeekRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.SeekRequest other = (com.google.cloud.pubsublite.proto.SeekRequest) obj;
+    com.google.cloud.pubsublite.proto.SeekRequest other =
+        (com.google.cloud.pubsublite.proto.SeekRequest) obj;
 
     if (!getTargetCase().equals(other.getTargetCase())) return false;
     switch (targetCase_) {
       case 1:
-        if (getNamedTargetValue()
-            != other.getNamedTargetValue()) return false;
+        if (getNamedTargetValue() != other.getNamedTargetValue()) return false;
         break;
       case 2:
-        if (!getCursor()
-            .equals(other.getCursor())) return false;
+        if (!getCursor().equals(other.getCursor())) return false;
         break;
       case 0:
       default:
@@ -462,97 +503,104 @@ private static final long serialVersionUID = 0L;
     return hash;
   }
 
-  public static com.google.cloud.pubsublite.proto.SeekRequest parseFrom(
-      java.nio.ByteBuffer data)
+  public static com.google.cloud.pubsublite.proto.SeekRequest parseFrom(java.nio.ByteBuffer data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SeekRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SeekRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SeekRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SeekRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SeekRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SeekRequest parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.SeekRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.SeekRequest parseDelimitedFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.SeekRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.SeekRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.SeekRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.SeekRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.SeekRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request to update the stream's delivery cursor based on the given target.
    * Resets the server available tokens to 0. SeekRequests may not be sent while
@@ -562,21 +610,23 @@ private static final long serialVersionUID = 0L;
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.SeekRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.SeekRequest)
       com.google.cloud.pubsublite.proto.SeekRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SeekRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_SeekRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SeekRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_SeekRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.SeekRequest.class, com.google.cloud.pubsublite.proto.SeekRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.SeekRequest.class,
+              com.google.cloud.pubsublite.proto.SeekRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.SeekRequest.newBuilder()
@@ -584,16 +634,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -603,9 +652,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SeekRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_SeekRequest_descriptor;
     }
 
     @java.lang.Override
@@ -624,7 +673,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.SeekRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.SeekRequest result = new com.google.cloud.pubsublite.proto.SeekRequest(this);
+      com.google.cloud.pubsublite.proto.SeekRequest result =
+          new com.google.cloud.pubsublite.proto.SeekRequest(this);
       if (targetCase_ == 1) {
         result.target_ = target_;
       }
@@ -644,38 +694,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.SeekRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.SeekRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.SeekRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -685,17 +736,20 @@ private static final long serialVersionUID = 0L;
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.SeekRequest other) {
       if (other == com.google.cloud.pubsublite.proto.SeekRequest.getDefaultInstance()) return this;
       switch (other.getTargetCase()) {
-        case NAMED_TARGET: {
-          setNamedTargetValue(other.getNamedTargetValue());
-          break;
-        }
-        case CURSOR: {
-          mergeCursor(other.getCursor());
-          break;
-        }
-        case TARGET_NOT_SET: {
-          break;
-        }
+        case NAMED_TARGET:
+          {
+            setNamedTargetValue(other.getNamedTargetValue());
+            break;
+          }
+        case CURSOR:
+          {
+            mergeCursor(other.getCursor());
+            break;
+          }
+        case TARGET_NOT_SET:
+          {
+            break;
+          }
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -725,12 +779,12 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     private int targetCase_ = 0;
     private java.lang.Object target_;
-    public TargetCase
-        getTargetCase() {
-      return TargetCase.forNumber(
-          targetCase_);
+
+    public TargetCase getTargetCase() {
+      return TargetCase.forNumber(targetCase_);
     }
 
     public Builder clearTarget() {
@@ -740,13 +794,15 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-
     /**
+     *
+     *
      * <pre>
      * A named target.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SeekRequest.NamedTarget named_target = 1;</code>
+     *
      * @return The enum numeric value on the wire for namedTarget.
      */
     public int getNamedTargetValue() {
@@ -756,11 +812,14 @@ private static final long serialVersionUID = 0L;
       return 0;
     }
     /**
+     *
+     *
      * <pre>
      * A named target.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SeekRequest.NamedTarget named_target = 1;</code>
+     *
      * @param value The enum numeric value on the wire for namedTarget to set.
      * @return This builder for chaining.
      */
@@ -771,28 +830,37 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A named target.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SeekRequest.NamedTarget named_target = 1;</code>
+     *
      * @return The namedTarget.
      */
     public com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget getNamedTarget() {
       if (targetCase_ == 1) {
         @SuppressWarnings("deprecation")
-        com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget result = com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget.valueOf(
-            (java.lang.Integer) target_);
-        return result == null ? com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget.UNRECOGNIZED : result;
+        com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget result =
+            com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget.valueOf(
+                (java.lang.Integer) target_);
+        return result == null
+            ? com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget.UNRECOGNIZED
+            : result;
       }
       return com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget.NAMED_TARGET_UNSPECIFIED;
     }
     /**
+     *
+     *
      * <pre>
      * A named target.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SeekRequest.NamedTarget named_target = 1;</code>
+     *
      * @param value The namedTarget to set.
      * @return This builder for chaining.
      */
@@ -806,11 +874,14 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A named target.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SeekRequest.NamedTarget named_target = 1;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearNamedTarget() {
@@ -823,26 +894,35 @@ private static final long serialVersionUID = 0L;
     }
 
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder> cursorBuilder_;
+            com.google.cloud.pubsublite.proto.Cursor,
+            com.google.cloud.pubsublite.proto.Cursor.Builder,
+            com.google.cloud.pubsublite.proto.CursorOrBuilder>
+        cursorBuilder_;
     /**
+     *
+     *
      * <pre>
      * A target corresponding to the cursor, pointing to anywhere in the
      * topic partition.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
+     *
      * @return Whether the cursor field is set.
      */
     public boolean hasCursor() {
       return targetCase_ == 2;
     }
     /**
+     *
+     *
      * <pre>
      * A target corresponding to the cursor, pointing to anywhere in the
      * topic partition.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
+     *
      * @return The cursor.
      */
     public com.google.cloud.pubsublite.proto.Cursor getCursor() {
@@ -859,6 +939,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A target corresponding to the cursor, pointing to anywhere in the
      * topic partition.
@@ -880,6 +962,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A target corresponding to the cursor, pointing to anywhere in the
      * topic partition.
@@ -887,8 +971,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
      */
-    public Builder setCursor(
-        com.google.cloud.pubsublite.proto.Cursor.Builder builderForValue) {
+    public Builder setCursor(com.google.cloud.pubsublite.proto.Cursor.Builder builderForValue) {
       if (cursorBuilder_ == null) {
         target_ = builderForValue.build();
         onChanged();
@@ -899,6 +982,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A target corresponding to the cursor, pointing to anywhere in the
      * topic partition.
@@ -908,10 +993,13 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeCursor(com.google.cloud.pubsublite.proto.Cursor value) {
       if (cursorBuilder_ == null) {
-        if (targetCase_ == 2 &&
-            target_ != com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()) {
-          target_ = com.google.cloud.pubsublite.proto.Cursor.newBuilder((com.google.cloud.pubsublite.proto.Cursor) target_)
-              .mergeFrom(value).buildPartial();
+        if (targetCase_ == 2
+            && target_ != com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()) {
+          target_ =
+              com.google.cloud.pubsublite.proto.Cursor.newBuilder(
+                      (com.google.cloud.pubsublite.proto.Cursor) target_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           target_ = value;
         }
@@ -926,6 +1014,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A target corresponding to the cursor, pointing to anywhere in the
      * topic partition.
@@ -950,6 +1040,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A target corresponding to the cursor, pointing to anywhere in the
      * topic partition.
@@ -961,6 +1053,8 @@ private static final long serialVersionUID = 0L;
       return getCursorFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * A target corresponding to the cursor, pointing to anywhere in the
      * topic partition.
@@ -979,6 +1073,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A target corresponding to the cursor, pointing to anywhere in the
      * topic partition.
@@ -987,26 +1083,32 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder> 
+            com.google.cloud.pubsublite.proto.Cursor,
+            com.google.cloud.pubsublite.proto.Cursor.Builder,
+            com.google.cloud.pubsublite.proto.CursorOrBuilder>
         getCursorFieldBuilder() {
       if (cursorBuilder_ == null) {
         if (!(targetCase_ == 2)) {
           target_ = com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance();
         }
-        cursorBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder>(
+        cursorBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Cursor,
+                com.google.cloud.pubsublite.proto.Cursor.Builder,
+                com.google.cloud.pubsublite.proto.CursorOrBuilder>(
                 (com.google.cloud.pubsublite.proto.Cursor) target_,
                 getParentForChildren(),
                 isClean());
         target_ = null;
       }
       targetCase_ = 2;
-      onChanged();;
+      onChanged();
+      ;
       return cursorBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -1016,12 +1118,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.SeekRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.SeekRequest)
   private static final com.google.cloud.pubsublite.proto.SeekRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.SeekRequest();
   }
@@ -1030,16 +1132,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<SeekRequest>
-      PARSER = new com.google.protobuf.AbstractParser<SeekRequest>() {
-    @java.lang.Override
-    public SeekRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new SeekRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<SeekRequest> PARSER =
+      new com.google.protobuf.AbstractParser<SeekRequest>() {
+        @java.lang.Override
+        public SeekRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new SeekRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<SeekRequest> parser() {
     return PARSER;
@@ -1054,6 +1156,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.SeekRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SeekRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SeekRequestOrBuilder.java
@@ -3,50 +3,65 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface SeekRequestOrBuilder extends
+public interface SeekRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.SeekRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * A named target.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SeekRequest.NamedTarget named_target = 1;</code>
+   *
    * @return The enum numeric value on the wire for namedTarget.
    */
   int getNamedTargetValue();
   /**
+   *
+   *
    * <pre>
    * A named target.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SeekRequest.NamedTarget named_target = 1;</code>
+   *
    * @return The namedTarget.
    */
   com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget getNamedTarget();
 
   /**
+   *
+   *
    * <pre>
    * A target corresponding to the cursor, pointing to anywhere in the
    * topic partition.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
+   *
    * @return Whether the cursor field is set.
    */
   boolean hasCursor();
   /**
+   *
+   *
    * <pre>
    * A target corresponding to the cursor, pointing to anywhere in the
    * topic partition.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 2;</code>
+   *
    * @return The cursor.
    */
   com.google.cloud.pubsublite.proto.Cursor getCursor();
   /**
+   *
+   *
    * <pre>
    * A target corresponding to the cursor, pointing to anywhere in the
    * topic partition.

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SeekResponse.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SeekResponse.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Response to a SeekRequest.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.SeekResponse}
  */
-public  final class SeekResponse extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class SeekResponse extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.SeekResponse)
     SeekResponseOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use SeekResponse.newBuilder() to construct.
   private SeekResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private SeekResponse() {
-  }
+
+  private SeekResponse() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new SeekResponse();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private SeekResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,76 +53,91 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            com.google.cloud.pubsublite.proto.Cursor.Builder subBuilder = null;
-            if (cursor_ != null) {
-              subBuilder = cursor_.toBuilder();
-            }
-            cursor_ = input.readMessage(com.google.cloud.pubsublite.proto.Cursor.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(cursor_);
-              cursor_ = subBuilder.buildPartial();
-            }
+          case 10:
+            {
+              com.google.cloud.pubsublite.proto.Cursor.Builder subBuilder = null;
+              if (cursor_ != null) {
+                subBuilder = cursor_.toBuilder();
+              }
+              cursor_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Cursor.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(cursor_);
+                cursor_ = subBuilder.buildPartial();
+              }
 
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SeekResponse_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.SubscriberProto
+        .internal_static_google_cloud_pubsublite_v1_SeekResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SeekResponse_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.SubscriberProto
+        .internal_static_google_cloud_pubsublite_v1_SeekResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.SeekResponse.class, com.google.cloud.pubsublite.proto.SeekResponse.Builder.class);
+            com.google.cloud.pubsublite.proto.SeekResponse.class,
+            com.google.cloud.pubsublite.proto.SeekResponse.Builder.class);
   }
 
   public static final int CURSOR_FIELD_NUMBER = 1;
   private com.google.cloud.pubsublite.proto.Cursor cursor_;
   /**
+   *
+   *
    * <pre>
    * The new delivery cursor for the current stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+   *
    * @return Whether the cursor field is set.
    */
   public boolean hasCursor() {
     return cursor_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * The new delivery cursor for the current stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+   *
    * @return The cursor.
    */
   public com.google.cloud.pubsublite.proto.Cursor getCursor() {
-    return cursor_ == null ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+    return cursor_ == null
+        ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+        : cursor_;
   }
   /**
+   *
+   *
    * <pre>
    * The new delivery cursor for the current stream.
    * </pre>
@@ -133,6 +149,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -144,8 +161,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (cursor_ != null) {
       output.writeMessage(1, getCursor());
     }
@@ -159,8 +175,7 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (cursor_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, getCursor());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(1, getCursor());
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -170,17 +185,17 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.SeekResponse)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.SeekResponse other = (com.google.cloud.pubsublite.proto.SeekResponse) obj;
+    com.google.cloud.pubsublite.proto.SeekResponse other =
+        (com.google.cloud.pubsublite.proto.SeekResponse) obj;
 
     if (hasCursor() != other.hasCursor()) return false;
     if (hasCursor()) {
-      if (!getCursor()
-          .equals(other.getCursor())) return false;
+      if (!getCursor().equals(other.getCursor())) return false;
     }
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
@@ -202,118 +217,127 @@ private static final long serialVersionUID = 0L;
     return hash;
   }
 
-  public static com.google.cloud.pubsublite.proto.SeekResponse parseFrom(
-      java.nio.ByteBuffer data)
+  public static com.google.cloud.pubsublite.proto.SeekResponse parseFrom(java.nio.ByteBuffer data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SeekResponse parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SeekResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SeekResponse parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SeekResponse parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SeekResponse parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SeekResponse parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.SeekResponse parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.SeekResponse parseDelimitedFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.SeekResponse parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.SeekResponse parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.SeekResponse parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.SeekResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.SeekResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Response to a SeekRequest.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.SeekResponse}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.SeekResponse)
       com.google.cloud.pubsublite.proto.SeekResponseOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SeekResponse_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_SeekResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SeekResponse_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_SeekResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.SeekResponse.class, com.google.cloud.pubsublite.proto.SeekResponse.Builder.class);
+              com.google.cloud.pubsublite.proto.SeekResponse.class,
+              com.google.cloud.pubsublite.proto.SeekResponse.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.SeekResponse.newBuilder()
@@ -321,16 +345,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -344,9 +367,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SeekResponse_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_SeekResponse_descriptor;
     }
 
     @java.lang.Override
@@ -365,7 +388,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.SeekResponse buildPartial() {
-      com.google.cloud.pubsublite.proto.SeekResponse result = new com.google.cloud.pubsublite.proto.SeekResponse(this);
+      com.google.cloud.pubsublite.proto.SeekResponse result =
+          new com.google.cloud.pubsublite.proto.SeekResponse(this);
       if (cursorBuilder_ == null) {
         result.cursor_ = cursor_;
       } else {
@@ -379,38 +403,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.SeekResponse) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.SeekResponse)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.SeekResponse) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -453,34 +478,47 @@ private static final long serialVersionUID = 0L;
 
     private com.google.cloud.pubsublite.proto.Cursor cursor_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder> cursorBuilder_;
+            com.google.cloud.pubsublite.proto.Cursor,
+            com.google.cloud.pubsublite.proto.Cursor.Builder,
+            com.google.cloud.pubsublite.proto.CursorOrBuilder>
+        cursorBuilder_;
     /**
+     *
+     *
      * <pre>
      * The new delivery cursor for the current stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+     *
      * @return Whether the cursor field is set.
      */
     public boolean hasCursor() {
       return cursorBuilder_ != null || cursor_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * The new delivery cursor for the current stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+     *
      * @return The cursor.
      */
     public com.google.cloud.pubsublite.proto.Cursor getCursor() {
       if (cursorBuilder_ == null) {
-        return cursor_ == null ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+        return cursor_ == null
+            ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+            : cursor_;
       } else {
         return cursorBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * The new delivery cursor for the current stream.
      * </pre>
@@ -501,14 +539,15 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The new delivery cursor for the current stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
      */
-    public Builder setCursor(
-        com.google.cloud.pubsublite.proto.Cursor.Builder builderForValue) {
+    public Builder setCursor(com.google.cloud.pubsublite.proto.Cursor.Builder builderForValue) {
       if (cursorBuilder_ == null) {
         cursor_ = builderForValue.build();
         onChanged();
@@ -519,6 +558,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The new delivery cursor for the current stream.
      * </pre>
@@ -529,7 +570,9 @@ private static final long serialVersionUID = 0L;
       if (cursorBuilder_ == null) {
         if (cursor_ != null) {
           cursor_ =
-            com.google.cloud.pubsublite.proto.Cursor.newBuilder(cursor_).mergeFrom(value).buildPartial();
+              com.google.cloud.pubsublite.proto.Cursor.newBuilder(cursor_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           cursor_ = value;
         }
@@ -541,6 +584,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The new delivery cursor for the current stream.
      * </pre>
@@ -559,6 +604,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The new delivery cursor for the current stream.
      * </pre>
@@ -566,11 +613,13 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
      */
     public com.google.cloud.pubsublite.proto.Cursor.Builder getCursorBuilder() {
-      
+
       onChanged();
       return getCursorFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * The new delivery cursor for the current stream.
      * </pre>
@@ -581,11 +630,14 @@ private static final long serialVersionUID = 0L;
       if (cursorBuilder_ != null) {
         return cursorBuilder_.getMessageOrBuilder();
       } else {
-        return cursor_ == null ?
-            com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+        return cursor_ == null
+            ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+            : cursor_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The new delivery cursor for the current stream.
      * </pre>
@@ -593,21 +645,24 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder> 
+            com.google.cloud.pubsublite.proto.Cursor,
+            com.google.cloud.pubsublite.proto.Cursor.Builder,
+            com.google.cloud.pubsublite.proto.CursorOrBuilder>
         getCursorFieldBuilder() {
       if (cursorBuilder_ == null) {
-        cursorBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder>(
-                getCursor(),
-                getParentForChildren(),
-                isClean());
+        cursorBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Cursor,
+                com.google.cloud.pubsublite.proto.Cursor.Builder,
+                com.google.cloud.pubsublite.proto.CursorOrBuilder>(
+                getCursor(), getParentForChildren(), isClean());
         cursor_ = null;
       }
       return cursorBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -617,12 +672,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.SeekResponse)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.SeekResponse)
   private static final com.google.cloud.pubsublite.proto.SeekResponse DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.SeekResponse();
   }
@@ -631,16 +686,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<SeekResponse>
-      PARSER = new com.google.protobuf.AbstractParser<SeekResponse>() {
-    @java.lang.Override
-    public SeekResponse parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new SeekResponse(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<SeekResponse> PARSER =
+      new com.google.protobuf.AbstractParser<SeekResponse>() {
+        @java.lang.Override
+        public SeekResponse parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new SeekResponse(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<SeekResponse> parser() {
     return PARSER;
@@ -655,6 +710,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.SeekResponse getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SeekResponseOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SeekResponseOrBuilder.java
@@ -3,29 +3,38 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface SeekResponseOrBuilder extends
+public interface SeekResponseOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.SeekResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The new delivery cursor for the current stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+   *
    * @return Whether the cursor field is set.
    */
   boolean hasCursor();
   /**
+   *
+   *
    * <pre>
    * The new delivery cursor for the current stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+   *
    * @return The cursor.
    */
   com.google.cloud.pubsublite.proto.Cursor getCursor();
   /**
+   *
+   *
    * <pre>
    * The new delivery cursor for the current stream.
    * </pre>

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SequencedCommitCursorRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SequencedCommitCursorRequest.java
@@ -4,6 +4,8 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Streaming request to update the committed cursor. Subsequent
  * SequencedCommitCursorRequests override outstanding ones.
@@ -11,30 +13,29 @@ package com.google.cloud.pubsublite.proto;
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.SequencedCommitCursorRequest}
  */
-public  final class SequencedCommitCursorRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class SequencedCommitCursorRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.SequencedCommitCursorRequest)
     SequencedCommitCursorRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use SequencedCommitCursorRequest.newBuilder() to construct.
   private SequencedCommitCursorRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private SequencedCommitCursorRequest() {
-  }
+
+  private SequencedCommitCursorRequest() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new SequencedCommitCursorRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private SequencedCommitCursorRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -53,76 +54,91 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            com.google.cloud.pubsublite.proto.Cursor.Builder subBuilder = null;
-            if (cursor_ != null) {
-              subBuilder = cursor_.toBuilder();
-            }
-            cursor_ = input.readMessage(com.google.cloud.pubsublite.proto.Cursor.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(cursor_);
-              cursor_ = subBuilder.buildPartial();
-            }
+          case 10:
+            {
+              com.google.cloud.pubsublite.proto.Cursor.Builder subBuilder = null;
+              if (cursor_ != null) {
+                subBuilder = cursor_.toBuilder();
+              }
+              cursor_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Cursor.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(cursor_);
+                cursor_ = subBuilder.buildPartial();
+              }
 
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.class, com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.class,
+            com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.Builder.class);
   }
 
   public static final int CURSOR_FIELD_NUMBER = 1;
   private com.google.cloud.pubsublite.proto.Cursor cursor_;
   /**
+   *
+   *
    * <pre>
    * The new value for the committed cursor.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+   *
    * @return Whether the cursor field is set.
    */
   public boolean hasCursor() {
     return cursor_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * The new value for the committed cursor.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+   *
    * @return The cursor.
    */
   public com.google.cloud.pubsublite.proto.Cursor getCursor() {
-    return cursor_ == null ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+    return cursor_ == null
+        ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+        : cursor_;
   }
   /**
+   *
+   *
    * <pre>
    * The new value for the committed cursor.
    * </pre>
@@ -134,6 +150,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -145,8 +162,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (cursor_ != null) {
       output.writeMessage(1, getCursor());
     }
@@ -160,8 +176,7 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (cursor_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, getCursor());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(1, getCursor());
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -171,17 +186,17 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest other = (com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) obj;
+    com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest other =
+        (com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) obj;
 
     if (hasCursor() != other.hasCursor()) return false;
     if (hasCursor()) {
-      if (!getCursor()
-          .equals(other.getCursor())) return false;
+      if (!getCursor().equals(other.getCursor())) return false;
     }
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
@@ -204,96 +219,104 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest parseFrom(byte[] data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+
+  public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest parseFrom(
+      byte[] data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Streaming request to update the committed cursor. Subsequent
    * SequencedCommitCursorRequests override outstanding ones.
@@ -301,21 +324,23 @@ private static final long serialVersionUID = 0L;
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.SequencedCommitCursorRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.SequencedCommitCursorRequest)
       com.google.cloud.pubsublite.proto.SequencedCommitCursorRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.class, com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.class,
+              com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.newBuilder()
@@ -323,16 +348,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -346,13 +370,14 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorRequest_descriptor;
     }
 
     @java.lang.Override
-    public com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest getDefaultInstanceForType() {
+    public com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest
+        getDefaultInstanceForType() {
       return com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.getDefaultInstance();
     }
 
@@ -367,7 +392,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest result = new com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest(this);
+      com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest result =
+          new com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest(this);
       if (cursorBuilder_ == null) {
         result.cursor_ = cursor_;
       } else {
@@ -381,38 +407,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -420,7 +447,9 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.getDefaultInstance()) return this;
+      if (other
+          == com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.getDefaultInstance())
+        return this;
       if (other.hasCursor()) {
         mergeCursor(other.getCursor());
       }
@@ -443,7 +472,9 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest)
+                e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -455,34 +486,47 @@ private static final long serialVersionUID = 0L;
 
     private com.google.cloud.pubsublite.proto.Cursor cursor_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder> cursorBuilder_;
+            com.google.cloud.pubsublite.proto.Cursor,
+            com.google.cloud.pubsublite.proto.Cursor.Builder,
+            com.google.cloud.pubsublite.proto.CursorOrBuilder>
+        cursorBuilder_;
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+     *
      * @return Whether the cursor field is set.
      */
     public boolean hasCursor() {
       return cursorBuilder_ != null || cursor_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+     *
      * @return The cursor.
      */
     public com.google.cloud.pubsublite.proto.Cursor getCursor() {
       if (cursorBuilder_ == null) {
-        return cursor_ == null ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+        return cursor_ == null
+            ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+            : cursor_;
       } else {
         return cursorBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
@@ -503,14 +547,15 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
      */
-    public Builder setCursor(
-        com.google.cloud.pubsublite.proto.Cursor.Builder builderForValue) {
+    public Builder setCursor(com.google.cloud.pubsublite.proto.Cursor.Builder builderForValue) {
       if (cursorBuilder_ == null) {
         cursor_ = builderForValue.build();
         onChanged();
@@ -521,6 +566,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
@@ -531,7 +578,9 @@ private static final long serialVersionUID = 0L;
       if (cursorBuilder_ == null) {
         if (cursor_ != null) {
           cursor_ =
-            com.google.cloud.pubsublite.proto.Cursor.newBuilder(cursor_).mergeFrom(value).buildPartial();
+              com.google.cloud.pubsublite.proto.Cursor.newBuilder(cursor_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           cursor_ = value;
         }
@@ -543,6 +592,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
@@ -561,6 +612,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
@@ -568,11 +621,13 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
      */
     public com.google.cloud.pubsublite.proto.Cursor.Builder getCursorBuilder() {
-      
+
       onChanged();
       return getCursorFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
@@ -583,11 +638,14 @@ private static final long serialVersionUID = 0L;
       if (cursorBuilder_ != null) {
         return cursorBuilder_.getMessageOrBuilder();
       } else {
-        return cursor_ == null ?
-            com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+        return cursor_ == null
+            ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+            : cursor_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The new value for the committed cursor.
      * </pre>
@@ -595,21 +653,24 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder> 
+            com.google.cloud.pubsublite.proto.Cursor,
+            com.google.cloud.pubsublite.proto.Cursor.Builder,
+            com.google.cloud.pubsublite.proto.CursorOrBuilder>
         getCursorFieldBuilder() {
       if (cursorBuilder_ == null) {
-        cursorBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder>(
-                getCursor(),
-                getParentForChildren(),
-                isClean());
+        cursorBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Cursor,
+                com.google.cloud.pubsublite.proto.Cursor.Builder,
+                com.google.cloud.pubsublite.proto.CursorOrBuilder>(
+                getCursor(), getParentForChildren(), isClean());
         cursor_ = null;
       }
       return cursorBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -619,30 +680,32 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.SequencedCommitCursorRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.SequencedCommitCursorRequest)
-  private static final com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest DEFAULT_INSTANCE;
+  private static final com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest
+      DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest();
   }
 
-  public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest getDefaultInstance() {
+  public static com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest
+      getDefaultInstance() {
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<SequencedCommitCursorRequest>
-      PARSER = new com.google.protobuf.AbstractParser<SequencedCommitCursorRequest>() {
-    @java.lang.Override
-    public SequencedCommitCursorRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new SequencedCommitCursorRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<SequencedCommitCursorRequest> PARSER =
+      new com.google.protobuf.AbstractParser<SequencedCommitCursorRequest>() {
+        @java.lang.Override
+        public SequencedCommitCursorRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new SequencedCommitCursorRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<SequencedCommitCursorRequest> parser() {
     return PARSER;
@@ -654,9 +717,8 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest getDefaultInstanceForType() {
+  public com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest
+      getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SequencedCommitCursorRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SequencedCommitCursorRequestOrBuilder.java
@@ -3,29 +3,38 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface SequencedCommitCursorRequestOrBuilder extends
+public interface SequencedCommitCursorRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.SequencedCommitCursorRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The new value for the committed cursor.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+   *
    * @return Whether the cursor field is set.
    */
   boolean hasCursor();
   /**
+   *
+   *
    * <pre>
    * The new value for the committed cursor.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+   *
    * @return The cursor.
    */
   com.google.cloud.pubsublite.proto.Cursor getCursor();
   /**
+   *
+   *
    * <pre>
    * The new value for the committed cursor.
    * </pre>

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SequencedCommitCursorResponse.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SequencedCommitCursorResponse.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Response to a SequencedCommitCursorRequest.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.SequencedCommitCursorResponse}
  */
-public  final class SequencedCommitCursorResponse extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class SequencedCommitCursorResponse extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.SequencedCommitCursorResponse)
     SequencedCommitCursorResponseOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use SequencedCommitCursorResponse.newBuilder() to construct.
   private SequencedCommitCursorResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private SequencedCommitCursorResponse() {
-  }
+
+  private SequencedCommitCursorResponse() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new SequencedCommitCursorResponse();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private SequencedCommitCursorResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,46 +53,50 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 8: {
-
-            acknowledgedCommits_ = input.readInt64();
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+          case 8:
+            {
+              acknowledgedCommits_ = input.readInt64();
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.class, com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.Builder.class);
+            com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.class,
+            com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.Builder.class);
   }
 
   public static final int ACKNOWLEDGED_COMMITS_FIELD_NUMBER = 1;
   private long acknowledgedCommits_;
   /**
+   *
+   *
    * <pre>
    * The number of outstanding SequencedCommitCursorRequests acknowledged by
    * this response. Note that SequencedCommitCursorRequests are acknowledged in
@@ -99,6 +104,7 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>int64 acknowledged_commits = 1;</code>
+   *
    * @return The acknowledgedCommits.
    */
   public long getAcknowledgedCommits() {
@@ -106,6 +112,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -117,8 +124,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (acknowledgedCommits_ != 0L) {
       output.writeInt64(1, acknowledgedCommits_);
     }
@@ -132,8 +138,7 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (acknowledgedCommits_ != 0L) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeInt64Size(1, acknowledgedCommits_);
+      size += com.google.protobuf.CodedOutputStream.computeInt64Size(1, acknowledgedCommits_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -143,15 +148,15 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse other = (com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) obj;
+    com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse other =
+        (com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) obj;
 
-    if (getAcknowledgedCommits()
-        != other.getAcknowledgedCommits()) return false;
+    if (getAcknowledgedCommits() != other.getAcknowledgedCommits()) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -164,125 +169,134 @@ private static final long serialVersionUID = 0L;
     int hash = 41;
     hash = (19 * hash) + getDescriptor().hashCode();
     hash = (37 * hash) + ACKNOWLEDGED_COMMITS_FIELD_NUMBER;
-    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-        getAcknowledgedCommits());
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(getAcknowledgedCommits());
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
   }
 
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse parseFrom(byte[] data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+
+  public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse parseFrom(
+      byte[] data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Response to a SequencedCommitCursorRequest.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.SequencedCommitCursorResponse}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.SequencedCommitCursorResponse)
       com.google.cloud.pubsublite.proto.SequencedCommitCursorResponseOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.class, com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.Builder.class);
+              com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.class,
+              com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.newBuilder()
@@ -290,16 +304,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -309,13 +322,14 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_SequencedCommitCursorResponse_descriptor;
     }
 
     @java.lang.Override
-    public com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse getDefaultInstanceForType() {
+    public com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse
+        getDefaultInstanceForType() {
       return com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.getDefaultInstance();
     }
 
@@ -330,7 +344,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse buildPartial() {
-      com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse result = new com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse(this);
+      com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse result =
+          new com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse(this);
       result.acknowledgedCommits_ = acknowledgedCommits_;
       onBuilt();
       return result;
@@ -340,46 +355,50 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) other);
       } else {
         super.mergeFrom(other);
         return this;
       }
     }
 
-    public Builder mergeFrom(com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse other) {
-      if (other == com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.getDefaultInstance()) return this;
+    public Builder mergeFrom(
+        com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse other) {
+      if (other
+          == com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.getDefaultInstance())
+        return this;
       if (other.getAcknowledgedCommits() != 0L) {
         setAcknowledgedCommits(other.getAcknowledgedCommits());
       }
@@ -402,7 +421,9 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse)
+                e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -412,8 +433,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-    private long acknowledgedCommits_ ;
+    private long acknowledgedCommits_;
     /**
+     *
+     *
      * <pre>
      * The number of outstanding SequencedCommitCursorRequests acknowledged by
      * this response. Note that SequencedCommitCursorRequests are acknowledged in
@@ -421,12 +444,15 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int64 acknowledged_commits = 1;</code>
+     *
      * @return The acknowledgedCommits.
      */
     public long getAcknowledgedCommits() {
       return acknowledgedCommits_;
     }
     /**
+     *
+     *
      * <pre>
      * The number of outstanding SequencedCommitCursorRequests acknowledged by
      * this response. Note that SequencedCommitCursorRequests are acknowledged in
@@ -434,16 +460,19 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int64 acknowledged_commits = 1;</code>
+     *
      * @param value The acknowledgedCommits to set.
      * @return This builder for chaining.
      */
     public Builder setAcknowledgedCommits(long value) {
-      
+
       acknowledgedCommits_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The number of outstanding SequencedCommitCursorRequests acknowledged by
      * this response. Note that SequencedCommitCursorRequests are acknowledged in
@@ -451,17 +480,18 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int64 acknowledged_commits = 1;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearAcknowledgedCommits() {
-      
+
       acknowledgedCommits_ = 0L;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -471,30 +501,32 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.SequencedCommitCursorResponse)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.SequencedCommitCursorResponse)
-  private static final com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse DEFAULT_INSTANCE;
+  private static final com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse
+      DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse();
   }
 
-  public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse getDefaultInstance() {
+  public static com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse
+      getDefaultInstance() {
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<SequencedCommitCursorResponse>
-      PARSER = new com.google.protobuf.AbstractParser<SequencedCommitCursorResponse>() {
-    @java.lang.Override
-    public SequencedCommitCursorResponse parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new SequencedCommitCursorResponse(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<SequencedCommitCursorResponse> PARSER =
+      new com.google.protobuf.AbstractParser<SequencedCommitCursorResponse>() {
+        @java.lang.Override
+        public SequencedCommitCursorResponse parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new SequencedCommitCursorResponse(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<SequencedCommitCursorResponse> parser() {
     return PARSER;
@@ -506,9 +538,8 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse getDefaultInstanceForType() {
+  public com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse
+      getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SequencedCommitCursorResponseOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SequencedCommitCursorResponseOrBuilder.java
@@ -3,11 +3,14 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface SequencedCommitCursorResponseOrBuilder extends
+public interface SequencedCommitCursorResponseOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.SequencedCommitCursorResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The number of outstanding SequencedCommitCursorRequests acknowledged by
    * this response. Note that SequencedCommitCursorRequests are acknowledged in
@@ -15,6 +18,7 @@ public interface SequencedCommitCursorResponseOrBuilder extends
    * </pre>
    *
    * <code>int64 acknowledged_commits = 1;</code>
+   *
    * @return The acknowledgedCommits.
    */
   long getAcknowledgedCommits();

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SequencedMessage.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SequencedMessage.java
@@ -3,33 +3,30 @@
 
 package com.google.cloud.pubsublite.proto;
 
-/**
- * Protobuf type {@code google.cloud.pubsublite.v1.SequencedMessage}
- */
-public  final class SequencedMessage extends
-    com.google.protobuf.GeneratedMessageV3 implements
+/** Protobuf type {@code google.cloud.pubsublite.v1.SequencedMessage} */
+public final class SequencedMessage extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.SequencedMessage)
     SequencedMessageOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use SequencedMessage.newBuilder() to construct.
   private SequencedMessage(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private SequencedMessage() {
-  }
+
+  private SequencedMessage() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new SequencedMessage();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private SequencedMessage(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -48,107 +45,127 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            com.google.cloud.pubsublite.proto.Cursor.Builder subBuilder = null;
-            if (cursor_ != null) {
-              subBuilder = cursor_.toBuilder();
-            }
-            cursor_ = input.readMessage(com.google.cloud.pubsublite.proto.Cursor.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(cursor_);
-              cursor_ = subBuilder.buildPartial();
-            }
+          case 10:
+            {
+              com.google.cloud.pubsublite.proto.Cursor.Builder subBuilder = null;
+              if (cursor_ != null) {
+                subBuilder = cursor_.toBuilder();
+              }
+              cursor_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Cursor.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(cursor_);
+                cursor_ = subBuilder.buildPartial();
+              }
 
-            break;
-          }
-          case 18: {
-            com.google.protobuf.Timestamp.Builder subBuilder = null;
-            if (publishTime_ != null) {
-              subBuilder = publishTime_.toBuilder();
+              break;
             }
-            publishTime_ = input.readMessage(com.google.protobuf.Timestamp.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(publishTime_);
-              publishTime_ = subBuilder.buildPartial();
-            }
+          case 18:
+            {
+              com.google.protobuf.Timestamp.Builder subBuilder = null;
+              if (publishTime_ != null) {
+                subBuilder = publishTime_.toBuilder();
+              }
+              publishTime_ =
+                  input.readMessage(com.google.protobuf.Timestamp.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(publishTime_);
+                publishTime_ = subBuilder.buildPartial();
+              }
 
-            break;
-          }
-          case 26: {
-            com.google.cloud.pubsublite.proto.PubSubMessage.Builder subBuilder = null;
-            if (message_ != null) {
-              subBuilder = message_.toBuilder();
+              break;
             }
-            message_ = input.readMessage(com.google.cloud.pubsublite.proto.PubSubMessage.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(message_);
-              message_ = subBuilder.buildPartial();
-            }
+          case 26:
+            {
+              com.google.cloud.pubsublite.proto.PubSubMessage.Builder subBuilder = null;
+              if (message_ != null) {
+                subBuilder = message_.toBuilder();
+              }
+              message_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.PubSubMessage.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(message_);
+                message_ = subBuilder.buildPartial();
+              }
 
-            break;
-          }
-          case 32: {
-
-            sizeBytes_ = input.readInt64();
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              break;
             }
-            break;
-          }
+          case 32:
+            {
+              sizeBytes_ = input.readInt64();
+              break;
+            }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_SequencedMessage_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CommonProto
+        .internal_static_google_cloud_pubsublite_v1_SequencedMessage_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_SequencedMessage_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CommonProto
+        .internal_static_google_cloud_pubsublite_v1_SequencedMessage_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.SequencedMessage.class, com.google.cloud.pubsublite.proto.SequencedMessage.Builder.class);
+            com.google.cloud.pubsublite.proto.SequencedMessage.class,
+            com.google.cloud.pubsublite.proto.SequencedMessage.Builder.class);
   }
 
   public static final int CURSOR_FIELD_NUMBER = 1;
   private com.google.cloud.pubsublite.proto.Cursor cursor_;
   /**
+   *
+   *
    * <pre>
    * The position of a message within the partition where it is stored.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+   *
    * @return Whether the cursor field is set.
    */
   public boolean hasCursor() {
     return cursor_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * The position of a message within the partition where it is stored.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+   *
    * @return The cursor.
    */
   public com.google.cloud.pubsublite.proto.Cursor getCursor() {
-    return cursor_ == null ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+    return cursor_ == null
+        ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+        : cursor_;
   }
   /**
+   *
+   *
    * <pre>
    * The position of a message within the partition where it is stored.
    * </pre>
@@ -162,30 +179,38 @@ private static final long serialVersionUID = 0L;
   public static final int PUBLISH_TIME_FIELD_NUMBER = 2;
   private com.google.protobuf.Timestamp publishTime_;
   /**
+   *
+   *
    * <pre>
    * The time when the message was received by the server when it was first
    * published.
    * </pre>
    *
    * <code>.google.protobuf.Timestamp publish_time = 2;</code>
+   *
    * @return Whether the publishTime field is set.
    */
   public boolean hasPublishTime() {
     return publishTime_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * The time when the message was received by the server when it was first
    * published.
    * </pre>
    *
    * <code>.google.protobuf.Timestamp publish_time = 2;</code>
+   *
    * @return The publishTime.
    */
   public com.google.protobuf.Timestamp getPublishTime() {
     return publishTime_ == null ? com.google.protobuf.Timestamp.getDefaultInstance() : publishTime_;
   }
   /**
+   *
+   *
    * <pre>
    * The time when the message was received by the server when it was first
    * published.
@@ -200,28 +225,38 @@ private static final long serialVersionUID = 0L;
   public static final int MESSAGE_FIELD_NUMBER = 3;
   private com.google.cloud.pubsublite.proto.PubSubMessage message_;
   /**
+   *
+   *
    * <pre>
    * The user message.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.PubSubMessage message = 3;</code>
+   *
    * @return Whether the message field is set.
    */
   public boolean hasMessage() {
     return message_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * The user message.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.PubSubMessage message = 3;</code>
+   *
    * @return The message.
    */
   public com.google.cloud.pubsublite.proto.PubSubMessage getMessage() {
-    return message_ == null ? com.google.cloud.pubsublite.proto.PubSubMessage.getDefaultInstance() : message_;
+    return message_ == null
+        ? com.google.cloud.pubsublite.proto.PubSubMessage.getDefaultInstance()
+        : message_;
   }
   /**
+   *
+   *
    * <pre>
    * The user message.
    * </pre>
@@ -235,11 +270,14 @@ private static final long serialVersionUID = 0L;
   public static final int SIZE_BYTES_FIELD_NUMBER = 4;
   private long sizeBytes_;
   /**
+   *
+   *
    * <pre>
    * The size in bytes of this message for flow control and quota purposes.
    * </pre>
    *
    * <code>int64 size_bytes = 4;</code>
+   *
    * @return The sizeBytes.
    */
   public long getSizeBytes() {
@@ -247,6 +285,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -258,8 +297,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (cursor_ != null) {
       output.writeMessage(1, getCursor());
     }
@@ -282,20 +320,16 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (cursor_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, getCursor());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(1, getCursor());
     }
     if (publishTime_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, getPublishTime());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(2, getPublishTime());
     }
     if (message_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(3, getMessage());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(3, getMessage());
     }
     if (sizeBytes_ != 0L) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeInt64Size(4, sizeBytes_);
+      size += com.google.protobuf.CodedOutputStream.computeInt64Size(4, sizeBytes_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -305,30 +339,27 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.SequencedMessage)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.SequencedMessage other = (com.google.cloud.pubsublite.proto.SequencedMessage) obj;
+    com.google.cloud.pubsublite.proto.SequencedMessage other =
+        (com.google.cloud.pubsublite.proto.SequencedMessage) obj;
 
     if (hasCursor() != other.hasCursor()) return false;
     if (hasCursor()) {
-      if (!getCursor()
-          .equals(other.getCursor())) return false;
+      if (!getCursor().equals(other.getCursor())) return false;
     }
     if (hasPublishTime() != other.hasPublishTime()) return false;
     if (hasPublishTime()) {
-      if (!getPublishTime()
-          .equals(other.getPublishTime())) return false;
+      if (!getPublishTime().equals(other.getPublishTime())) return false;
     }
     if (hasMessage() != other.hasMessage()) return false;
     if (hasMessage()) {
-      if (!getMessage()
-          .equals(other.getMessage())) return false;
+      if (!getMessage().equals(other.getMessage())) return false;
     }
-    if (getSizeBytes()
-        != other.getSizeBytes()) return false;
+    if (getSizeBytes() != other.getSizeBytes()) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -353,121 +384,125 @@ private static final long serialVersionUID = 0L;
       hash = (53 * hash) + getMessage().hashCode();
     }
     hash = (37 * hash) + SIZE_BYTES_FIELD_NUMBER;
-    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-        getSizeBytes());
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(getSizeBytes());
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
   }
 
   public static com.google.cloud.pubsublite.proto.SequencedMessage parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedMessage parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedMessage parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedMessage parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedMessage parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedMessage parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.SequencedMessage parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.SequencedMessage parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.SequencedMessage parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.SequencedMessage parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedMessage parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.SequencedMessage parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.SequencedMessage parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.SequencedMessage parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.SequencedMessage prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
-  /**
-   * Protobuf type {@code google.cloud.pubsublite.v1.SequencedMessage}
-   */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  /** Protobuf type {@code google.cloud.pubsublite.v1.SequencedMessage} */
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.SequencedMessage)
       com.google.cloud.pubsublite.proto.SequencedMessageOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_SequencedMessage_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_SequencedMessage_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_SequencedMessage_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_SequencedMessage_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.SequencedMessage.class, com.google.cloud.pubsublite.proto.SequencedMessage.Builder.class);
+              com.google.cloud.pubsublite.proto.SequencedMessage.class,
+              com.google.cloud.pubsublite.proto.SequencedMessage.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.SequencedMessage.newBuilder()
@@ -475,16 +510,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -512,9 +546,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_SequencedMessage_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_SequencedMessage_descriptor;
     }
 
     @java.lang.Override
@@ -533,7 +567,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.SequencedMessage buildPartial() {
-      com.google.cloud.pubsublite.proto.SequencedMessage result = new com.google.cloud.pubsublite.proto.SequencedMessage(this);
+      com.google.cloud.pubsublite.proto.SequencedMessage result =
+          new com.google.cloud.pubsublite.proto.SequencedMessage(this);
       if (cursorBuilder_ == null) {
         result.cursor_ = cursor_;
       } else {
@@ -558,38 +593,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.SequencedMessage) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.SequencedMessage)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.SequencedMessage) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -597,7 +633,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.SequencedMessage other) {
-      if (other == com.google.cloud.pubsublite.proto.SequencedMessage.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.SequencedMessage.getDefaultInstance())
+        return this;
       if (other.hasCursor()) {
         mergeCursor(other.getCursor());
       }
@@ -629,7 +666,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.SequencedMessage) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.SequencedMessage) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -641,34 +679,47 @@ private static final long serialVersionUID = 0L;
 
     private com.google.cloud.pubsublite.proto.Cursor cursor_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder> cursorBuilder_;
+            com.google.cloud.pubsublite.proto.Cursor,
+            com.google.cloud.pubsublite.proto.Cursor.Builder,
+            com.google.cloud.pubsublite.proto.CursorOrBuilder>
+        cursorBuilder_;
     /**
+     *
+     *
      * <pre>
      * The position of a message within the partition where it is stored.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+     *
      * @return Whether the cursor field is set.
      */
     public boolean hasCursor() {
       return cursorBuilder_ != null || cursor_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * The position of a message within the partition where it is stored.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+     *
      * @return The cursor.
      */
     public com.google.cloud.pubsublite.proto.Cursor getCursor() {
       if (cursorBuilder_ == null) {
-        return cursor_ == null ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+        return cursor_ == null
+            ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+            : cursor_;
       } else {
         return cursorBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * The position of a message within the partition where it is stored.
      * </pre>
@@ -689,14 +740,15 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The position of a message within the partition where it is stored.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
      */
-    public Builder setCursor(
-        com.google.cloud.pubsublite.proto.Cursor.Builder builderForValue) {
+    public Builder setCursor(com.google.cloud.pubsublite.proto.Cursor.Builder builderForValue) {
       if (cursorBuilder_ == null) {
         cursor_ = builderForValue.build();
         onChanged();
@@ -707,6 +759,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The position of a message within the partition where it is stored.
      * </pre>
@@ -717,7 +771,9 @@ private static final long serialVersionUID = 0L;
       if (cursorBuilder_ == null) {
         if (cursor_ != null) {
           cursor_ =
-            com.google.cloud.pubsublite.proto.Cursor.newBuilder(cursor_).mergeFrom(value).buildPartial();
+              com.google.cloud.pubsublite.proto.Cursor.newBuilder(cursor_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           cursor_ = value;
         }
@@ -729,6 +785,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The position of a message within the partition where it is stored.
      * </pre>
@@ -747,6 +805,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The position of a message within the partition where it is stored.
      * </pre>
@@ -754,11 +814,13 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
      */
     public com.google.cloud.pubsublite.proto.Cursor.Builder getCursorBuilder() {
-      
+
       onChanged();
       return getCursorFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * The position of a message within the partition where it is stored.
      * </pre>
@@ -769,11 +831,14 @@ private static final long serialVersionUID = 0L;
       if (cursorBuilder_ != null) {
         return cursorBuilder_.getMessageOrBuilder();
       } else {
-        return cursor_ == null ?
-            com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance() : cursor_;
+        return cursor_ == null
+            ? com.google.cloud.pubsublite.proto.Cursor.getDefaultInstance()
+            : cursor_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The position of a message within the partition where it is stored.
      * </pre>
@@ -781,14 +846,17 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder> 
+            com.google.cloud.pubsublite.proto.Cursor,
+            com.google.cloud.pubsublite.proto.Cursor.Builder,
+            com.google.cloud.pubsublite.proto.CursorOrBuilder>
         getCursorFieldBuilder() {
       if (cursorBuilder_ == null) {
-        cursorBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Cursor, com.google.cloud.pubsublite.proto.Cursor.Builder, com.google.cloud.pubsublite.proto.CursorOrBuilder>(
-                getCursor(),
-                getParentForChildren(),
-                isClean());
+        cursorBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Cursor,
+                com.google.cloud.pubsublite.proto.Cursor.Builder,
+                com.google.cloud.pubsublite.proto.CursorOrBuilder>(
+                getCursor(), getParentForChildren(), isClean());
         cursor_ = null;
       }
       return cursorBuilder_;
@@ -796,36 +864,49 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Timestamp publishTime_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> publishTimeBuilder_;
+            com.google.protobuf.Timestamp,
+            com.google.protobuf.Timestamp.Builder,
+            com.google.protobuf.TimestampOrBuilder>
+        publishTimeBuilder_;
     /**
+     *
+     *
      * <pre>
      * The time when the message was received by the server when it was first
      * published.
      * </pre>
      *
      * <code>.google.protobuf.Timestamp publish_time = 2;</code>
+     *
      * @return Whether the publishTime field is set.
      */
     public boolean hasPublishTime() {
       return publishTimeBuilder_ != null || publishTime_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * The time when the message was received by the server when it was first
      * published.
      * </pre>
      *
      * <code>.google.protobuf.Timestamp publish_time = 2;</code>
+     *
      * @return The publishTime.
      */
     public com.google.protobuf.Timestamp getPublishTime() {
       if (publishTimeBuilder_ == null) {
-        return publishTime_ == null ? com.google.protobuf.Timestamp.getDefaultInstance() : publishTime_;
+        return publishTime_ == null
+            ? com.google.protobuf.Timestamp.getDefaultInstance()
+            : publishTime_;
       } else {
         return publishTimeBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * The time when the message was received by the server when it was first
      * published.
@@ -847,6 +928,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The time when the message was received by the server when it was first
      * published.
@@ -854,8 +937,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.google.protobuf.Timestamp publish_time = 2;</code>
      */
-    public Builder setPublishTime(
-        com.google.protobuf.Timestamp.Builder builderForValue) {
+    public Builder setPublishTime(com.google.protobuf.Timestamp.Builder builderForValue) {
       if (publishTimeBuilder_ == null) {
         publishTime_ = builderForValue.build();
         onChanged();
@@ -866,6 +948,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The time when the message was received by the server when it was first
      * published.
@@ -877,7 +961,9 @@ private static final long serialVersionUID = 0L;
       if (publishTimeBuilder_ == null) {
         if (publishTime_ != null) {
           publishTime_ =
-            com.google.protobuf.Timestamp.newBuilder(publishTime_).mergeFrom(value).buildPartial();
+              com.google.protobuf.Timestamp.newBuilder(publishTime_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           publishTime_ = value;
         }
@@ -889,6 +975,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The time when the message was received by the server when it was first
      * published.
@@ -908,6 +996,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The time when the message was received by the server when it was first
      * published.
@@ -916,11 +1006,13 @@ private static final long serialVersionUID = 0L;
      * <code>.google.protobuf.Timestamp publish_time = 2;</code>
      */
     public com.google.protobuf.Timestamp.Builder getPublishTimeBuilder() {
-      
+
       onChanged();
       return getPublishTimeFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * The time when the message was received by the server when it was first
      * published.
@@ -932,11 +1024,14 @@ private static final long serialVersionUID = 0L;
       if (publishTimeBuilder_ != null) {
         return publishTimeBuilder_.getMessageOrBuilder();
       } else {
-        return publishTime_ == null ?
-            com.google.protobuf.Timestamp.getDefaultInstance() : publishTime_;
+        return publishTime_ == null
+            ? com.google.protobuf.Timestamp.getDefaultInstance()
+            : publishTime_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The time when the message was received by the server when it was first
      * published.
@@ -945,14 +1040,17 @@ private static final long serialVersionUID = 0L;
      * <code>.google.protobuf.Timestamp publish_time = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> 
+            com.google.protobuf.Timestamp,
+            com.google.protobuf.Timestamp.Builder,
+            com.google.protobuf.TimestampOrBuilder>
         getPublishTimeFieldBuilder() {
       if (publishTimeBuilder_ == null) {
-        publishTimeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder>(
-                getPublishTime(),
-                getParentForChildren(),
-                isClean());
+        publishTimeBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.protobuf.Timestamp,
+                com.google.protobuf.Timestamp.Builder,
+                com.google.protobuf.TimestampOrBuilder>(
+                getPublishTime(), getParentForChildren(), isClean());
         publishTime_ = null;
       }
       return publishTimeBuilder_;
@@ -960,34 +1058,47 @@ private static final long serialVersionUID = 0L;
 
     private com.google.cloud.pubsublite.proto.PubSubMessage message_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.PubSubMessage, com.google.cloud.pubsublite.proto.PubSubMessage.Builder, com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder> messageBuilder_;
+            com.google.cloud.pubsublite.proto.PubSubMessage,
+            com.google.cloud.pubsublite.proto.PubSubMessage.Builder,
+            com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder>
+        messageBuilder_;
     /**
+     *
+     *
      * <pre>
      * The user message.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.PubSubMessage message = 3;</code>
+     *
      * @return Whether the message field is set.
      */
     public boolean hasMessage() {
       return messageBuilder_ != null || message_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * The user message.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.PubSubMessage message = 3;</code>
+     *
      * @return The message.
      */
     public com.google.cloud.pubsublite.proto.PubSubMessage getMessage() {
       if (messageBuilder_ == null) {
-        return message_ == null ? com.google.cloud.pubsublite.proto.PubSubMessage.getDefaultInstance() : message_;
+        return message_ == null
+            ? com.google.cloud.pubsublite.proto.PubSubMessage.getDefaultInstance()
+            : message_;
       } else {
         return messageBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * The user message.
      * </pre>
@@ -1008,6 +1119,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The user message.
      * </pre>
@@ -1026,6 +1139,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The user message.
      * </pre>
@@ -1036,7 +1151,9 @@ private static final long serialVersionUID = 0L;
       if (messageBuilder_ == null) {
         if (message_ != null) {
           message_ =
-            com.google.cloud.pubsublite.proto.PubSubMessage.newBuilder(message_).mergeFrom(value).buildPartial();
+              com.google.cloud.pubsublite.proto.PubSubMessage.newBuilder(message_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           message_ = value;
         }
@@ -1048,6 +1165,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The user message.
      * </pre>
@@ -1066,6 +1185,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The user message.
      * </pre>
@@ -1073,11 +1194,13 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.PubSubMessage message = 3;</code>
      */
     public com.google.cloud.pubsublite.proto.PubSubMessage.Builder getMessageBuilder() {
-      
+
       onChanged();
       return getMessageFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * The user message.
      * </pre>
@@ -1088,11 +1211,14 @@ private static final long serialVersionUID = 0L;
       if (messageBuilder_ != null) {
         return messageBuilder_.getMessageOrBuilder();
       } else {
-        return message_ == null ?
-            com.google.cloud.pubsublite.proto.PubSubMessage.getDefaultInstance() : message_;
+        return message_ == null
+            ? com.google.cloud.pubsublite.proto.PubSubMessage.getDefaultInstance()
+            : message_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The user message.
      * </pre>
@@ -1100,63 +1226,75 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.PubSubMessage message = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.PubSubMessage, com.google.cloud.pubsublite.proto.PubSubMessage.Builder, com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder> 
+            com.google.cloud.pubsublite.proto.PubSubMessage,
+            com.google.cloud.pubsublite.proto.PubSubMessage.Builder,
+            com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder>
         getMessageFieldBuilder() {
       if (messageBuilder_ == null) {
-        messageBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.PubSubMessage, com.google.cloud.pubsublite.proto.PubSubMessage.Builder, com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder>(
-                getMessage(),
-                getParentForChildren(),
-                isClean());
+        messageBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.PubSubMessage,
+                com.google.cloud.pubsublite.proto.PubSubMessage.Builder,
+                com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder>(
+                getMessage(), getParentForChildren(), isClean());
         message_ = null;
       }
       return messageBuilder_;
     }
 
-    private long sizeBytes_ ;
+    private long sizeBytes_;
     /**
+     *
+     *
      * <pre>
      * The size in bytes of this message for flow control and quota purposes.
      * </pre>
      *
      * <code>int64 size_bytes = 4;</code>
+     *
      * @return The sizeBytes.
      */
     public long getSizeBytes() {
       return sizeBytes_;
     }
     /**
+     *
+     *
      * <pre>
      * The size in bytes of this message for flow control and quota purposes.
      * </pre>
      *
      * <code>int64 size_bytes = 4;</code>
+     *
      * @param value The sizeBytes to set.
      * @return This builder for chaining.
      */
     public Builder setSizeBytes(long value) {
-      
+
       sizeBytes_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The size in bytes of this message for flow control and quota purposes.
      * </pre>
      *
      * <code>int64 size_bytes = 4;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearSizeBytes() {
-      
+
       sizeBytes_ = 0L;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -1166,12 +1304,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.SequencedMessage)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.SequencedMessage)
   private static final com.google.cloud.pubsublite.proto.SequencedMessage DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.SequencedMessage();
   }
@@ -1180,16 +1318,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<SequencedMessage>
-      PARSER = new com.google.protobuf.AbstractParser<SequencedMessage>() {
-    @java.lang.Override
-    public SequencedMessage parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new SequencedMessage(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<SequencedMessage> PARSER =
+      new com.google.protobuf.AbstractParser<SequencedMessage>() {
+        @java.lang.Override
+        public SequencedMessage parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new SequencedMessage(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<SequencedMessage> parser() {
     return PARSER;
@@ -1204,6 +1342,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.SequencedMessage getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SequencedMessageOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SequencedMessageOrBuilder.java
@@ -3,29 +3,38 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface SequencedMessageOrBuilder extends
+public interface SequencedMessageOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.SequencedMessage)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The position of a message within the partition where it is stored.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+   *
    * @return Whether the cursor field is set.
    */
   boolean hasCursor();
   /**
+   *
+   *
    * <pre>
    * The position of a message within the partition where it is stored.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Cursor cursor = 1;</code>
+   *
    * @return The cursor.
    */
   com.google.cloud.pubsublite.proto.Cursor getCursor();
   /**
+   *
+   *
    * <pre>
    * The position of a message within the partition where it is stored.
    * </pre>
@@ -35,26 +44,34 @@ public interface SequencedMessageOrBuilder extends
   com.google.cloud.pubsublite.proto.CursorOrBuilder getCursorOrBuilder();
 
   /**
+   *
+   *
    * <pre>
    * The time when the message was received by the server when it was first
    * published.
    * </pre>
    *
    * <code>.google.protobuf.Timestamp publish_time = 2;</code>
+   *
    * @return Whether the publishTime field is set.
    */
   boolean hasPublishTime();
   /**
+   *
+   *
    * <pre>
    * The time when the message was received by the server when it was first
    * published.
    * </pre>
    *
    * <code>.google.protobuf.Timestamp publish_time = 2;</code>
+   *
    * @return The publishTime.
    */
   com.google.protobuf.Timestamp getPublishTime();
   /**
+   *
+   *
    * <pre>
    * The time when the message was received by the server when it was first
    * published.
@@ -65,24 +82,32 @@ public interface SequencedMessageOrBuilder extends
   com.google.protobuf.TimestampOrBuilder getPublishTimeOrBuilder();
 
   /**
+   *
+   *
    * <pre>
    * The user message.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.PubSubMessage message = 3;</code>
+   *
    * @return Whether the message field is set.
    */
   boolean hasMessage();
   /**
+   *
+   *
    * <pre>
    * The user message.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.PubSubMessage message = 3;</code>
+   *
    * @return The message.
    */
   com.google.cloud.pubsublite.proto.PubSubMessage getMessage();
   /**
+   *
+   *
    * <pre>
    * The user message.
    * </pre>
@@ -92,11 +117,14 @@ public interface SequencedMessageOrBuilder extends
   com.google.cloud.pubsublite.proto.PubSubMessageOrBuilder getMessageOrBuilder();
 
   /**
+   *
+   *
    * <pre>
    * The size in bytes of this message for flow control and quota purposes.
    * </pre>
    *
    * <code>int64 size_bytes = 4;</code>
+   *
    * @return The sizeBytes.
    */
   long getSizeBytes();

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/StreamingCommitCursorRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/StreamingCommitCursorRequest.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * A request sent from the client to the server on a stream.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.StreamingCommitCursorRequest}
  */
-public  final class StreamingCommitCursorRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class StreamingCommitCursorRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.StreamingCommitCursorRequest)
     StreamingCommitCursorRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use StreamingCommitCursorRequest.newBuilder() to construct.
   private StreamingCommitCursorRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private StreamingCommitCursorRequest() {
-  }
+
+  private StreamingCommitCursorRequest() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new StreamingCommitCursorRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private StreamingCommitCursorRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,75 +53,94 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.Builder subBuilder = null;
-            if (requestCase_ == 1) {
-              subBuilder = ((com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) request_).toBuilder();
+          case 10:
+            {
+              com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.Builder subBuilder =
+                  null;
+              if (requestCase_ == 1) {
+                subBuilder =
+                    ((com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) request_)
+                        .toBuilder();
+              }
+              request_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.parser(),
+                      extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(
+                    (com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) request_);
+                request_ = subBuilder.buildPartial();
+              }
+              requestCase_ = 1;
+              break;
             }
-            request_ =
-                input.readMessage(com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) request_);
-              request_ = subBuilder.buildPartial();
+          case 18:
+            {
+              com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.Builder subBuilder =
+                  null;
+              if (requestCase_ == 2) {
+                subBuilder =
+                    ((com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) request_)
+                        .toBuilder();
+              }
+              request_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.parser(),
+                      extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(
+                    (com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) request_);
+                request_ = subBuilder.buildPartial();
+              }
+              requestCase_ = 2;
+              break;
             }
-            requestCase_ = 1;
-            break;
-          }
-          case 18: {
-            com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.Builder subBuilder = null;
-            if (requestCase_ == 2) {
-              subBuilder = ((com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) request_).toBuilder();
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
             }
-            request_ =
-                input.readMessage(com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) request_);
-              request_ = subBuilder.buildPartial();
-            }
-            requestCase_ = 2;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest.class, com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest.class,
+            com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest.Builder.class);
   }
 
   private int requestCase_ = 0;
   private java.lang.Object request_;
+
   public enum RequestCase
-      implements com.google.protobuf.Internal.EnumLite,
+      implements
+          com.google.protobuf.Internal.EnumLite,
           com.google.protobuf.AbstractMessage.InternalOneOfEnum {
     INITIAL(1),
     COMMIT(2),
     REQUEST_NOT_SET(0);
     private final int value;
+
     private RequestCase(int value) {
       this.value = value;
     }
@@ -136,104 +156,126 @@ private static final long serialVersionUID = 0L;
 
     public static RequestCase forNumber(int value) {
       switch (value) {
-        case 1: return INITIAL;
-        case 2: return COMMIT;
-        case 0: return REQUEST_NOT_SET;
-        default: return null;
+        case 1:
+          return INITIAL;
+        case 2:
+          return COMMIT;
+        case 0:
+          return REQUEST_NOT_SET;
+        default:
+          return null;
       }
     }
+
     public int getNumber() {
       return this.value;
     }
   };
 
-  public RequestCase
-  getRequestCase() {
-    return RequestCase.forNumber(
-        requestCase_);
+  public RequestCase getRequestCase() {
+    return RequestCase.forNumber(requestCase_);
   }
 
   public static final int INITIAL_FIELD_NUMBER = 1;
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialCommitCursorRequest initial = 1;</code>
+   *
    * @return Whether the initial field is set.
    */
   public boolean hasInitial() {
     return requestCase_ == 1;
   }
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialCommitCursorRequest initial = 1;</code>
+   *
    * @return The initial.
    */
   public com.google.cloud.pubsublite.proto.InitialCommitCursorRequest getInitial() {
     if (requestCase_ == 1) {
-       return (com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) request_;
+      return (com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) request_;
     }
     return com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.getDefaultInstance();
   }
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialCommitCursorRequest initial = 1;</code>
    */
-  public com.google.cloud.pubsublite.proto.InitialCommitCursorRequestOrBuilder getInitialOrBuilder() {
+  public com.google.cloud.pubsublite.proto.InitialCommitCursorRequestOrBuilder
+      getInitialOrBuilder() {
     if (requestCase_ == 1) {
-       return (com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) request_;
+      return (com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) request_;
     }
     return com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.getDefaultInstance();
   }
 
   public static final int COMMIT_FIELD_NUMBER = 2;
   /**
+   *
+   *
    * <pre>
    * Request to commit a new cursor value.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorRequest commit = 2;</code>
+   *
    * @return Whether the commit field is set.
    */
   public boolean hasCommit() {
     return requestCase_ == 2;
   }
   /**
+   *
+   *
    * <pre>
    * Request to commit a new cursor value.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorRequest commit = 2;</code>
+   *
    * @return The commit.
    */
   public com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest getCommit() {
     if (requestCase_ == 2) {
-       return (com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) request_;
+      return (com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) request_;
     }
     return com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.getDefaultInstance();
   }
   /**
+   *
+   *
    * <pre>
    * Request to commit a new cursor value.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorRequest commit = 2;</code>
    */
-  public com.google.cloud.pubsublite.proto.SequencedCommitCursorRequestOrBuilder getCommitOrBuilder() {
+  public com.google.cloud.pubsublite.proto.SequencedCommitCursorRequestOrBuilder
+      getCommitOrBuilder() {
     if (requestCase_ == 2) {
-       return (com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) request_;
+      return (com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) request_;
     }
     return com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.getDefaultInstance();
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -245,13 +287,14 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (requestCase_ == 1) {
-      output.writeMessage(1, (com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) request_);
+      output.writeMessage(
+          1, (com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) request_);
     }
     if (requestCase_ == 2) {
-      output.writeMessage(2, (com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) request_);
+      output.writeMessage(
+          2, (com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) request_);
     }
     unknownFields.writeTo(output);
   }
@@ -263,12 +306,14 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (requestCase_ == 1) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, (com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) request_);
+      size +=
+          com.google.protobuf.CodedOutputStream.computeMessageSize(
+              1, (com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) request_);
     }
     if (requestCase_ == 2) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, (com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) request_);
+      size +=
+          com.google.protobuf.CodedOutputStream.computeMessageSize(
+              2, (com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) request_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -278,22 +323,21 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest other = (com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest) obj;
+    com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest other =
+        (com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest) obj;
 
     if (!getRequestCase().equals(other.getRequestCase())) return false;
     switch (requestCase_) {
       case 1:
-        if (!getInitial()
-            .equals(other.getInitial())) return false;
+        if (!getInitial().equals(other.getInitial())) return false;
         break;
       case 2:
-        if (!getCommit()
-            .equals(other.getCommit())) return false;
+        if (!getCommit().equals(other.getCommit())) return false;
         break;
       case 0:
       default:
@@ -327,117 +371,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest parseFrom(byte[] data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+
+  public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest parseFrom(
+      byte[] data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * A request sent from the client to the server on a stream.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.StreamingCommitCursorRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.StreamingCommitCursorRequest)
       com.google.cloud.pubsublite.proto.StreamingCommitCursorRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest.class, com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest.class,
+              com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest.newBuilder()
@@ -445,16 +499,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -464,13 +517,14 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorRequest_descriptor;
     }
 
     @java.lang.Override
-    public com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest getDefaultInstanceForType() {
+    public com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest
+        getDefaultInstanceForType() {
       return com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest.getDefaultInstance();
     }
 
@@ -485,7 +539,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest result = new com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest(this);
+      com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest result =
+          new com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest(this);
       if (requestCase_ == 1) {
         if (initialBuilder_ == null) {
           result.request_ = request_;
@@ -509,38 +564,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -548,19 +604,24 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest.getDefaultInstance()) return this;
+      if (other
+          == com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest.getDefaultInstance())
+        return this;
       switch (other.getRequestCase()) {
-        case INITIAL: {
-          mergeInitial(other.getInitial());
-          break;
-        }
-        case COMMIT: {
-          mergeCommit(other.getCommit());
-          break;
-        }
-        case REQUEST_NOT_SET: {
-          break;
-        }
+        case INITIAL:
+          {
+            mergeInitial(other.getInitial());
+            break;
+          }
+        case COMMIT:
+          {
+            mergeCommit(other.getCommit());
+            break;
+          }
+        case REQUEST_NOT_SET:
+          {
+            break;
+          }
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -581,7 +642,9 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest)
+                e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -590,12 +653,12 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     private int requestCase_ = 0;
     private java.lang.Object request_;
-    public RequestCase
-        getRequestCase() {
-      return RequestCase.forNumber(
-          requestCase_);
+
+    public RequestCase getRequestCase() {
+      return RequestCase.forNumber(requestCase_);
     }
 
     public Builder clearRequest() {
@@ -605,26 +668,34 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.InitialCommitCursorRequest, com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.Builder, com.google.cloud.pubsublite.proto.InitialCommitCursorRequestOrBuilder> initialBuilder_;
+            com.google.cloud.pubsublite.proto.InitialCommitCursorRequest,
+            com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.Builder,
+            com.google.cloud.pubsublite.proto.InitialCommitCursorRequestOrBuilder>
+        initialBuilder_;
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialCommitCursorRequest initial = 1;</code>
+     *
      * @return Whether the initial field is set.
      */
     public boolean hasInitial() {
       return requestCase_ == 1;
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialCommitCursorRequest initial = 1;</code>
+     *
      * @return The initial.
      */
     public com.google.cloud.pubsublite.proto.InitialCommitCursorRequest getInitial() {
@@ -641,6 +712,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
@@ -661,6 +734,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
@@ -679,18 +754,26 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialCommitCursorRequest initial = 1;</code>
      */
-    public Builder mergeInitial(com.google.cloud.pubsublite.proto.InitialCommitCursorRequest value) {
+    public Builder mergeInitial(
+        com.google.cloud.pubsublite.proto.InitialCommitCursorRequest value) {
       if (initialBuilder_ == null) {
-        if (requestCase_ == 1 &&
-            request_ != com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.getDefaultInstance()) {
-          request_ = com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.newBuilder((com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) request_)
-              .mergeFrom(value).buildPartial();
+        if (requestCase_ == 1
+            && request_
+                != com.google.cloud.pubsublite.proto.InitialCommitCursorRequest
+                    .getDefaultInstance()) {
+          request_ =
+              com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.newBuilder(
+                      (com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) request_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           request_ = value;
         }
@@ -705,6 +788,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
@@ -728,23 +813,29 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialCommitCursorRequest initial = 1;</code>
      */
-    public com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.Builder getInitialBuilder() {
+    public com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.Builder
+        getInitialBuilder() {
       return getInitialFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialCommitCursorRequest initial = 1;</code>
      */
-    public com.google.cloud.pubsublite.proto.InitialCommitCursorRequestOrBuilder getInitialOrBuilder() {
+    public com.google.cloud.pubsublite.proto.InitialCommitCursorRequestOrBuilder
+        getInitialOrBuilder() {
       if ((requestCase_ == 1) && (initialBuilder_ != null)) {
         return initialBuilder_.getMessageOrBuilder();
       } else {
@@ -755,6 +846,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
@@ -762,43 +855,59 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.InitialCommitCursorRequest initial = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.InitialCommitCursorRequest, com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.Builder, com.google.cloud.pubsublite.proto.InitialCommitCursorRequestOrBuilder> 
+            com.google.cloud.pubsublite.proto.InitialCommitCursorRequest,
+            com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.Builder,
+            com.google.cloud.pubsublite.proto.InitialCommitCursorRequestOrBuilder>
         getInitialFieldBuilder() {
       if (initialBuilder_ == null) {
         if (!(requestCase_ == 1)) {
-          request_ = com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.getDefaultInstance();
+          request_ =
+              com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.getDefaultInstance();
         }
-        initialBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.InitialCommitCursorRequest, com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.Builder, com.google.cloud.pubsublite.proto.InitialCommitCursorRequestOrBuilder>(
+        initialBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.InitialCommitCursorRequest,
+                com.google.cloud.pubsublite.proto.InitialCommitCursorRequest.Builder,
+                com.google.cloud.pubsublite.proto.InitialCommitCursorRequestOrBuilder>(
                 (com.google.cloud.pubsublite.proto.InitialCommitCursorRequest) request_,
                 getParentForChildren(),
                 isClean());
         request_ = null;
       }
       requestCase_ = 1;
-      onChanged();;
+      onChanged();
+      ;
       return initialBuilder_;
     }
 
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest, com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.Builder, com.google.cloud.pubsublite.proto.SequencedCommitCursorRequestOrBuilder> commitBuilder_;
+            com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest,
+            com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.Builder,
+            com.google.cloud.pubsublite.proto.SequencedCommitCursorRequestOrBuilder>
+        commitBuilder_;
     /**
+     *
+     *
      * <pre>
      * Request to commit a new cursor value.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorRequest commit = 2;</code>
+     *
      * @return Whether the commit field is set.
      */
     public boolean hasCommit() {
       return requestCase_ == 2;
     }
     /**
+     *
+     *
      * <pre>
      * Request to commit a new cursor value.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorRequest commit = 2;</code>
+     *
      * @return The commit.
      */
     public com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest getCommit() {
@@ -815,6 +924,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Request to commit a new cursor value.
      * </pre>
@@ -835,6 +946,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Request to commit a new cursor value.
      * </pre>
@@ -853,18 +966,26 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Request to commit a new cursor value.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorRequest commit = 2;</code>
      */
-    public Builder mergeCommit(com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest value) {
+    public Builder mergeCommit(
+        com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest value) {
       if (commitBuilder_ == null) {
-        if (requestCase_ == 2 &&
-            request_ != com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.getDefaultInstance()) {
-          request_ = com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.newBuilder((com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) request_)
-              .mergeFrom(value).buildPartial();
+        if (requestCase_ == 2
+            && request_
+                != com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest
+                    .getDefaultInstance()) {
+          request_ =
+              com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.newBuilder(
+                      (com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) request_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           request_ = value;
         }
@@ -879,6 +1000,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Request to commit a new cursor value.
      * </pre>
@@ -902,23 +1025,29 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Request to commit a new cursor value.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorRequest commit = 2;</code>
      */
-    public com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.Builder getCommitBuilder() {
+    public com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.Builder
+        getCommitBuilder() {
       return getCommitFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * Request to commit a new cursor value.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorRequest commit = 2;</code>
      */
-    public com.google.cloud.pubsublite.proto.SequencedCommitCursorRequestOrBuilder getCommitOrBuilder() {
+    public com.google.cloud.pubsublite.proto.SequencedCommitCursorRequestOrBuilder
+        getCommitOrBuilder() {
       if ((requestCase_ == 2) && (commitBuilder_ != null)) {
         return commitBuilder_.getMessageOrBuilder();
       } else {
@@ -929,6 +1058,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Request to commit a new cursor value.
      * </pre>
@@ -936,26 +1067,33 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorRequest commit = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest, com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.Builder, com.google.cloud.pubsublite.proto.SequencedCommitCursorRequestOrBuilder> 
+            com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest,
+            com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.Builder,
+            com.google.cloud.pubsublite.proto.SequencedCommitCursorRequestOrBuilder>
         getCommitFieldBuilder() {
       if (commitBuilder_ == null) {
         if (!(requestCase_ == 2)) {
-          request_ = com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.getDefaultInstance();
+          request_ =
+              com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.getDefaultInstance();
         }
-        commitBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest, com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.Builder, com.google.cloud.pubsublite.proto.SequencedCommitCursorRequestOrBuilder>(
+        commitBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest,
+                com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest.Builder,
+                com.google.cloud.pubsublite.proto.SequencedCommitCursorRequestOrBuilder>(
                 (com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest) request_,
                 getParentForChildren(),
                 isClean());
         request_ = null;
       }
       requestCase_ = 2;
-      onChanged();;
+      onChanged();
+      ;
       return commitBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -965,30 +1103,32 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.StreamingCommitCursorRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.StreamingCommitCursorRequest)
-  private static final com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest DEFAULT_INSTANCE;
+  private static final com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest
+      DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest();
   }
 
-  public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest getDefaultInstance() {
+  public static com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest
+      getDefaultInstance() {
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<StreamingCommitCursorRequest>
-      PARSER = new com.google.protobuf.AbstractParser<StreamingCommitCursorRequest>() {
-    @java.lang.Override
-    public StreamingCommitCursorRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new StreamingCommitCursorRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<StreamingCommitCursorRequest> PARSER =
+      new com.google.protobuf.AbstractParser<StreamingCommitCursorRequest>() {
+        @java.lang.Override
+        public StreamingCommitCursorRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new StreamingCommitCursorRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<StreamingCommitCursorRequest> parser() {
     return PARSER;
@@ -1000,9 +1140,8 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest getDefaultInstanceForType() {
+  public com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest
+      getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/StreamingCommitCursorRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/StreamingCommitCursorRequestOrBuilder.java
@@ -3,29 +3,38 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface StreamingCommitCursorRequestOrBuilder extends
+public interface StreamingCommitCursorRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.StreamingCommitCursorRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialCommitCursorRequest initial = 1;</code>
+   *
    * @return Whether the initial field is set.
    */
   boolean hasInitial();
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialCommitCursorRequest initial = 1;</code>
+   *
    * @return The initial.
    */
   com.google.cloud.pubsublite.proto.InitialCommitCursorRequest getInitial();
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
@@ -35,24 +44,32 @@ public interface StreamingCommitCursorRequestOrBuilder extends
   com.google.cloud.pubsublite.proto.InitialCommitCursorRequestOrBuilder getInitialOrBuilder();
 
   /**
+   *
+   *
    * <pre>
    * Request to commit a new cursor value.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorRequest commit = 2;</code>
+   *
    * @return Whether the commit field is set.
    */
   boolean hasCommit();
   /**
+   *
+   *
    * <pre>
    * Request to commit a new cursor value.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorRequest commit = 2;</code>
+   *
    * @return The commit.
    */
   com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest getCommit();
   /**
+   *
+   *
    * <pre>
    * Request to commit a new cursor value.
    * </pre>
@@ -61,5 +78,6 @@ public interface StreamingCommitCursorRequestOrBuilder extends
    */
   com.google.cloud.pubsublite.proto.SequencedCommitCursorRequestOrBuilder getCommitOrBuilder();
 
-  public com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest.RequestCase getRequestCase();
+  public com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest.RequestCase
+      getRequestCase();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/StreamingCommitCursorResponse.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/StreamingCommitCursorResponse.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Response to a StreamingCommitCursorRequest.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.StreamingCommitCursorResponse}
  */
-public  final class StreamingCommitCursorResponse extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class StreamingCommitCursorResponse extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.StreamingCommitCursorResponse)
     StreamingCommitCursorResponseOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use StreamingCommitCursorResponse.newBuilder() to construct.
   private StreamingCommitCursorResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private StreamingCommitCursorResponse() {
-  }
+
+  private StreamingCommitCursorResponse() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new StreamingCommitCursorResponse();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private StreamingCommitCursorResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,75 +53,94 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.Builder subBuilder = null;
-            if (requestCase_ == 1) {
-              subBuilder = ((com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) request_).toBuilder();
+          case 10:
+            {
+              com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.Builder subBuilder =
+                  null;
+              if (requestCase_ == 1) {
+                subBuilder =
+                    ((com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) request_)
+                        .toBuilder();
+              }
+              request_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.parser(),
+                      extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(
+                    (com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) request_);
+                request_ = subBuilder.buildPartial();
+              }
+              requestCase_ = 1;
+              break;
             }
-            request_ =
-                input.readMessage(com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) request_);
-              request_ = subBuilder.buildPartial();
+          case 18:
+            {
+              com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.Builder subBuilder =
+                  null;
+              if (requestCase_ == 2) {
+                subBuilder =
+                    ((com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) request_)
+                        .toBuilder();
+              }
+              request_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.parser(),
+                      extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(
+                    (com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) request_);
+                request_ = subBuilder.buildPartial();
+              }
+              requestCase_ = 2;
+              break;
             }
-            requestCase_ = 1;
-            break;
-          }
-          case 18: {
-            com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.Builder subBuilder = null;
-            if (requestCase_ == 2) {
-              subBuilder = ((com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) request_).toBuilder();
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
             }
-            request_ =
-                input.readMessage(com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) request_);
-              request_ = subBuilder.buildPartial();
-            }
-            requestCase_ = 2;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CursorProto
+        .internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse.class, com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse.Builder.class);
+            com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse.class,
+            com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse.Builder.class);
   }
 
   private int requestCase_ = 0;
   private java.lang.Object request_;
+
   public enum RequestCase
-      implements com.google.protobuf.Internal.EnumLite,
+      implements
+          com.google.protobuf.Internal.EnumLite,
           com.google.protobuf.AbstractMessage.InternalOneOfEnum {
     INITIAL(1),
     COMMIT(2),
     REQUEST_NOT_SET(0);
     private final int value;
+
     private RequestCase(int value) {
       this.value = value;
     }
@@ -136,104 +156,126 @@ private static final long serialVersionUID = 0L;
 
     public static RequestCase forNumber(int value) {
       switch (value) {
-        case 1: return INITIAL;
-        case 2: return COMMIT;
-        case 0: return REQUEST_NOT_SET;
-        default: return null;
+        case 1:
+          return INITIAL;
+        case 2:
+          return COMMIT;
+        case 0:
+          return REQUEST_NOT_SET;
+        default:
+          return null;
       }
     }
+
     public int getNumber() {
       return this.value;
     }
   };
 
-  public RequestCase
-  getRequestCase() {
-    return RequestCase.forNumber(
-        requestCase_);
+  public RequestCase getRequestCase() {
+    return RequestCase.forNumber(requestCase_);
   }
 
   public static final int INITIAL_FIELD_NUMBER = 1;
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialCommitCursorResponse initial = 1;</code>
+   *
    * @return Whether the initial field is set.
    */
   public boolean hasInitial() {
     return requestCase_ == 1;
   }
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialCommitCursorResponse initial = 1;</code>
+   *
    * @return The initial.
    */
   public com.google.cloud.pubsublite.proto.InitialCommitCursorResponse getInitial() {
     if (requestCase_ == 1) {
-       return (com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) request_;
+      return (com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) request_;
     }
     return com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.getDefaultInstance();
   }
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialCommitCursorResponse initial = 1;</code>
    */
-  public com.google.cloud.pubsublite.proto.InitialCommitCursorResponseOrBuilder getInitialOrBuilder() {
+  public com.google.cloud.pubsublite.proto.InitialCommitCursorResponseOrBuilder
+      getInitialOrBuilder() {
     if (requestCase_ == 1) {
-       return (com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) request_;
+      return (com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) request_;
     }
     return com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.getDefaultInstance();
   }
 
   public static final int COMMIT_FIELD_NUMBER = 2;
   /**
+   *
+   *
    * <pre>
    * Response to committing a new cursor value.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorResponse commit = 2;</code>
+   *
    * @return Whether the commit field is set.
    */
   public boolean hasCommit() {
     return requestCase_ == 2;
   }
   /**
+   *
+   *
    * <pre>
    * Response to committing a new cursor value.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorResponse commit = 2;</code>
+   *
    * @return The commit.
    */
   public com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse getCommit() {
     if (requestCase_ == 2) {
-       return (com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) request_;
+      return (com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) request_;
     }
     return com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.getDefaultInstance();
   }
   /**
+   *
+   *
    * <pre>
    * Response to committing a new cursor value.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorResponse commit = 2;</code>
    */
-  public com.google.cloud.pubsublite.proto.SequencedCommitCursorResponseOrBuilder getCommitOrBuilder() {
+  public com.google.cloud.pubsublite.proto.SequencedCommitCursorResponseOrBuilder
+      getCommitOrBuilder() {
     if (requestCase_ == 2) {
-       return (com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) request_;
+      return (com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) request_;
     }
     return com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.getDefaultInstance();
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -245,13 +287,14 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (requestCase_ == 1) {
-      output.writeMessage(1, (com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) request_);
+      output.writeMessage(
+          1, (com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) request_);
     }
     if (requestCase_ == 2) {
-      output.writeMessage(2, (com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) request_);
+      output.writeMessage(
+          2, (com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) request_);
     }
     unknownFields.writeTo(output);
   }
@@ -263,12 +306,14 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (requestCase_ == 1) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, (com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) request_);
+      size +=
+          com.google.protobuf.CodedOutputStream.computeMessageSize(
+              1, (com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) request_);
     }
     if (requestCase_ == 2) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, (com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) request_);
+      size +=
+          com.google.protobuf.CodedOutputStream.computeMessageSize(
+              2, (com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) request_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -278,22 +323,21 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse other = (com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse) obj;
+    com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse other =
+        (com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse) obj;
 
     if (!getRequestCase().equals(other.getRequestCase())) return false;
     switch (requestCase_) {
       case 1:
-        if (!getInitial()
-            .equals(other.getInitial())) return false;
+        if (!getInitial().equals(other.getInitial())) return false;
         break;
       case 2:
-        if (!getCommit()
-            .equals(other.getCommit())) return false;
+        if (!getCommit().equals(other.getCommit())) return false;
         break;
       case 0:
       default:
@@ -327,117 +371,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse parseFrom(byte[] data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+
+  public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse parseFrom(
+      byte[] data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Response to a StreamingCommitCursorRequest.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.StreamingCommitCursorResponse}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.StreamingCommitCursorResponse)
       com.google.cloud.pubsublite.proto.StreamingCommitCursorResponseOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse.class, com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse.Builder.class);
+              com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse.class,
+              com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse.newBuilder()
@@ -445,16 +499,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -464,13 +517,14 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CursorProto.internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CursorProto
+          .internal_static_google_cloud_pubsublite_v1_StreamingCommitCursorResponse_descriptor;
     }
 
     @java.lang.Override
-    public com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse getDefaultInstanceForType() {
+    public com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse
+        getDefaultInstanceForType() {
       return com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse.getDefaultInstance();
     }
 
@@ -485,7 +539,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse buildPartial() {
-      com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse result = new com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse(this);
+      com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse result =
+          new com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse(this);
       if (requestCase_ == 1) {
         if (initialBuilder_ == null) {
           result.request_ = request_;
@@ -509,58 +564,65 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse) other);
       } else {
         super.mergeFrom(other);
         return this;
       }
     }
 
-    public Builder mergeFrom(com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse other) {
-      if (other == com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse.getDefaultInstance()) return this;
+    public Builder mergeFrom(
+        com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse other) {
+      if (other
+          == com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse.getDefaultInstance())
+        return this;
       switch (other.getRequestCase()) {
-        case INITIAL: {
-          mergeInitial(other.getInitial());
-          break;
-        }
-        case COMMIT: {
-          mergeCommit(other.getCommit());
-          break;
-        }
-        case REQUEST_NOT_SET: {
-          break;
-        }
+        case INITIAL:
+          {
+            mergeInitial(other.getInitial());
+            break;
+          }
+        case COMMIT:
+          {
+            mergeCommit(other.getCommit());
+            break;
+          }
+        case REQUEST_NOT_SET:
+          {
+            break;
+          }
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -581,7 +643,9 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse)
+                e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -590,12 +654,12 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     private int requestCase_ = 0;
     private java.lang.Object request_;
-    public RequestCase
-        getRequestCase() {
-      return RequestCase.forNumber(
-          requestCase_);
+
+    public RequestCase getRequestCase() {
+      return RequestCase.forNumber(requestCase_);
     }
 
     public Builder clearRequest() {
@@ -605,26 +669,34 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.InitialCommitCursorResponse, com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.Builder, com.google.cloud.pubsublite.proto.InitialCommitCursorResponseOrBuilder> initialBuilder_;
+            com.google.cloud.pubsublite.proto.InitialCommitCursorResponse,
+            com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.Builder,
+            com.google.cloud.pubsublite.proto.InitialCommitCursorResponseOrBuilder>
+        initialBuilder_;
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialCommitCursorResponse initial = 1;</code>
+     *
      * @return Whether the initial field is set.
      */
     public boolean hasInitial() {
       return requestCase_ == 1;
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialCommitCursorResponse initial = 1;</code>
+     *
      * @return The initial.
      */
     public com.google.cloud.pubsublite.proto.InitialCommitCursorResponse getInitial() {
@@ -641,6 +713,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
@@ -661,6 +735,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
@@ -679,18 +755,26 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialCommitCursorResponse initial = 1;</code>
      */
-    public Builder mergeInitial(com.google.cloud.pubsublite.proto.InitialCommitCursorResponse value) {
+    public Builder mergeInitial(
+        com.google.cloud.pubsublite.proto.InitialCommitCursorResponse value) {
       if (initialBuilder_ == null) {
-        if (requestCase_ == 1 &&
-            request_ != com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.getDefaultInstance()) {
-          request_ = com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.newBuilder((com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) request_)
-              .mergeFrom(value).buildPartial();
+        if (requestCase_ == 1
+            && request_
+                != com.google.cloud.pubsublite.proto.InitialCommitCursorResponse
+                    .getDefaultInstance()) {
+          request_ =
+              com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.newBuilder(
+                      (com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) request_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           request_ = value;
         }
@@ -705,6 +789,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
@@ -728,23 +814,29 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialCommitCursorResponse initial = 1;</code>
      */
-    public com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.Builder getInitialBuilder() {
+    public com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.Builder
+        getInitialBuilder() {
       return getInitialFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialCommitCursorResponse initial = 1;</code>
      */
-    public com.google.cloud.pubsublite.proto.InitialCommitCursorResponseOrBuilder getInitialOrBuilder() {
+    public com.google.cloud.pubsublite.proto.InitialCommitCursorResponseOrBuilder
+        getInitialOrBuilder() {
       if ((requestCase_ == 1) && (initialBuilder_ != null)) {
         return initialBuilder_.getMessageOrBuilder();
       } else {
@@ -755,6 +847,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
@@ -762,43 +856,59 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.InitialCommitCursorResponse initial = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.InitialCommitCursorResponse, com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.Builder, com.google.cloud.pubsublite.proto.InitialCommitCursorResponseOrBuilder> 
+            com.google.cloud.pubsublite.proto.InitialCommitCursorResponse,
+            com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.Builder,
+            com.google.cloud.pubsublite.proto.InitialCommitCursorResponseOrBuilder>
         getInitialFieldBuilder() {
       if (initialBuilder_ == null) {
         if (!(requestCase_ == 1)) {
-          request_ = com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.getDefaultInstance();
+          request_ =
+              com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.getDefaultInstance();
         }
-        initialBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.InitialCommitCursorResponse, com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.Builder, com.google.cloud.pubsublite.proto.InitialCommitCursorResponseOrBuilder>(
+        initialBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.InitialCommitCursorResponse,
+                com.google.cloud.pubsublite.proto.InitialCommitCursorResponse.Builder,
+                com.google.cloud.pubsublite.proto.InitialCommitCursorResponseOrBuilder>(
                 (com.google.cloud.pubsublite.proto.InitialCommitCursorResponse) request_,
                 getParentForChildren(),
                 isClean());
         request_ = null;
       }
       requestCase_ = 1;
-      onChanged();;
+      onChanged();
+      ;
       return initialBuilder_;
     }
 
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse, com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.Builder, com.google.cloud.pubsublite.proto.SequencedCommitCursorResponseOrBuilder> commitBuilder_;
+            com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse,
+            com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.Builder,
+            com.google.cloud.pubsublite.proto.SequencedCommitCursorResponseOrBuilder>
+        commitBuilder_;
     /**
+     *
+     *
      * <pre>
      * Response to committing a new cursor value.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorResponse commit = 2;</code>
+     *
      * @return Whether the commit field is set.
      */
     public boolean hasCommit() {
       return requestCase_ == 2;
     }
     /**
+     *
+     *
      * <pre>
      * Response to committing a new cursor value.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorResponse commit = 2;</code>
+     *
      * @return The commit.
      */
     public com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse getCommit() {
@@ -815,13 +925,16 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Response to committing a new cursor value.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorResponse commit = 2;</code>
      */
-    public Builder setCommit(com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse value) {
+    public Builder setCommit(
+        com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse value) {
       if (commitBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
@@ -835,6 +948,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Response to committing a new cursor value.
      * </pre>
@@ -853,18 +968,26 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Response to committing a new cursor value.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorResponse commit = 2;</code>
      */
-    public Builder mergeCommit(com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse value) {
+    public Builder mergeCommit(
+        com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse value) {
       if (commitBuilder_ == null) {
-        if (requestCase_ == 2 &&
-            request_ != com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.getDefaultInstance()) {
-          request_ = com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.newBuilder((com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) request_)
-              .mergeFrom(value).buildPartial();
+        if (requestCase_ == 2
+            && request_
+                != com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse
+                    .getDefaultInstance()) {
+          request_ =
+              com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.newBuilder(
+                      (com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) request_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           request_ = value;
         }
@@ -879,6 +1002,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Response to committing a new cursor value.
      * </pre>
@@ -902,23 +1027,29 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Response to committing a new cursor value.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorResponse commit = 2;</code>
      */
-    public com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.Builder getCommitBuilder() {
+    public com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.Builder
+        getCommitBuilder() {
       return getCommitFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * Response to committing a new cursor value.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorResponse commit = 2;</code>
      */
-    public com.google.cloud.pubsublite.proto.SequencedCommitCursorResponseOrBuilder getCommitOrBuilder() {
+    public com.google.cloud.pubsublite.proto.SequencedCommitCursorResponseOrBuilder
+        getCommitOrBuilder() {
       if ((requestCase_ == 2) && (commitBuilder_ != null)) {
         return commitBuilder_.getMessageOrBuilder();
       } else {
@@ -929,6 +1060,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Response to committing a new cursor value.
      * </pre>
@@ -936,26 +1069,33 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorResponse commit = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse, com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.Builder, com.google.cloud.pubsublite.proto.SequencedCommitCursorResponseOrBuilder> 
+            com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse,
+            com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.Builder,
+            com.google.cloud.pubsublite.proto.SequencedCommitCursorResponseOrBuilder>
         getCommitFieldBuilder() {
       if (commitBuilder_ == null) {
         if (!(requestCase_ == 2)) {
-          request_ = com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.getDefaultInstance();
+          request_ =
+              com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.getDefaultInstance();
         }
-        commitBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse, com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.Builder, com.google.cloud.pubsublite.proto.SequencedCommitCursorResponseOrBuilder>(
+        commitBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse,
+                com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse.Builder,
+                com.google.cloud.pubsublite.proto.SequencedCommitCursorResponseOrBuilder>(
                 (com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse) request_,
                 getParentForChildren(),
                 isClean());
         request_ = null;
       }
       requestCase_ = 2;
-      onChanged();;
+      onChanged();
+      ;
       return commitBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -965,30 +1105,32 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.StreamingCommitCursorResponse)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.StreamingCommitCursorResponse)
-  private static final com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse DEFAULT_INSTANCE;
+  private static final com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse
+      DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse();
   }
 
-  public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse getDefaultInstance() {
+  public static com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse
+      getDefaultInstance() {
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<StreamingCommitCursorResponse>
-      PARSER = new com.google.protobuf.AbstractParser<StreamingCommitCursorResponse>() {
-    @java.lang.Override
-    public StreamingCommitCursorResponse parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new StreamingCommitCursorResponse(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<StreamingCommitCursorResponse> PARSER =
+      new com.google.protobuf.AbstractParser<StreamingCommitCursorResponse>() {
+        @java.lang.Override
+        public StreamingCommitCursorResponse parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new StreamingCommitCursorResponse(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<StreamingCommitCursorResponse> parser() {
     return PARSER;
@@ -1000,9 +1142,8 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse getDefaultInstanceForType() {
+  public com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse
+      getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/StreamingCommitCursorResponseOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/StreamingCommitCursorResponseOrBuilder.java
@@ -3,29 +3,38 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface StreamingCommitCursorResponseOrBuilder extends
+public interface StreamingCommitCursorResponseOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.StreamingCommitCursorResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialCommitCursorResponse initial = 1;</code>
+   *
    * @return Whether the initial field is set.
    */
   boolean hasInitial();
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialCommitCursorResponse initial = 1;</code>
+   *
    * @return The initial.
    */
   com.google.cloud.pubsublite.proto.InitialCommitCursorResponse getInitial();
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
@@ -35,24 +44,32 @@ public interface StreamingCommitCursorResponseOrBuilder extends
   com.google.cloud.pubsublite.proto.InitialCommitCursorResponseOrBuilder getInitialOrBuilder();
 
   /**
+   *
+   *
    * <pre>
    * Response to committing a new cursor value.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorResponse commit = 2;</code>
+   *
    * @return Whether the commit field is set.
    */
   boolean hasCommit();
   /**
+   *
+   *
    * <pre>
    * Response to committing a new cursor value.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SequencedCommitCursorResponse commit = 2;</code>
+   *
    * @return The commit.
    */
   com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse getCommit();
   /**
+   *
+   *
    * <pre>
    * Response to committing a new cursor value.
    * </pre>
@@ -61,5 +78,6 @@ public interface StreamingCommitCursorResponseOrBuilder extends
    */
   com.google.cloud.pubsublite.proto.SequencedCommitCursorResponseOrBuilder getCommitOrBuilder();
 
-  public com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse.RequestCase getRequestCase();
+  public com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse.RequestCase
+      getRequestCase();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SubscribeRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SubscribeRequest.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * A request sent from the client to the server on a stream.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.SubscribeRequest}
  */
-public  final class SubscribeRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class SubscribeRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.SubscribeRequest)
     SubscribeRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use SubscribeRequest.newBuilder() to construct.
   private SubscribeRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private SubscribeRequest() {
-  }
+
+  private SubscribeRequest() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new SubscribeRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private SubscribeRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,90 +53,108 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            com.google.cloud.pubsublite.proto.InitialSubscribeRequest.Builder subBuilder = null;
-            if (requestCase_ == 1) {
-              subBuilder = ((com.google.cloud.pubsublite.proto.InitialSubscribeRequest) request_).toBuilder();
+          case 10:
+            {
+              com.google.cloud.pubsublite.proto.InitialSubscribeRequest.Builder subBuilder = null;
+              if (requestCase_ == 1) {
+                subBuilder =
+                    ((com.google.cloud.pubsublite.proto.InitialSubscribeRequest) request_)
+                        .toBuilder();
+              }
+              request_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.InitialSubscribeRequest.parser(),
+                      extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(
+                    (com.google.cloud.pubsublite.proto.InitialSubscribeRequest) request_);
+                request_ = subBuilder.buildPartial();
+              }
+              requestCase_ = 1;
+              break;
             }
-            request_ =
-                input.readMessage(com.google.cloud.pubsublite.proto.InitialSubscribeRequest.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.InitialSubscribeRequest) request_);
-              request_ = subBuilder.buildPartial();
+          case 18:
+            {
+              com.google.cloud.pubsublite.proto.SeekRequest.Builder subBuilder = null;
+              if (requestCase_ == 2) {
+                subBuilder = ((com.google.cloud.pubsublite.proto.SeekRequest) request_).toBuilder();
+              }
+              request_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.SeekRequest.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.SeekRequest) request_);
+                request_ = subBuilder.buildPartial();
+              }
+              requestCase_ = 2;
+              break;
             }
-            requestCase_ = 1;
-            break;
-          }
-          case 18: {
-            com.google.cloud.pubsublite.proto.SeekRequest.Builder subBuilder = null;
-            if (requestCase_ == 2) {
-              subBuilder = ((com.google.cloud.pubsublite.proto.SeekRequest) request_).toBuilder();
+          case 26:
+            {
+              com.google.cloud.pubsublite.proto.FlowControlRequest.Builder subBuilder = null;
+              if (requestCase_ == 3) {
+                subBuilder =
+                    ((com.google.cloud.pubsublite.proto.FlowControlRequest) request_).toBuilder();
+              }
+              request_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.FlowControlRequest.parser(),
+                      extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(
+                    (com.google.cloud.pubsublite.proto.FlowControlRequest) request_);
+                request_ = subBuilder.buildPartial();
+              }
+              requestCase_ = 3;
+              break;
             }
-            request_ =
-                input.readMessage(com.google.cloud.pubsublite.proto.SeekRequest.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.SeekRequest) request_);
-              request_ = subBuilder.buildPartial();
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
             }
-            requestCase_ = 2;
-            break;
-          }
-          case 26: {
-            com.google.cloud.pubsublite.proto.FlowControlRequest.Builder subBuilder = null;
-            if (requestCase_ == 3) {
-              subBuilder = ((com.google.cloud.pubsublite.proto.FlowControlRequest) request_).toBuilder();
-            }
-            request_ =
-                input.readMessage(com.google.cloud.pubsublite.proto.FlowControlRequest.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.FlowControlRequest) request_);
-              request_ = subBuilder.buildPartial();
-            }
-            requestCase_ = 3;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SubscribeRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.SubscriberProto
+        .internal_static_google_cloud_pubsublite_v1_SubscribeRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SubscribeRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.SubscriberProto
+        .internal_static_google_cloud_pubsublite_v1_SubscribeRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.SubscribeRequest.class, com.google.cloud.pubsublite.proto.SubscribeRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.SubscribeRequest.class,
+            com.google.cloud.pubsublite.proto.SubscribeRequest.Builder.class);
   }
 
   private int requestCase_ = 0;
   private java.lang.Object request_;
+
   public enum RequestCase
-      implements com.google.protobuf.Internal.EnumLite,
+      implements
+          com.google.protobuf.Internal.EnumLite,
           com.google.protobuf.AbstractMessage.InternalOneOfEnum {
     INITIAL(1),
     SEEK(2),
     FLOW_CONTROL(3),
     REQUEST_NOT_SET(0);
     private final int value;
+
     private RequestCase(int value) {
       this.value = value;
     }
@@ -151,51 +170,63 @@ private static final long serialVersionUID = 0L;
 
     public static RequestCase forNumber(int value) {
       switch (value) {
-        case 1: return INITIAL;
-        case 2: return SEEK;
-        case 3: return FLOW_CONTROL;
-        case 0: return REQUEST_NOT_SET;
-        default: return null;
+        case 1:
+          return INITIAL;
+        case 2:
+          return SEEK;
+        case 3:
+          return FLOW_CONTROL;
+        case 0:
+          return REQUEST_NOT_SET;
+        default:
+          return null;
       }
     }
+
     public int getNumber() {
       return this.value;
     }
   };
 
-  public RequestCase
-  getRequestCase() {
-    return RequestCase.forNumber(
-        requestCase_);
+  public RequestCase getRequestCase() {
+    return RequestCase.forNumber(requestCase_);
   }
 
   public static final int INITIAL_FIELD_NUMBER = 1;
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialSubscribeRequest initial = 1;</code>
+   *
    * @return Whether the initial field is set.
    */
   public boolean hasInitial() {
     return requestCase_ == 1;
   }
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialSubscribeRequest initial = 1;</code>
+   *
    * @return The initial.
    */
   public com.google.cloud.pubsublite.proto.InitialSubscribeRequest getInitial() {
     if (requestCase_ == 1) {
-       return (com.google.cloud.pubsublite.proto.InitialSubscribeRequest) request_;
+      return (com.google.cloud.pubsublite.proto.InitialSubscribeRequest) request_;
     }
     return com.google.cloud.pubsublite.proto.InitialSubscribeRequest.getDefaultInstance();
   }
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
@@ -204,38 +235,46 @@ private static final long serialVersionUID = 0L;
    */
   public com.google.cloud.pubsublite.proto.InitialSubscribeRequestOrBuilder getInitialOrBuilder() {
     if (requestCase_ == 1) {
-       return (com.google.cloud.pubsublite.proto.InitialSubscribeRequest) request_;
+      return (com.google.cloud.pubsublite.proto.InitialSubscribeRequest) request_;
     }
     return com.google.cloud.pubsublite.proto.InitialSubscribeRequest.getDefaultInstance();
   }
 
   public static final int SEEK_FIELD_NUMBER = 2;
   /**
+   *
+   *
    * <pre>
    * Request to update the stream's delivery cursor.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SeekRequest seek = 2;</code>
+   *
    * @return Whether the seek field is set.
    */
   public boolean hasSeek() {
     return requestCase_ == 2;
   }
   /**
+   *
+   *
    * <pre>
    * Request to update the stream's delivery cursor.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SeekRequest seek = 2;</code>
+   *
    * @return The seek.
    */
   public com.google.cloud.pubsublite.proto.SeekRequest getSeek() {
     if (requestCase_ == 2) {
-       return (com.google.cloud.pubsublite.proto.SeekRequest) request_;
+      return (com.google.cloud.pubsublite.proto.SeekRequest) request_;
     }
     return com.google.cloud.pubsublite.proto.SeekRequest.getDefaultInstance();
   }
   /**
+   *
+   *
    * <pre>
    * Request to update the stream's delivery cursor.
    * </pre>
@@ -244,38 +283,46 @@ private static final long serialVersionUID = 0L;
    */
   public com.google.cloud.pubsublite.proto.SeekRequestOrBuilder getSeekOrBuilder() {
     if (requestCase_ == 2) {
-       return (com.google.cloud.pubsublite.proto.SeekRequest) request_;
+      return (com.google.cloud.pubsublite.proto.SeekRequest) request_;
     }
     return com.google.cloud.pubsublite.proto.SeekRequest.getDefaultInstance();
   }
 
   public static final int FLOW_CONTROL_FIELD_NUMBER = 3;
   /**
+   *
+   *
    * <pre>
    * Request to grant tokens to the server,
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.FlowControlRequest flow_control = 3;</code>
+   *
    * @return Whether the flowControl field is set.
    */
   public boolean hasFlowControl() {
     return requestCase_ == 3;
   }
   /**
+   *
+   *
    * <pre>
    * Request to grant tokens to the server,
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.FlowControlRequest flow_control = 3;</code>
+   *
    * @return The flowControl.
    */
   public com.google.cloud.pubsublite.proto.FlowControlRequest getFlowControl() {
     if (requestCase_ == 3) {
-       return (com.google.cloud.pubsublite.proto.FlowControlRequest) request_;
+      return (com.google.cloud.pubsublite.proto.FlowControlRequest) request_;
     }
     return com.google.cloud.pubsublite.proto.FlowControlRequest.getDefaultInstance();
   }
   /**
+   *
+   *
    * <pre>
    * Request to grant tokens to the server,
    * </pre>
@@ -284,12 +331,13 @@ private static final long serialVersionUID = 0L;
    */
   public com.google.cloud.pubsublite.proto.FlowControlRequestOrBuilder getFlowControlOrBuilder() {
     if (requestCase_ == 3) {
-       return (com.google.cloud.pubsublite.proto.FlowControlRequest) request_;
+      return (com.google.cloud.pubsublite.proto.FlowControlRequest) request_;
     }
     return com.google.cloud.pubsublite.proto.FlowControlRequest.getDefaultInstance();
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -301,8 +349,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (requestCase_ == 1) {
       output.writeMessage(1, (com.google.cloud.pubsublite.proto.InitialSubscribeRequest) request_);
     }
@@ -322,16 +369,19 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (requestCase_ == 1) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, (com.google.cloud.pubsublite.proto.InitialSubscribeRequest) request_);
+      size +=
+          com.google.protobuf.CodedOutputStream.computeMessageSize(
+              1, (com.google.cloud.pubsublite.proto.InitialSubscribeRequest) request_);
     }
     if (requestCase_ == 2) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, (com.google.cloud.pubsublite.proto.SeekRequest) request_);
+      size +=
+          com.google.protobuf.CodedOutputStream.computeMessageSize(
+              2, (com.google.cloud.pubsublite.proto.SeekRequest) request_);
     }
     if (requestCase_ == 3) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(3, (com.google.cloud.pubsublite.proto.FlowControlRequest) request_);
+      size +=
+          com.google.protobuf.CodedOutputStream.computeMessageSize(
+              3, (com.google.cloud.pubsublite.proto.FlowControlRequest) request_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -341,26 +391,24 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.SubscribeRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.SubscribeRequest other = (com.google.cloud.pubsublite.proto.SubscribeRequest) obj;
+    com.google.cloud.pubsublite.proto.SubscribeRequest other =
+        (com.google.cloud.pubsublite.proto.SubscribeRequest) obj;
 
     if (!getRequestCase().equals(other.getRequestCase())) return false;
     switch (requestCase_) {
       case 1:
-        if (!getInitial()
-            .equals(other.getInitial())) return false;
+        if (!getInitial().equals(other.getInitial())) return false;
         break;
       case 2:
-        if (!getSeek()
-            .equals(other.getSeek())) return false;
+        if (!getSeek().equals(other.getSeek())) return false;
         break;
       case 3:
-        if (!getFlowControl()
-            .equals(other.getFlowControl())) return false;
+        if (!getFlowControl().equals(other.getFlowControl())) return false;
         break;
       case 0:
       default:
@@ -398,117 +446,126 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.SubscribeRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SubscribeRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SubscribeRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SubscribeRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SubscribeRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SubscribeRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.SubscribeRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.SubscribeRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.SubscribeRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.SubscribeRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SubscribeRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.SubscribeRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.SubscribeRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.SubscribeRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.SubscribeRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * A request sent from the client to the server on a stream.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.SubscribeRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.SubscribeRequest)
       com.google.cloud.pubsublite.proto.SubscribeRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SubscribeRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_SubscribeRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SubscribeRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_SubscribeRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.SubscribeRequest.class, com.google.cloud.pubsublite.proto.SubscribeRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.SubscribeRequest.class,
+              com.google.cloud.pubsublite.proto.SubscribeRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.SubscribeRequest.newBuilder()
@@ -516,16 +573,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -535,9 +591,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SubscribeRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_SubscribeRequest_descriptor;
     }
 
     @java.lang.Override
@@ -556,7 +612,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.SubscribeRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.SubscribeRequest result = new com.google.cloud.pubsublite.proto.SubscribeRequest(this);
+      com.google.cloud.pubsublite.proto.SubscribeRequest result =
+          new com.google.cloud.pubsublite.proto.SubscribeRequest(this);
       if (requestCase_ == 1) {
         if (initialBuilder_ == null) {
           result.request_ = request_;
@@ -587,38 +644,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.SubscribeRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.SubscribeRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.SubscribeRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -626,23 +684,28 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.SubscribeRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.SubscribeRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.SubscribeRequest.getDefaultInstance())
+        return this;
       switch (other.getRequestCase()) {
-        case INITIAL: {
-          mergeInitial(other.getInitial());
-          break;
-        }
-        case SEEK: {
-          mergeSeek(other.getSeek());
-          break;
-        }
-        case FLOW_CONTROL: {
-          mergeFlowControl(other.getFlowControl());
-          break;
-        }
-        case REQUEST_NOT_SET: {
-          break;
-        }
+        case INITIAL:
+          {
+            mergeInitial(other.getInitial());
+            break;
+          }
+        case SEEK:
+          {
+            mergeSeek(other.getSeek());
+            break;
+          }
+        case FLOW_CONTROL:
+          {
+            mergeFlowControl(other.getFlowControl());
+            break;
+          }
+        case REQUEST_NOT_SET:
+          {
+            break;
+          }
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -663,7 +726,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.SubscribeRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.SubscribeRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -672,12 +736,12 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     private int requestCase_ = 0;
     private java.lang.Object request_;
-    public RequestCase
-        getRequestCase() {
-      return RequestCase.forNumber(
-          requestCase_);
+
+    public RequestCase getRequestCase() {
+      return RequestCase.forNumber(requestCase_);
     }
 
     public Builder clearRequest() {
@@ -687,26 +751,34 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.InitialSubscribeRequest, com.google.cloud.pubsublite.proto.InitialSubscribeRequest.Builder, com.google.cloud.pubsublite.proto.InitialSubscribeRequestOrBuilder> initialBuilder_;
+            com.google.cloud.pubsublite.proto.InitialSubscribeRequest,
+            com.google.cloud.pubsublite.proto.InitialSubscribeRequest.Builder,
+            com.google.cloud.pubsublite.proto.InitialSubscribeRequestOrBuilder>
+        initialBuilder_;
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialSubscribeRequest initial = 1;</code>
+     *
      * @return Whether the initial field is set.
      */
     public boolean hasInitial() {
       return requestCase_ == 1;
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialSubscribeRequest initial = 1;</code>
+     *
      * @return The initial.
      */
     public com.google.cloud.pubsublite.proto.InitialSubscribeRequest getInitial() {
@@ -723,6 +795,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
@@ -743,6 +817,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
@@ -761,6 +837,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
@@ -769,10 +847,14 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeInitial(com.google.cloud.pubsublite.proto.InitialSubscribeRequest value) {
       if (initialBuilder_ == null) {
-        if (requestCase_ == 1 &&
-            request_ != com.google.cloud.pubsublite.proto.InitialSubscribeRequest.getDefaultInstance()) {
-          request_ = com.google.cloud.pubsublite.proto.InitialSubscribeRequest.newBuilder((com.google.cloud.pubsublite.proto.InitialSubscribeRequest) request_)
-              .mergeFrom(value).buildPartial();
+        if (requestCase_ == 1
+            && request_
+                != com.google.cloud.pubsublite.proto.InitialSubscribeRequest.getDefaultInstance()) {
+          request_ =
+              com.google.cloud.pubsublite.proto.InitialSubscribeRequest.newBuilder(
+                      (com.google.cloud.pubsublite.proto.InitialSubscribeRequest) request_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           request_ = value;
         }
@@ -787,6 +869,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
@@ -810,6 +894,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
@@ -820,13 +906,16 @@ private static final long serialVersionUID = 0L;
       return getInitialFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialSubscribeRequest initial = 1;</code>
      */
-    public com.google.cloud.pubsublite.proto.InitialSubscribeRequestOrBuilder getInitialOrBuilder() {
+    public com.google.cloud.pubsublite.proto.InitialSubscribeRequestOrBuilder
+        getInitialOrBuilder() {
       if ((requestCase_ == 1) && (initialBuilder_ != null)) {
         return initialBuilder_.getMessageOrBuilder();
       } else {
@@ -837,6 +926,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Initial request on the stream.
      * </pre>
@@ -844,43 +935,58 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.InitialSubscribeRequest initial = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.InitialSubscribeRequest, com.google.cloud.pubsublite.proto.InitialSubscribeRequest.Builder, com.google.cloud.pubsublite.proto.InitialSubscribeRequestOrBuilder> 
+            com.google.cloud.pubsublite.proto.InitialSubscribeRequest,
+            com.google.cloud.pubsublite.proto.InitialSubscribeRequest.Builder,
+            com.google.cloud.pubsublite.proto.InitialSubscribeRequestOrBuilder>
         getInitialFieldBuilder() {
       if (initialBuilder_ == null) {
         if (!(requestCase_ == 1)) {
           request_ = com.google.cloud.pubsublite.proto.InitialSubscribeRequest.getDefaultInstance();
         }
-        initialBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.InitialSubscribeRequest, com.google.cloud.pubsublite.proto.InitialSubscribeRequest.Builder, com.google.cloud.pubsublite.proto.InitialSubscribeRequestOrBuilder>(
+        initialBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.InitialSubscribeRequest,
+                com.google.cloud.pubsublite.proto.InitialSubscribeRequest.Builder,
+                com.google.cloud.pubsublite.proto.InitialSubscribeRequestOrBuilder>(
                 (com.google.cloud.pubsublite.proto.InitialSubscribeRequest) request_,
                 getParentForChildren(),
                 isClean());
         request_ = null;
       }
       requestCase_ = 1;
-      onChanged();;
+      onChanged();
+      ;
       return initialBuilder_;
     }
 
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.SeekRequest, com.google.cloud.pubsublite.proto.SeekRequest.Builder, com.google.cloud.pubsublite.proto.SeekRequestOrBuilder> seekBuilder_;
+            com.google.cloud.pubsublite.proto.SeekRequest,
+            com.google.cloud.pubsublite.proto.SeekRequest.Builder,
+            com.google.cloud.pubsublite.proto.SeekRequestOrBuilder>
+        seekBuilder_;
     /**
+     *
+     *
      * <pre>
      * Request to update the stream's delivery cursor.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SeekRequest seek = 2;</code>
+     *
      * @return Whether the seek field is set.
      */
     public boolean hasSeek() {
       return requestCase_ == 2;
     }
     /**
+     *
+     *
      * <pre>
      * Request to update the stream's delivery cursor.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SeekRequest seek = 2;</code>
+     *
      * @return The seek.
      */
     public com.google.cloud.pubsublite.proto.SeekRequest getSeek() {
@@ -897,6 +1003,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Request to update the stream's delivery cursor.
      * </pre>
@@ -917,14 +1025,15 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Request to update the stream's delivery cursor.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SeekRequest seek = 2;</code>
      */
-    public Builder setSeek(
-        com.google.cloud.pubsublite.proto.SeekRequest.Builder builderForValue) {
+    public Builder setSeek(com.google.cloud.pubsublite.proto.SeekRequest.Builder builderForValue) {
       if (seekBuilder_ == null) {
         request_ = builderForValue.build();
         onChanged();
@@ -935,6 +1044,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Request to update the stream's delivery cursor.
      * </pre>
@@ -943,10 +1054,13 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeSeek(com.google.cloud.pubsublite.proto.SeekRequest value) {
       if (seekBuilder_ == null) {
-        if (requestCase_ == 2 &&
-            request_ != com.google.cloud.pubsublite.proto.SeekRequest.getDefaultInstance()) {
-          request_ = com.google.cloud.pubsublite.proto.SeekRequest.newBuilder((com.google.cloud.pubsublite.proto.SeekRequest) request_)
-              .mergeFrom(value).buildPartial();
+        if (requestCase_ == 2
+            && request_ != com.google.cloud.pubsublite.proto.SeekRequest.getDefaultInstance()) {
+          request_ =
+              com.google.cloud.pubsublite.proto.SeekRequest.newBuilder(
+                      (com.google.cloud.pubsublite.proto.SeekRequest) request_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           request_ = value;
         }
@@ -961,6 +1075,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Request to update the stream's delivery cursor.
      * </pre>
@@ -984,6 +1100,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Request to update the stream's delivery cursor.
      * </pre>
@@ -994,6 +1112,8 @@ private static final long serialVersionUID = 0L;
       return getSeekFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * Request to update the stream's delivery cursor.
      * </pre>
@@ -1011,6 +1131,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Request to update the stream's delivery cursor.
      * </pre>
@@ -1018,43 +1140,58 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.SeekRequest seek = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.SeekRequest, com.google.cloud.pubsublite.proto.SeekRequest.Builder, com.google.cloud.pubsublite.proto.SeekRequestOrBuilder> 
+            com.google.cloud.pubsublite.proto.SeekRequest,
+            com.google.cloud.pubsublite.proto.SeekRequest.Builder,
+            com.google.cloud.pubsublite.proto.SeekRequestOrBuilder>
         getSeekFieldBuilder() {
       if (seekBuilder_ == null) {
         if (!(requestCase_ == 2)) {
           request_ = com.google.cloud.pubsublite.proto.SeekRequest.getDefaultInstance();
         }
-        seekBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.SeekRequest, com.google.cloud.pubsublite.proto.SeekRequest.Builder, com.google.cloud.pubsublite.proto.SeekRequestOrBuilder>(
+        seekBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.SeekRequest,
+                com.google.cloud.pubsublite.proto.SeekRequest.Builder,
+                com.google.cloud.pubsublite.proto.SeekRequestOrBuilder>(
                 (com.google.cloud.pubsublite.proto.SeekRequest) request_,
                 getParentForChildren(),
                 isClean());
         request_ = null;
       }
       requestCase_ = 2;
-      onChanged();;
+      onChanged();
+      ;
       return seekBuilder_;
     }
 
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.FlowControlRequest, com.google.cloud.pubsublite.proto.FlowControlRequest.Builder, com.google.cloud.pubsublite.proto.FlowControlRequestOrBuilder> flowControlBuilder_;
+            com.google.cloud.pubsublite.proto.FlowControlRequest,
+            com.google.cloud.pubsublite.proto.FlowControlRequest.Builder,
+            com.google.cloud.pubsublite.proto.FlowControlRequestOrBuilder>
+        flowControlBuilder_;
     /**
+     *
+     *
      * <pre>
      * Request to grant tokens to the server,
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.FlowControlRequest flow_control = 3;</code>
+     *
      * @return Whether the flowControl field is set.
      */
     public boolean hasFlowControl() {
       return requestCase_ == 3;
     }
     /**
+     *
+     *
      * <pre>
      * Request to grant tokens to the server,
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.FlowControlRequest flow_control = 3;</code>
+     *
      * @return The flowControl.
      */
     public com.google.cloud.pubsublite.proto.FlowControlRequest getFlowControl() {
@@ -1071,6 +1208,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Request to grant tokens to the server,
      * </pre>
@@ -1091,6 +1230,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Request to grant tokens to the server,
      * </pre>
@@ -1109,6 +1250,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Request to grant tokens to the server,
      * </pre>
@@ -1117,10 +1260,14 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeFlowControl(com.google.cloud.pubsublite.proto.FlowControlRequest value) {
       if (flowControlBuilder_ == null) {
-        if (requestCase_ == 3 &&
-            request_ != com.google.cloud.pubsublite.proto.FlowControlRequest.getDefaultInstance()) {
-          request_ = com.google.cloud.pubsublite.proto.FlowControlRequest.newBuilder((com.google.cloud.pubsublite.proto.FlowControlRequest) request_)
-              .mergeFrom(value).buildPartial();
+        if (requestCase_ == 3
+            && request_
+                != com.google.cloud.pubsublite.proto.FlowControlRequest.getDefaultInstance()) {
+          request_ =
+              com.google.cloud.pubsublite.proto.FlowControlRequest.newBuilder(
+                      (com.google.cloud.pubsublite.proto.FlowControlRequest) request_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           request_ = value;
         }
@@ -1135,6 +1282,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Request to grant tokens to the server,
      * </pre>
@@ -1158,6 +1307,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Request to grant tokens to the server,
      * </pre>
@@ -1168,6 +1319,8 @@ private static final long serialVersionUID = 0L;
       return getFlowControlFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * Request to grant tokens to the server,
      * </pre>
@@ -1185,6 +1338,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Request to grant tokens to the server,
      * </pre>
@@ -1192,26 +1347,32 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.FlowControlRequest flow_control = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.FlowControlRequest, com.google.cloud.pubsublite.proto.FlowControlRequest.Builder, com.google.cloud.pubsublite.proto.FlowControlRequestOrBuilder> 
+            com.google.cloud.pubsublite.proto.FlowControlRequest,
+            com.google.cloud.pubsublite.proto.FlowControlRequest.Builder,
+            com.google.cloud.pubsublite.proto.FlowControlRequestOrBuilder>
         getFlowControlFieldBuilder() {
       if (flowControlBuilder_ == null) {
         if (!(requestCase_ == 3)) {
           request_ = com.google.cloud.pubsublite.proto.FlowControlRequest.getDefaultInstance();
         }
-        flowControlBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.FlowControlRequest, com.google.cloud.pubsublite.proto.FlowControlRequest.Builder, com.google.cloud.pubsublite.proto.FlowControlRequestOrBuilder>(
+        flowControlBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.FlowControlRequest,
+                com.google.cloud.pubsublite.proto.FlowControlRequest.Builder,
+                com.google.cloud.pubsublite.proto.FlowControlRequestOrBuilder>(
                 (com.google.cloud.pubsublite.proto.FlowControlRequest) request_,
                 getParentForChildren(),
                 isClean());
         request_ = null;
       }
       requestCase_ = 3;
-      onChanged();;
+      onChanged();
+      ;
       return flowControlBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -1221,12 +1382,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.SubscribeRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.SubscribeRequest)
   private static final com.google.cloud.pubsublite.proto.SubscribeRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.SubscribeRequest();
   }
@@ -1235,16 +1396,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<SubscribeRequest>
-      PARSER = new com.google.protobuf.AbstractParser<SubscribeRequest>() {
-    @java.lang.Override
-    public SubscribeRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new SubscribeRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<SubscribeRequest> PARSER =
+      new com.google.protobuf.AbstractParser<SubscribeRequest>() {
+        @java.lang.Override
+        public SubscribeRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new SubscribeRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<SubscribeRequest> parser() {
     return PARSER;
@@ -1259,6 +1420,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.SubscribeRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SubscribeRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SubscribeRequestOrBuilder.java
@@ -3,29 +3,38 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface SubscribeRequestOrBuilder extends
+public interface SubscribeRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.SubscribeRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialSubscribeRequest initial = 1;</code>
+   *
    * @return Whether the initial field is set.
    */
   boolean hasInitial();
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialSubscribeRequest initial = 1;</code>
+   *
    * @return The initial.
    */
   com.google.cloud.pubsublite.proto.InitialSubscribeRequest getInitial();
   /**
+   *
+   *
    * <pre>
    * Initial request on the stream.
    * </pre>
@@ -35,24 +44,32 @@ public interface SubscribeRequestOrBuilder extends
   com.google.cloud.pubsublite.proto.InitialSubscribeRequestOrBuilder getInitialOrBuilder();
 
   /**
+   *
+   *
    * <pre>
    * Request to update the stream's delivery cursor.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SeekRequest seek = 2;</code>
+   *
    * @return Whether the seek field is set.
    */
   boolean hasSeek();
   /**
+   *
+   *
    * <pre>
    * Request to update the stream's delivery cursor.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SeekRequest seek = 2;</code>
+   *
    * @return The seek.
    */
   com.google.cloud.pubsublite.proto.SeekRequest getSeek();
   /**
+   *
+   *
    * <pre>
    * Request to update the stream's delivery cursor.
    * </pre>
@@ -62,24 +79,32 @@ public interface SubscribeRequestOrBuilder extends
   com.google.cloud.pubsublite.proto.SeekRequestOrBuilder getSeekOrBuilder();
 
   /**
+   *
+   *
    * <pre>
    * Request to grant tokens to the server,
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.FlowControlRequest flow_control = 3;</code>
+   *
    * @return Whether the flowControl field is set.
    */
   boolean hasFlowControl();
   /**
+   *
+   *
    * <pre>
    * Request to grant tokens to the server,
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.FlowControlRequest flow_control = 3;</code>
+   *
    * @return The flowControl.
    */
   com.google.cloud.pubsublite.proto.FlowControlRequest getFlowControl();
   /**
+   *
+   *
    * <pre>
    * Request to grant tokens to the server,
    * </pre>

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SubscribeResponse.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SubscribeResponse.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Response to SubscribeRequest.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.SubscribeResponse}
  */
-public  final class SubscribeResponse extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class SubscribeResponse extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.SubscribeResponse)
     SubscribeResponseOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use SubscribeResponse.newBuilder() to construct.
   private SubscribeResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private SubscribeResponse() {
-  }
+
+  private SubscribeResponse() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new SubscribeResponse();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private SubscribeResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,90 +53,108 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            com.google.cloud.pubsublite.proto.InitialSubscribeResponse.Builder subBuilder = null;
-            if (responseCase_ == 1) {
-              subBuilder = ((com.google.cloud.pubsublite.proto.InitialSubscribeResponse) response_).toBuilder();
+          case 10:
+            {
+              com.google.cloud.pubsublite.proto.InitialSubscribeResponse.Builder subBuilder = null;
+              if (responseCase_ == 1) {
+                subBuilder =
+                    ((com.google.cloud.pubsublite.proto.InitialSubscribeResponse) response_)
+                        .toBuilder();
+              }
+              response_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.InitialSubscribeResponse.parser(),
+                      extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(
+                    (com.google.cloud.pubsublite.proto.InitialSubscribeResponse) response_);
+                response_ = subBuilder.buildPartial();
+              }
+              responseCase_ = 1;
+              break;
             }
-            response_ =
-                input.readMessage(com.google.cloud.pubsublite.proto.InitialSubscribeResponse.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.InitialSubscribeResponse) response_);
-              response_ = subBuilder.buildPartial();
+          case 18:
+            {
+              com.google.cloud.pubsublite.proto.SeekResponse.Builder subBuilder = null;
+              if (responseCase_ == 2) {
+                subBuilder =
+                    ((com.google.cloud.pubsublite.proto.SeekResponse) response_).toBuilder();
+              }
+              response_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.SeekResponse.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.SeekResponse) response_);
+                response_ = subBuilder.buildPartial();
+              }
+              responseCase_ = 2;
+              break;
             }
-            responseCase_ = 1;
-            break;
-          }
-          case 18: {
-            com.google.cloud.pubsublite.proto.SeekResponse.Builder subBuilder = null;
-            if (responseCase_ == 2) {
-              subBuilder = ((com.google.cloud.pubsublite.proto.SeekResponse) response_).toBuilder();
+          case 26:
+            {
+              com.google.cloud.pubsublite.proto.MessageResponse.Builder subBuilder = null;
+              if (responseCase_ == 3) {
+                subBuilder =
+                    ((com.google.cloud.pubsublite.proto.MessageResponse) response_).toBuilder();
+              }
+              response_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.MessageResponse.parser(),
+                      extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.MessageResponse) response_);
+                response_ = subBuilder.buildPartial();
+              }
+              responseCase_ = 3;
+              break;
             }
-            response_ =
-                input.readMessage(com.google.cloud.pubsublite.proto.SeekResponse.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.SeekResponse) response_);
-              response_ = subBuilder.buildPartial();
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
             }
-            responseCase_ = 2;
-            break;
-          }
-          case 26: {
-            com.google.cloud.pubsublite.proto.MessageResponse.Builder subBuilder = null;
-            if (responseCase_ == 3) {
-              subBuilder = ((com.google.cloud.pubsublite.proto.MessageResponse) response_).toBuilder();
-            }
-            response_ =
-                input.readMessage(com.google.cloud.pubsublite.proto.MessageResponse.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom((com.google.cloud.pubsublite.proto.MessageResponse) response_);
-              response_ = subBuilder.buildPartial();
-            }
-            responseCase_ = 3;
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SubscribeResponse_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.SubscriberProto
+        .internal_static_google_cloud_pubsublite_v1_SubscribeResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SubscribeResponse_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.SubscriberProto
+        .internal_static_google_cloud_pubsublite_v1_SubscribeResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.SubscribeResponse.class, com.google.cloud.pubsublite.proto.SubscribeResponse.Builder.class);
+            com.google.cloud.pubsublite.proto.SubscribeResponse.class,
+            com.google.cloud.pubsublite.proto.SubscribeResponse.Builder.class);
   }
 
   private int responseCase_ = 0;
   private java.lang.Object response_;
+
   public enum ResponseCase
-      implements com.google.protobuf.Internal.EnumLite,
+      implements
+          com.google.protobuf.Internal.EnumLite,
           com.google.protobuf.AbstractMessage.InternalOneOfEnum {
     INITIAL(1),
     SEEK(2),
     MESSAGES(3),
     RESPONSE_NOT_SET(0);
     private final int value;
+
     private ResponseCase(int value) {
       this.value = value;
     }
@@ -151,51 +170,63 @@ private static final long serialVersionUID = 0L;
 
     public static ResponseCase forNumber(int value) {
       switch (value) {
-        case 1: return INITIAL;
-        case 2: return SEEK;
-        case 3: return MESSAGES;
-        case 0: return RESPONSE_NOT_SET;
-        default: return null;
+        case 1:
+          return INITIAL;
+        case 2:
+          return SEEK;
+        case 3:
+          return MESSAGES;
+        case 0:
+          return RESPONSE_NOT_SET;
+        default:
+          return null;
       }
     }
+
     public int getNumber() {
       return this.value;
     }
   };
 
-  public ResponseCase
-  getResponseCase() {
-    return ResponseCase.forNumber(
-        responseCase_);
+  public ResponseCase getResponseCase() {
+    return ResponseCase.forNumber(responseCase_);
   }
 
   public static final int INITIAL_FIELD_NUMBER = 1;
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialSubscribeResponse initial = 1;</code>
+   *
    * @return Whether the initial field is set.
    */
   public boolean hasInitial() {
     return responseCase_ == 1;
   }
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialSubscribeResponse initial = 1;</code>
+   *
    * @return The initial.
    */
   public com.google.cloud.pubsublite.proto.InitialSubscribeResponse getInitial() {
     if (responseCase_ == 1) {
-       return (com.google.cloud.pubsublite.proto.InitialSubscribeResponse) response_;
+      return (com.google.cloud.pubsublite.proto.InitialSubscribeResponse) response_;
     }
     return com.google.cloud.pubsublite.proto.InitialSubscribeResponse.getDefaultInstance();
   }
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
@@ -204,38 +235,46 @@ private static final long serialVersionUID = 0L;
    */
   public com.google.cloud.pubsublite.proto.InitialSubscribeResponseOrBuilder getInitialOrBuilder() {
     if (responseCase_ == 1) {
-       return (com.google.cloud.pubsublite.proto.InitialSubscribeResponse) response_;
+      return (com.google.cloud.pubsublite.proto.InitialSubscribeResponse) response_;
     }
     return com.google.cloud.pubsublite.proto.InitialSubscribeResponse.getDefaultInstance();
   }
 
   public static final int SEEK_FIELD_NUMBER = 2;
   /**
+   *
+   *
    * <pre>
    * Response to a Seek operation.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SeekResponse seek = 2;</code>
+   *
    * @return Whether the seek field is set.
    */
   public boolean hasSeek() {
     return responseCase_ == 2;
   }
   /**
+   *
+   *
    * <pre>
    * Response to a Seek operation.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SeekResponse seek = 2;</code>
+   *
    * @return The seek.
    */
   public com.google.cloud.pubsublite.proto.SeekResponse getSeek() {
     if (responseCase_ == 2) {
-       return (com.google.cloud.pubsublite.proto.SeekResponse) response_;
+      return (com.google.cloud.pubsublite.proto.SeekResponse) response_;
     }
     return com.google.cloud.pubsublite.proto.SeekResponse.getDefaultInstance();
   }
   /**
+   *
+   *
    * <pre>
    * Response to a Seek operation.
    * </pre>
@@ -244,38 +283,46 @@ private static final long serialVersionUID = 0L;
    */
   public com.google.cloud.pubsublite.proto.SeekResponseOrBuilder getSeekOrBuilder() {
     if (responseCase_ == 2) {
-       return (com.google.cloud.pubsublite.proto.SeekResponse) response_;
+      return (com.google.cloud.pubsublite.proto.SeekResponse) response_;
     }
     return com.google.cloud.pubsublite.proto.SeekResponse.getDefaultInstance();
   }
 
   public static final int MESSAGES_FIELD_NUMBER = 3;
   /**
+   *
+   *
    * <pre>
    * Response containing messages from the topic partition.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.MessageResponse messages = 3;</code>
+   *
    * @return Whether the messages field is set.
    */
   public boolean hasMessages() {
     return responseCase_ == 3;
   }
   /**
+   *
+   *
    * <pre>
    * Response containing messages from the topic partition.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.MessageResponse messages = 3;</code>
+   *
    * @return The messages.
    */
   public com.google.cloud.pubsublite.proto.MessageResponse getMessages() {
     if (responseCase_ == 3) {
-       return (com.google.cloud.pubsublite.proto.MessageResponse) response_;
+      return (com.google.cloud.pubsublite.proto.MessageResponse) response_;
     }
     return com.google.cloud.pubsublite.proto.MessageResponse.getDefaultInstance();
   }
   /**
+   *
+   *
    * <pre>
    * Response containing messages from the topic partition.
    * </pre>
@@ -284,12 +331,13 @@ private static final long serialVersionUID = 0L;
    */
   public com.google.cloud.pubsublite.proto.MessageResponseOrBuilder getMessagesOrBuilder() {
     if (responseCase_ == 3) {
-       return (com.google.cloud.pubsublite.proto.MessageResponse) response_;
+      return (com.google.cloud.pubsublite.proto.MessageResponse) response_;
     }
     return com.google.cloud.pubsublite.proto.MessageResponse.getDefaultInstance();
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -301,10 +349,10 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (responseCase_ == 1) {
-      output.writeMessage(1, (com.google.cloud.pubsublite.proto.InitialSubscribeResponse) response_);
+      output.writeMessage(
+          1, (com.google.cloud.pubsublite.proto.InitialSubscribeResponse) response_);
     }
     if (responseCase_ == 2) {
       output.writeMessage(2, (com.google.cloud.pubsublite.proto.SeekResponse) response_);
@@ -322,16 +370,19 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (responseCase_ == 1) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, (com.google.cloud.pubsublite.proto.InitialSubscribeResponse) response_);
+      size +=
+          com.google.protobuf.CodedOutputStream.computeMessageSize(
+              1, (com.google.cloud.pubsublite.proto.InitialSubscribeResponse) response_);
     }
     if (responseCase_ == 2) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, (com.google.cloud.pubsublite.proto.SeekResponse) response_);
+      size +=
+          com.google.protobuf.CodedOutputStream.computeMessageSize(
+              2, (com.google.cloud.pubsublite.proto.SeekResponse) response_);
     }
     if (responseCase_ == 3) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(3, (com.google.cloud.pubsublite.proto.MessageResponse) response_);
+      size +=
+          com.google.protobuf.CodedOutputStream.computeMessageSize(
+              3, (com.google.cloud.pubsublite.proto.MessageResponse) response_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -341,26 +392,24 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.SubscribeResponse)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.SubscribeResponse other = (com.google.cloud.pubsublite.proto.SubscribeResponse) obj;
+    com.google.cloud.pubsublite.proto.SubscribeResponse other =
+        (com.google.cloud.pubsublite.proto.SubscribeResponse) obj;
 
     if (!getResponseCase().equals(other.getResponseCase())) return false;
     switch (responseCase_) {
       case 1:
-        if (!getInitial()
-            .equals(other.getInitial())) return false;
+        if (!getInitial().equals(other.getInitial())) return false;
         break;
       case 2:
-        if (!getSeek()
-            .equals(other.getSeek())) return false;
+        if (!getSeek().equals(other.getSeek())) return false;
         break;
       case 3:
-        if (!getMessages()
-            .equals(other.getMessages())) return false;
+        if (!getMessages().equals(other.getMessages())) return false;
         break;
       case 0:
       default:
@@ -398,117 +447,126 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.SubscribeResponse parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SubscribeResponse parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SubscribeResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SubscribeResponse parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SubscribeResponse parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.SubscribeResponse parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.SubscribeResponse parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.SubscribeResponse parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.SubscribeResponse parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.SubscribeResponse parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.SubscribeResponse parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.SubscribeResponse parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.SubscribeResponse parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.SubscribeResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.SubscribeResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Response to SubscribeRequest.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.SubscribeResponse}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.SubscribeResponse)
       com.google.cloud.pubsublite.proto.SubscribeResponseOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SubscribeResponse_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_SubscribeResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SubscribeResponse_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_SubscribeResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.SubscribeResponse.class, com.google.cloud.pubsublite.proto.SubscribeResponse.Builder.class);
+              com.google.cloud.pubsublite.proto.SubscribeResponse.class,
+              com.google.cloud.pubsublite.proto.SubscribeResponse.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.SubscribeResponse.newBuilder()
@@ -516,16 +574,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -535,9 +592,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.SubscriberProto.internal_static_google_cloud_pubsublite_v1_SubscribeResponse_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.SubscriberProto
+          .internal_static_google_cloud_pubsublite_v1_SubscribeResponse_descriptor;
     }
 
     @java.lang.Override
@@ -556,7 +613,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.SubscribeResponse buildPartial() {
-      com.google.cloud.pubsublite.proto.SubscribeResponse result = new com.google.cloud.pubsublite.proto.SubscribeResponse(this);
+      com.google.cloud.pubsublite.proto.SubscribeResponse result =
+          new com.google.cloud.pubsublite.proto.SubscribeResponse(this);
       if (responseCase_ == 1) {
         if (initialBuilder_ == null) {
           result.response_ = response_;
@@ -587,38 +645,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.SubscribeResponse) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.SubscribeResponse)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.SubscribeResponse) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -626,23 +685,28 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.SubscribeResponse other) {
-      if (other == com.google.cloud.pubsublite.proto.SubscribeResponse.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.SubscribeResponse.getDefaultInstance())
+        return this;
       switch (other.getResponseCase()) {
-        case INITIAL: {
-          mergeInitial(other.getInitial());
-          break;
-        }
-        case SEEK: {
-          mergeSeek(other.getSeek());
-          break;
-        }
-        case MESSAGES: {
-          mergeMessages(other.getMessages());
-          break;
-        }
-        case RESPONSE_NOT_SET: {
-          break;
-        }
+        case INITIAL:
+          {
+            mergeInitial(other.getInitial());
+            break;
+          }
+        case SEEK:
+          {
+            mergeSeek(other.getSeek());
+            break;
+          }
+        case MESSAGES:
+          {
+            mergeMessages(other.getMessages());
+            break;
+          }
+        case RESPONSE_NOT_SET:
+          {
+            break;
+          }
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -663,7 +727,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.SubscribeResponse) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.SubscribeResponse) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -672,12 +737,12 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+
     private int responseCase_ = 0;
     private java.lang.Object response_;
-    public ResponseCase
-        getResponseCase() {
-      return ResponseCase.forNumber(
-          responseCase_);
+
+    public ResponseCase getResponseCase() {
+      return ResponseCase.forNumber(responseCase_);
     }
 
     public Builder clearResponse() {
@@ -687,26 +752,34 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.InitialSubscribeResponse, com.google.cloud.pubsublite.proto.InitialSubscribeResponse.Builder, com.google.cloud.pubsublite.proto.InitialSubscribeResponseOrBuilder> initialBuilder_;
+            com.google.cloud.pubsublite.proto.InitialSubscribeResponse,
+            com.google.cloud.pubsublite.proto.InitialSubscribeResponse.Builder,
+            com.google.cloud.pubsublite.proto.InitialSubscribeResponseOrBuilder>
+        initialBuilder_;
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialSubscribeResponse initial = 1;</code>
+     *
      * @return Whether the initial field is set.
      */
     public boolean hasInitial() {
       return responseCase_ == 1;
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialSubscribeResponse initial = 1;</code>
+     *
      * @return The initial.
      */
     public com.google.cloud.pubsublite.proto.InitialSubscribeResponse getInitial() {
@@ -723,6 +796,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
@@ -743,6 +818,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
@@ -761,6 +838,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
@@ -769,10 +848,15 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeInitial(com.google.cloud.pubsublite.proto.InitialSubscribeResponse value) {
       if (initialBuilder_ == null) {
-        if (responseCase_ == 1 &&
-            response_ != com.google.cloud.pubsublite.proto.InitialSubscribeResponse.getDefaultInstance()) {
-          response_ = com.google.cloud.pubsublite.proto.InitialSubscribeResponse.newBuilder((com.google.cloud.pubsublite.proto.InitialSubscribeResponse) response_)
-              .mergeFrom(value).buildPartial();
+        if (responseCase_ == 1
+            && response_
+                != com.google.cloud.pubsublite.proto.InitialSubscribeResponse
+                    .getDefaultInstance()) {
+          response_ =
+              com.google.cloud.pubsublite.proto.InitialSubscribeResponse.newBuilder(
+                      (com.google.cloud.pubsublite.proto.InitialSubscribeResponse) response_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           response_ = value;
         }
@@ -787,6 +871,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
@@ -810,6 +896,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
@@ -820,13 +908,16 @@ private static final long serialVersionUID = 0L;
       return getInitialFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.InitialSubscribeResponse initial = 1;</code>
      */
-    public com.google.cloud.pubsublite.proto.InitialSubscribeResponseOrBuilder getInitialOrBuilder() {
+    public com.google.cloud.pubsublite.proto.InitialSubscribeResponseOrBuilder
+        getInitialOrBuilder() {
       if ((responseCase_ == 1) && (initialBuilder_ != null)) {
         return initialBuilder_.getMessageOrBuilder();
       } else {
@@ -837,6 +928,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Initial response on the stream.
      * </pre>
@@ -844,43 +937,59 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.InitialSubscribeResponse initial = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.InitialSubscribeResponse, com.google.cloud.pubsublite.proto.InitialSubscribeResponse.Builder, com.google.cloud.pubsublite.proto.InitialSubscribeResponseOrBuilder> 
+            com.google.cloud.pubsublite.proto.InitialSubscribeResponse,
+            com.google.cloud.pubsublite.proto.InitialSubscribeResponse.Builder,
+            com.google.cloud.pubsublite.proto.InitialSubscribeResponseOrBuilder>
         getInitialFieldBuilder() {
       if (initialBuilder_ == null) {
         if (!(responseCase_ == 1)) {
-          response_ = com.google.cloud.pubsublite.proto.InitialSubscribeResponse.getDefaultInstance();
+          response_ =
+              com.google.cloud.pubsublite.proto.InitialSubscribeResponse.getDefaultInstance();
         }
-        initialBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.InitialSubscribeResponse, com.google.cloud.pubsublite.proto.InitialSubscribeResponse.Builder, com.google.cloud.pubsublite.proto.InitialSubscribeResponseOrBuilder>(
+        initialBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.InitialSubscribeResponse,
+                com.google.cloud.pubsublite.proto.InitialSubscribeResponse.Builder,
+                com.google.cloud.pubsublite.proto.InitialSubscribeResponseOrBuilder>(
                 (com.google.cloud.pubsublite.proto.InitialSubscribeResponse) response_,
                 getParentForChildren(),
                 isClean());
         response_ = null;
       }
       responseCase_ = 1;
-      onChanged();;
+      onChanged();
+      ;
       return initialBuilder_;
     }
 
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.SeekResponse, com.google.cloud.pubsublite.proto.SeekResponse.Builder, com.google.cloud.pubsublite.proto.SeekResponseOrBuilder> seekBuilder_;
+            com.google.cloud.pubsublite.proto.SeekResponse,
+            com.google.cloud.pubsublite.proto.SeekResponse.Builder,
+            com.google.cloud.pubsublite.proto.SeekResponseOrBuilder>
+        seekBuilder_;
     /**
+     *
+     *
      * <pre>
      * Response to a Seek operation.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SeekResponse seek = 2;</code>
+     *
      * @return Whether the seek field is set.
      */
     public boolean hasSeek() {
       return responseCase_ == 2;
     }
     /**
+     *
+     *
      * <pre>
      * Response to a Seek operation.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SeekResponse seek = 2;</code>
+     *
      * @return The seek.
      */
     public com.google.cloud.pubsublite.proto.SeekResponse getSeek() {
@@ -897,6 +1006,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Response to a Seek operation.
      * </pre>
@@ -917,14 +1028,15 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Response to a Seek operation.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.SeekResponse seek = 2;</code>
      */
-    public Builder setSeek(
-        com.google.cloud.pubsublite.proto.SeekResponse.Builder builderForValue) {
+    public Builder setSeek(com.google.cloud.pubsublite.proto.SeekResponse.Builder builderForValue) {
       if (seekBuilder_ == null) {
         response_ = builderForValue.build();
         onChanged();
@@ -935,6 +1047,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Response to a Seek operation.
      * </pre>
@@ -943,10 +1057,13 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeSeek(com.google.cloud.pubsublite.proto.SeekResponse value) {
       if (seekBuilder_ == null) {
-        if (responseCase_ == 2 &&
-            response_ != com.google.cloud.pubsublite.proto.SeekResponse.getDefaultInstance()) {
-          response_ = com.google.cloud.pubsublite.proto.SeekResponse.newBuilder((com.google.cloud.pubsublite.proto.SeekResponse) response_)
-              .mergeFrom(value).buildPartial();
+        if (responseCase_ == 2
+            && response_ != com.google.cloud.pubsublite.proto.SeekResponse.getDefaultInstance()) {
+          response_ =
+              com.google.cloud.pubsublite.proto.SeekResponse.newBuilder(
+                      (com.google.cloud.pubsublite.proto.SeekResponse) response_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           response_ = value;
         }
@@ -961,6 +1078,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Response to a Seek operation.
      * </pre>
@@ -984,6 +1103,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Response to a Seek operation.
      * </pre>
@@ -994,6 +1115,8 @@ private static final long serialVersionUID = 0L;
       return getSeekFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * Response to a Seek operation.
      * </pre>
@@ -1011,6 +1134,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Response to a Seek operation.
      * </pre>
@@ -1018,43 +1143,58 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.SeekResponse seek = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.SeekResponse, com.google.cloud.pubsublite.proto.SeekResponse.Builder, com.google.cloud.pubsublite.proto.SeekResponseOrBuilder> 
+            com.google.cloud.pubsublite.proto.SeekResponse,
+            com.google.cloud.pubsublite.proto.SeekResponse.Builder,
+            com.google.cloud.pubsublite.proto.SeekResponseOrBuilder>
         getSeekFieldBuilder() {
       if (seekBuilder_ == null) {
         if (!(responseCase_ == 2)) {
           response_ = com.google.cloud.pubsublite.proto.SeekResponse.getDefaultInstance();
         }
-        seekBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.SeekResponse, com.google.cloud.pubsublite.proto.SeekResponse.Builder, com.google.cloud.pubsublite.proto.SeekResponseOrBuilder>(
+        seekBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.SeekResponse,
+                com.google.cloud.pubsublite.proto.SeekResponse.Builder,
+                com.google.cloud.pubsublite.proto.SeekResponseOrBuilder>(
                 (com.google.cloud.pubsublite.proto.SeekResponse) response_,
                 getParentForChildren(),
                 isClean());
         response_ = null;
       }
       responseCase_ = 2;
-      onChanged();;
+      onChanged();
+      ;
       return seekBuilder_;
     }
 
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.MessageResponse, com.google.cloud.pubsublite.proto.MessageResponse.Builder, com.google.cloud.pubsublite.proto.MessageResponseOrBuilder> messagesBuilder_;
+            com.google.cloud.pubsublite.proto.MessageResponse,
+            com.google.cloud.pubsublite.proto.MessageResponse.Builder,
+            com.google.cloud.pubsublite.proto.MessageResponseOrBuilder>
+        messagesBuilder_;
     /**
+     *
+     *
      * <pre>
      * Response containing messages from the topic partition.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.MessageResponse messages = 3;</code>
+     *
      * @return Whether the messages field is set.
      */
     public boolean hasMessages() {
       return responseCase_ == 3;
     }
     /**
+     *
+     *
      * <pre>
      * Response containing messages from the topic partition.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.MessageResponse messages = 3;</code>
+     *
      * @return The messages.
      */
     public com.google.cloud.pubsublite.proto.MessageResponse getMessages() {
@@ -1071,6 +1211,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Response containing messages from the topic partition.
      * </pre>
@@ -1091,6 +1233,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Response containing messages from the topic partition.
      * </pre>
@@ -1109,6 +1253,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Response containing messages from the topic partition.
      * </pre>
@@ -1117,10 +1263,14 @@ private static final long serialVersionUID = 0L;
      */
     public Builder mergeMessages(com.google.cloud.pubsublite.proto.MessageResponse value) {
       if (messagesBuilder_ == null) {
-        if (responseCase_ == 3 &&
-            response_ != com.google.cloud.pubsublite.proto.MessageResponse.getDefaultInstance()) {
-          response_ = com.google.cloud.pubsublite.proto.MessageResponse.newBuilder((com.google.cloud.pubsublite.proto.MessageResponse) response_)
-              .mergeFrom(value).buildPartial();
+        if (responseCase_ == 3
+            && response_
+                != com.google.cloud.pubsublite.proto.MessageResponse.getDefaultInstance()) {
+          response_ =
+              com.google.cloud.pubsublite.proto.MessageResponse.newBuilder(
+                      (com.google.cloud.pubsublite.proto.MessageResponse) response_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           response_ = value;
         }
@@ -1135,6 +1285,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Response containing messages from the topic partition.
      * </pre>
@@ -1158,6 +1310,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * Response containing messages from the topic partition.
      * </pre>
@@ -1168,6 +1322,8 @@ private static final long serialVersionUID = 0L;
       return getMessagesFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * Response containing messages from the topic partition.
      * </pre>
@@ -1185,6 +1341,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * Response containing messages from the topic partition.
      * </pre>
@@ -1192,26 +1350,32 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.MessageResponse messages = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.MessageResponse, com.google.cloud.pubsublite.proto.MessageResponse.Builder, com.google.cloud.pubsublite.proto.MessageResponseOrBuilder> 
+            com.google.cloud.pubsublite.proto.MessageResponse,
+            com.google.cloud.pubsublite.proto.MessageResponse.Builder,
+            com.google.cloud.pubsublite.proto.MessageResponseOrBuilder>
         getMessagesFieldBuilder() {
       if (messagesBuilder_ == null) {
         if (!(responseCase_ == 3)) {
           response_ = com.google.cloud.pubsublite.proto.MessageResponse.getDefaultInstance();
         }
-        messagesBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.MessageResponse, com.google.cloud.pubsublite.proto.MessageResponse.Builder, com.google.cloud.pubsublite.proto.MessageResponseOrBuilder>(
+        messagesBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.MessageResponse,
+                com.google.cloud.pubsublite.proto.MessageResponse.Builder,
+                com.google.cloud.pubsublite.proto.MessageResponseOrBuilder>(
                 (com.google.cloud.pubsublite.proto.MessageResponse) response_,
                 getParentForChildren(),
                 isClean());
         response_ = null;
       }
       responseCase_ = 3;
-      onChanged();;
+      onChanged();
+      ;
       return messagesBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -1221,12 +1385,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.SubscribeResponse)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.SubscribeResponse)
   private static final com.google.cloud.pubsublite.proto.SubscribeResponse DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.SubscribeResponse();
   }
@@ -1235,16 +1399,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<SubscribeResponse>
-      PARSER = new com.google.protobuf.AbstractParser<SubscribeResponse>() {
-    @java.lang.Override
-    public SubscribeResponse parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new SubscribeResponse(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<SubscribeResponse> PARSER =
+      new com.google.protobuf.AbstractParser<SubscribeResponse>() {
+        @java.lang.Override
+        public SubscribeResponse parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new SubscribeResponse(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<SubscribeResponse> parser() {
     return PARSER;
@@ -1259,6 +1423,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.SubscribeResponse getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SubscribeResponseOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SubscribeResponseOrBuilder.java
@@ -3,29 +3,38 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface SubscribeResponseOrBuilder extends
+public interface SubscribeResponseOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.SubscribeResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialSubscribeResponse initial = 1;</code>
+   *
    * @return Whether the initial field is set.
    */
   boolean hasInitial();
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.InitialSubscribeResponse initial = 1;</code>
+   *
    * @return The initial.
    */
   com.google.cloud.pubsublite.proto.InitialSubscribeResponse getInitial();
   /**
+   *
+   *
    * <pre>
    * Initial response on the stream.
    * </pre>
@@ -35,24 +44,32 @@ public interface SubscribeResponseOrBuilder extends
   com.google.cloud.pubsublite.proto.InitialSubscribeResponseOrBuilder getInitialOrBuilder();
 
   /**
+   *
+   *
    * <pre>
    * Response to a Seek operation.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SeekResponse seek = 2;</code>
+   *
    * @return Whether the seek field is set.
    */
   boolean hasSeek();
   /**
+   *
+   *
    * <pre>
    * Response to a Seek operation.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.SeekResponse seek = 2;</code>
+   *
    * @return The seek.
    */
   com.google.cloud.pubsublite.proto.SeekResponse getSeek();
   /**
+   *
+   *
    * <pre>
    * Response to a Seek operation.
    * </pre>
@@ -62,24 +79,32 @@ public interface SubscribeResponseOrBuilder extends
   com.google.cloud.pubsublite.proto.SeekResponseOrBuilder getSeekOrBuilder();
 
   /**
+   *
+   *
    * <pre>
    * Response containing messages from the topic partition.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.MessageResponse messages = 3;</code>
+   *
    * @return Whether the messages field is set.
    */
   boolean hasMessages();
   /**
+   *
+   *
    * <pre>
    * Response containing messages from the topic partition.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.MessageResponse messages = 3;</code>
+   *
    * @return The messages.
    */
   com.google.cloud.pubsublite.proto.MessageResponse getMessages();
   /**
+   *
+   *
    * <pre>
    * Response containing messages from the topic partition.
    * </pre>

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SubscriberProto.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SubscriberProto.java
@@ -5,153 +5,160 @@ package com.google.cloud.pubsublite.proto;
 
 public final class SubscriberProto {
   private SubscriberProto() {}
-  public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistryLite registry) {
+
+  public static void registerAllExtensions(com.google.protobuf.ExtensionRegistryLite registry) {}
+
+  public static void registerAllExtensions(com.google.protobuf.ExtensionRegistry registry) {
+    registerAllExtensions((com.google.protobuf.ExtensionRegistryLite) registry);
   }
 
-  public static void registerAllExtensions(
-      com.google.protobuf.ExtensionRegistry registry) {
-    registerAllExtensions(
-        (com.google.protobuf.ExtensionRegistryLite) registry);
-  }
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_SeekRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_SeekRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_SeekRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_SeekResponse_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_SeekResponse_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_SeekResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_FlowControlRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_FlowControlRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_FlowControlRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_SubscribeRequest_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_SubscribeRequest_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_SubscribeRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_MessageResponse_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_MessageResponse_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_MessageResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_cloud_pubsublite_v1_SubscribeResponse_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_cloud_pubsublite_v1_SubscribeResponse_descriptor;
+  static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_cloud_pubsublite_v1_SubscribeResponse_fieldAccessorTable;
 
-  public static com.google.protobuf.Descriptors.FileDescriptor
-      getDescriptor() {
+  public static com.google.protobuf.Descriptors.FileDescriptor getDescriptor() {
     return descriptor;
   }
-  private static  com.google.protobuf.Descriptors.FileDescriptor
-      descriptor;
+
+  private static com.google.protobuf.Descriptors.FileDescriptor descriptor;
+
   static {
     java.lang.String[] descriptorData = {
-      "\n+google/cloud/pubsublite/v1/subscriber." +
-      "proto\022\032google.cloud.pubsublite.v1\032\'googl" +
-      "e/cloud/pubsublite/v1/common.proto\"B\n\027In" +
-      "itialSubscribeRequest\022\024\n\014subscription\030\001 " +
-      "\001(\t\022\021\n\tpartition\030\002 \001(\003\"N\n\030InitialSubscri" +
-      "beResponse\0222\n\006cursor\030\001 \001(\0132\".google.clou" +
-      "d.pubsublite.v1.Cursor\"\347\001\n\013SeekRequest\022K" +
-      "\n\014named_target\030\001 \001(\01623.google.cloud.pubs" +
-      "ublite.v1.SeekRequest.NamedTargetH\000\0224\n\006c" +
-      "ursor\030\002 \001(\0132\".google.cloud.pubsublite.v1" +
-      ".CursorH\000\"K\n\013NamedTarget\022\034\n\030NAMED_TARGET" +
-      "_UNSPECIFIED\020\000\022\010\n\004HEAD\020\001\022\024\n\020COMMITTED_CU" +
-      "RSOR\020\002B\010\n\006target\"B\n\014SeekResponse\0222\n\006curs" +
-      "or\030\001 \001(\0132\".google.cloud.pubsublite.v1.Cu" +
-      "rsor\"E\n\022FlowControlRequest\022\030\n\020allowed_me" +
-      "ssages\030\001 \001(\003\022\025\n\rallowed_bytes\030\002 \001(\003\"\346\001\n\020" +
-      "SubscribeRequest\022F\n\007initial\030\001 \001(\01323.goog" +
-      "le.cloud.pubsublite.v1.InitialSubscribeR" +
-      "equestH\000\0227\n\004seek\030\002 \001(\0132\'.google.cloud.pu" +
-      "bsublite.v1.SeekRequestH\000\022F\n\014flow_contro" +
-      "l\030\003 \001(\0132..google.cloud.pubsublite.v1.Flo" +
-      "wControlRequestH\000B\t\n\007request\"Q\n\017MessageR" +
-      "esponse\022>\n\010messages\030\001 \003(\0132,.google.cloud" +
-      ".pubsublite.v1.SequencedMessage\"\343\001\n\021Subs" +
-      "cribeResponse\022G\n\007initial\030\001 \001(\01324.google." +
-      "cloud.pubsublite.v1.InitialSubscribeResp" +
-      "onseH\000\0228\n\004seek\030\002 \001(\0132(.google.cloud.pubs" +
-      "ublite.v1.SeekResponseH\000\022?\n\010messages\030\003 \001" +
-      "(\0132+.google.cloud.pubsublite.v1.MessageR" +
-      "esponseH\000B\n\n\010response2\203\001\n\021SubscriberServ" +
-      "ice\022n\n\tSubscribe\022,.google.cloud.pubsubli" +
-      "te.v1.SubscribeRequest\032-.google.cloud.pu" +
-      "bsublite.v1.SubscribeResponse\"\000(\0010\001B9\n!c" +
-      "om.google.cloud.pubsublite.protoB\017Subscr" +
-      "iberProtoP\001\370\001\001b\006proto3"
+      "\n+google/cloud/pubsublite/v1/subscriber."
+          + "proto\022\032google.cloud.pubsublite.v1\032\'googl"
+          + "e/cloud/pubsublite/v1/common.proto\"B\n\027In"
+          + "itialSubscribeRequest\022\024\n\014subscription\030\001 "
+          + "\001(\t\022\021\n\tpartition\030\002 \001(\003\"N\n\030InitialSubscri"
+          + "beResponse\0222\n\006cursor\030\001 \001(\0132\".google.clou"
+          + "d.pubsublite.v1.Cursor\"\347\001\n\013SeekRequest\022K"
+          + "\n\014named_target\030\001 \001(\01623.google.cloud.pubs"
+          + "ublite.v1.SeekRequest.NamedTargetH\000\0224\n\006c"
+          + "ursor\030\002 \001(\0132\".google.cloud.pubsublite.v1"
+          + ".CursorH\000\"K\n\013NamedTarget\022\034\n\030NAMED_TARGET"
+          + "_UNSPECIFIED\020\000\022\010\n\004HEAD\020\001\022\024\n\020COMMITTED_CU"
+          + "RSOR\020\002B\010\n\006target\"B\n\014SeekResponse\0222\n\006curs"
+          + "or\030\001 \001(\0132\".google.cloud.pubsublite.v1.Cu"
+          + "rsor\"E\n\022FlowControlRequest\022\030\n\020allowed_me"
+          + "ssages\030\001 \001(\003\022\025\n\rallowed_bytes\030\002 \001(\003\"\346\001\n\020"
+          + "SubscribeRequest\022F\n\007initial\030\001 \001(\01323.goog"
+          + "le.cloud.pubsublite.v1.InitialSubscribeR"
+          + "equestH\000\0227\n\004seek\030\002 \001(\0132\'.google.cloud.pu"
+          + "bsublite.v1.SeekRequestH\000\022F\n\014flow_contro"
+          + "l\030\003 \001(\0132..google.cloud.pubsublite.v1.Flo"
+          + "wControlRequestH\000B\t\n\007request\"Q\n\017MessageR"
+          + "esponse\022>\n\010messages\030\001 \003(\0132,.google.cloud"
+          + ".pubsublite.v1.SequencedMessage\"\343\001\n\021Subs"
+          + "cribeResponse\022G\n\007initial\030\001 \001(\01324.google."
+          + "cloud.pubsublite.v1.InitialSubscribeResp"
+          + "onseH\000\0228\n\004seek\030\002 \001(\0132(.google.cloud.pubs"
+          + "ublite.v1.SeekResponseH\000\022?\n\010messages\030\003 \001"
+          + "(\0132+.google.cloud.pubsublite.v1.MessageR"
+          + "esponseH\000B\n\n\010response2\203\001\n\021SubscriberServ"
+          + "ice\022n\n\tSubscribe\022,.google.cloud.pubsubli"
+          + "te.v1.SubscribeRequest\032-.google.cloud.pu"
+          + "bsublite.v1.SubscribeResponse\"\000(\0010\001B9\n!c"
+          + "om.google.cloud.pubsublite.protoB\017Subscr"
+          + "iberProtoP\001\370\001\001b\006proto3"
     };
-    descriptor = com.google.protobuf.Descriptors.FileDescriptor
-      .internalBuildGeneratedFileFrom(descriptorData,
-        new com.google.protobuf.Descriptors.FileDescriptor[] {
-          com.google.cloud.pubsublite.proto.CommonProto.getDescriptor(),
-        });
+    descriptor =
+        com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
+            descriptorData,
+            new com.google.protobuf.Descriptors.FileDescriptor[] {
+              com.google.cloud.pubsublite.proto.CommonProto.getDescriptor(),
+            });
     internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_descriptor =
-      getDescriptor().getMessageTypes().get(0);
-    internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_descriptor,
-        new java.lang.String[] { "Subscription", "Partition", });
+        getDescriptor().getMessageTypes().get(0);
+    internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_InitialSubscribeRequest_descriptor,
+            new java.lang.String[] {
+              "Subscription", "Partition",
+            });
     internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_descriptor =
-      getDescriptor().getMessageTypes().get(1);
-    internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_descriptor,
-        new java.lang.String[] { "Cursor", });
+        getDescriptor().getMessageTypes().get(1);
+    internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_InitialSubscribeResponse_descriptor,
+            new java.lang.String[] {
+              "Cursor",
+            });
     internal_static_google_cloud_pubsublite_v1_SeekRequest_descriptor =
-      getDescriptor().getMessageTypes().get(2);
-    internal_static_google_cloud_pubsublite_v1_SeekRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_SeekRequest_descriptor,
-        new java.lang.String[] { "NamedTarget", "Cursor", "Target", });
+        getDescriptor().getMessageTypes().get(2);
+    internal_static_google_cloud_pubsublite_v1_SeekRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_SeekRequest_descriptor,
+            new java.lang.String[] {
+              "NamedTarget", "Cursor", "Target",
+            });
     internal_static_google_cloud_pubsublite_v1_SeekResponse_descriptor =
-      getDescriptor().getMessageTypes().get(3);
-    internal_static_google_cloud_pubsublite_v1_SeekResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_SeekResponse_descriptor,
-        new java.lang.String[] { "Cursor", });
+        getDescriptor().getMessageTypes().get(3);
+    internal_static_google_cloud_pubsublite_v1_SeekResponse_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_SeekResponse_descriptor,
+            new java.lang.String[] {
+              "Cursor",
+            });
     internal_static_google_cloud_pubsublite_v1_FlowControlRequest_descriptor =
-      getDescriptor().getMessageTypes().get(4);
-    internal_static_google_cloud_pubsublite_v1_FlowControlRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_FlowControlRequest_descriptor,
-        new java.lang.String[] { "AllowedMessages", "AllowedBytes", });
+        getDescriptor().getMessageTypes().get(4);
+    internal_static_google_cloud_pubsublite_v1_FlowControlRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_FlowControlRequest_descriptor,
+            new java.lang.String[] {
+              "AllowedMessages", "AllowedBytes",
+            });
     internal_static_google_cloud_pubsublite_v1_SubscribeRequest_descriptor =
-      getDescriptor().getMessageTypes().get(5);
-    internal_static_google_cloud_pubsublite_v1_SubscribeRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_SubscribeRequest_descriptor,
-        new java.lang.String[] { "Initial", "Seek", "FlowControl", "Request", });
+        getDescriptor().getMessageTypes().get(5);
+    internal_static_google_cloud_pubsublite_v1_SubscribeRequest_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_SubscribeRequest_descriptor,
+            new java.lang.String[] {
+              "Initial", "Seek", "FlowControl", "Request",
+            });
     internal_static_google_cloud_pubsublite_v1_MessageResponse_descriptor =
-      getDescriptor().getMessageTypes().get(6);
-    internal_static_google_cloud_pubsublite_v1_MessageResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_MessageResponse_descriptor,
-        new java.lang.String[] { "Messages", });
+        getDescriptor().getMessageTypes().get(6);
+    internal_static_google_cloud_pubsublite_v1_MessageResponse_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_MessageResponse_descriptor,
+            new java.lang.String[] {
+              "Messages",
+            });
     internal_static_google_cloud_pubsublite_v1_SubscribeResponse_descriptor =
-      getDescriptor().getMessageTypes().get(7);
-    internal_static_google_cloud_pubsublite_v1_SubscribeResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_cloud_pubsublite_v1_SubscribeResponse_descriptor,
-        new java.lang.String[] { "Initial", "Seek", "Messages", "Response", });
+        getDescriptor().getMessageTypes().get(7);
+    internal_static_google_cloud_pubsublite_v1_SubscribeResponse_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+            internal_static_google_cloud_pubsublite_v1_SubscribeResponse_descriptor,
+            new java.lang.String[] {
+              "Initial", "Seek", "Messages", "Response",
+            });
     com.google.cloud.pubsublite.proto.CommonProto.getDescriptor();
   }
 

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/Subscription.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/Subscription.java
@@ -4,21 +4,24 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Metadata about a subscription resource.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.Subscription}
  */
-public  final class Subscription extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class Subscription extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.Subscription)
     SubscriptionOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use Subscription.newBuilder() to construct.
   private Subscription(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private Subscription() {
     name_ = "";
     topic_ = "";
@@ -26,16 +29,15 @@ private static final long serialVersionUID = 0L;
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new Subscription();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private Subscription(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -54,118 +56,141 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            name_ = s;
-            break;
-          }
-          case 18: {
-            java.lang.String s = input.readStringRequireUtf8();
+              name_ = s;
+              break;
+            }
+          case 18:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            topic_ = s;
-            break;
-          }
-          case 26: {
-            com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.Builder subBuilder = null;
-            if (deliveryConfig_ != null) {
-              subBuilder = deliveryConfig_.toBuilder();
+              topic_ = s;
+              break;
             }
-            deliveryConfig_ = input.readMessage(com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(deliveryConfig_);
-              deliveryConfig_ = subBuilder.buildPartial();
-            }
+          case 26:
+            {
+              com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.Builder subBuilder =
+                  null;
+              if (deliveryConfig_ != null) {
+                subBuilder = deliveryConfig_.toBuilder();
+              }
+              deliveryConfig_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.parser(),
+                      extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(deliveryConfig_);
+                deliveryConfig_ = subBuilder.buildPartial();
+              }
 
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Subscription_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CommonProto
+        .internal_static_google_cloud_pubsublite_v1_Subscription_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Subscription_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CommonProto
+        .internal_static_google_cloud_pubsublite_v1_Subscription_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.Subscription.class, com.google.cloud.pubsublite.proto.Subscription.Builder.class);
+            com.google.cloud.pubsublite.proto.Subscription.class,
+            com.google.cloud.pubsublite.proto.Subscription.Builder.class);
   }
 
-  public interface DeliveryConfigOrBuilder extends
+  public interface DeliveryConfigOrBuilder
+      extends
       // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.Subscription.DeliveryConfig)
       com.google.protobuf.MessageOrBuilder {
 
     /**
+     *
+     *
      * <pre>
      * The DeliveryRequirement for this subscription.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;
+     * </code>
+     *
      * @return The enum numeric value on the wire for deliveryRequirement.
      */
     int getDeliveryRequirementValue();
     /**
+     *
+     *
      * <pre>
      * The DeliveryRequirement for this subscription.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;
+     * </code>
+     *
      * @return The deliveryRequirement.
      */
-    com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement getDeliveryRequirement();
+    com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement
+        getDeliveryRequirement();
   }
   /**
+   *
+   *
    * <pre>
    * The settings for a subscription's message delivery.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.Subscription.DeliveryConfig}
    */
-  public  static final class DeliveryConfig extends
-      com.google.protobuf.GeneratedMessageV3 implements
+  public static final class DeliveryConfig extends com.google.protobuf.GeneratedMessageV3
+      implements
       // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.Subscription.DeliveryConfig)
       DeliveryConfigOrBuilder {
-  private static final long serialVersionUID = 0L;
+    private static final long serialVersionUID = 0L;
     // Use DeliveryConfig.newBuilder() to construct.
     private DeliveryConfig(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
+
     private DeliveryConfig() {
       deliveryRequirement_ = 0;
     }
 
     @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected java.lang.Object newInstance(
-        UnusedPrivateParameter unused) {
+    protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
       return new DeliveryConfig();
     }
 
     @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
+    public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
       return this.unknownFields;
     }
+
     private DeliveryConfig(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -184,55 +209,62 @@ private static final long serialVersionUID = 0L;
             case 0:
               done = true;
               break;
-            case 24: {
-              int rawValue = input.readEnum();
+            case 24:
+              {
+                int rawValue = input.readEnum();
 
-              deliveryRequirement_ = rawValue;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
+                deliveryRequirement_ = rawValue;
+                break;
               }
-              break;
-            }
+            default:
+              {
+                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
+        throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
     }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_descriptor;
+
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.class, com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.Builder.class);
+              com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.class,
+              com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.Builder.class);
     }
 
     /**
+     *
+     *
      * <pre>
      * When this subscription should send messages to subscribers relative to
      * messages persistence in storage.
      * </pre>
      *
-     * Protobuf enum {@code google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement}
+     * Protobuf enum {@code
+     * google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement}
      */
-    public enum DeliveryRequirement
-        implements com.google.protobuf.ProtocolMessageEnum {
+    public enum DeliveryRequirement implements com.google.protobuf.ProtocolMessageEnum {
       /**
+       *
+       *
        * <pre>
        * Default value. This value is unused.
        * </pre>
@@ -241,6 +273,8 @@ private static final long serialVersionUID = 0L;
        */
       DELIVERY_REQUIREMENT_UNSPECIFIED(0),
       /**
+       *
+       *
        * <pre>
        * The server does not wait for a published message to be successfully
        * written to storage before delivering it to subscribers. As such, a
@@ -275,6 +309,8 @@ private static final long serialVersionUID = 0L;
        */
       DELIVER_IMMEDIATELY(1),
       /**
+       *
+       *
        * <pre>
        * The server will not deliver a published message to subscribers until
        * the message has been successfully written to storage. This will result
@@ -288,6 +324,8 @@ private static final long serialVersionUID = 0L;
       ;
 
       /**
+       *
+       *
        * <pre>
        * Default value. This value is unused.
        * </pre>
@@ -296,6 +334,8 @@ private static final long serialVersionUID = 0L;
        */
       public static final int DELIVERY_REQUIREMENT_UNSPECIFIED_VALUE = 0;
       /**
+       *
+       *
        * <pre>
        * The server does not wait for a published message to be successfully
        * written to storage before delivering it to subscribers. As such, a
@@ -330,6 +370,8 @@ private static final long serialVersionUID = 0L;
        */
       public static final int DELIVER_IMMEDIATELY_VALUE = 1;
       /**
+       *
+       *
        * <pre>
        * The server will not deliver a published message to subscribers until
        * the message has been successfully written to storage. This will result
@@ -339,7 +381,6 @@ private static final long serialVersionUID = 0L;
        * <code>DELIVER_AFTER_STORED = 2;</code>
        */
       public static final int DELIVER_AFTER_STORED_VALUE = 2;
-
 
       public final int getNumber() {
         if (this == UNRECOGNIZED) {
@@ -365,10 +406,14 @@ private static final long serialVersionUID = 0L;
        */
       public static DeliveryRequirement forNumber(int value) {
         switch (value) {
-          case 0: return DELIVERY_REQUIREMENT_UNSPECIFIED;
-          case 1: return DELIVER_IMMEDIATELY;
-          case 2: return DELIVER_AFTER_STORED;
-          default: return null;
+          case 0:
+            return DELIVERY_REQUIREMENT_UNSPECIFIED;
+          case 1:
+            return DELIVER_IMMEDIATELY;
+          case 2:
+            return DELIVER_AFTER_STORED;
+          default:
+            return null;
         }
       }
 
@@ -376,25 +421,27 @@ private static final long serialVersionUID = 0L;
           internalGetValueMap() {
         return internalValueMap;
       }
-      private static final com.google.protobuf.Internal.EnumLiteMap<
-          DeliveryRequirement> internalValueMap =
-            new com.google.protobuf.Internal.EnumLiteMap<DeliveryRequirement>() {
-              public DeliveryRequirement findValueByNumber(int number) {
-                return DeliveryRequirement.forNumber(number);
-              }
-            };
 
-      public final com.google.protobuf.Descriptors.EnumValueDescriptor
-          getValueDescriptor() {
+      private static final com.google.protobuf.Internal.EnumLiteMap<DeliveryRequirement>
+          internalValueMap =
+              new com.google.protobuf.Internal.EnumLiteMap<DeliveryRequirement>() {
+                public DeliveryRequirement findValueByNumber(int number) {
+                  return DeliveryRequirement.forNumber(number);
+                }
+              };
+
+      public final com.google.protobuf.Descriptors.EnumValueDescriptor getValueDescriptor() {
         return getDescriptor().getValues().get(ordinal());
       }
-      public final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptorForType() {
+
+      public final com.google.protobuf.Descriptors.EnumDescriptor getDescriptorForType() {
         return getDescriptor();
       }
-      public static final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptor() {
-        return com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.getDescriptor().getEnumTypes().get(0);
+
+      public static final com.google.protobuf.Descriptors.EnumDescriptor getDescriptor() {
+        return com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.getDescriptor()
+            .getEnumTypes()
+            .get(0);
       }
 
       private static final DeliveryRequirement[] VALUES = values();
@@ -402,8 +449,7 @@ private static final long serialVersionUID = 0L;
       public static DeliveryRequirement valueOf(
           com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
         if (desc.getType() != getDescriptor()) {
-          throw new java.lang.IllegalArgumentException(
-            "EnumValueDescriptor is not for this type.");
+          throw new java.lang.IllegalArgumentException("EnumValueDescriptor is not for this type.");
         }
         if (desc.getIndex() == -1) {
           return UNRECOGNIZED;
@@ -423,31 +469,48 @@ private static final long serialVersionUID = 0L;
     public static final int DELIVERY_REQUIREMENT_FIELD_NUMBER = 3;
     private int deliveryRequirement_;
     /**
+     *
+     *
      * <pre>
      * The DeliveryRequirement for this subscription.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;
+     * </code>
+     *
      * @return The enum numeric value on the wire for deliveryRequirement.
      */
     public int getDeliveryRequirementValue() {
       return deliveryRequirement_;
     }
     /**
+     *
+     *
      * <pre>
      * The DeliveryRequirement for this subscription.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;
+     * </code>
+     *
      * @return The deliveryRequirement.
      */
-    public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement getDeliveryRequirement() {
+    public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement
+        getDeliveryRequirement() {
       @SuppressWarnings("deprecation")
-      com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement result = com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement.valueOf(deliveryRequirement_);
-      return result == null ? com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement.UNRECOGNIZED : result;
+      com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement result =
+          com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement.valueOf(
+              deliveryRequirement_);
+      return result == null
+          ? com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement
+              .UNRECOGNIZED
+          : result;
     }
 
     private byte memoizedIsInitialized = -1;
+
     @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -459,9 +522,11 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
-      if (deliveryRequirement_ != com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement.DELIVERY_REQUIREMENT_UNSPECIFIED.getNumber()) {
+    public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
+      if (deliveryRequirement_
+          != com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement
+              .DELIVERY_REQUIREMENT_UNSPECIFIED
+              .getNumber()) {
         output.writeEnum(3, deliveryRequirement_);
       }
       unknownFields.writeTo(output);
@@ -473,9 +538,11 @@ private static final long serialVersionUID = 0L;
       if (size != -1) return size;
 
       size = 0;
-      if (deliveryRequirement_ != com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement.DELIVERY_REQUIREMENT_UNSPECIFIED.getNumber()) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(3, deliveryRequirement_);
+      if (deliveryRequirement_
+          != com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement
+              .DELIVERY_REQUIREMENT_UNSPECIFIED
+              .getNumber()) {
+        size += com.google.protobuf.CodedOutputStream.computeEnumSize(3, deliveryRequirement_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -485,12 +552,13 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
-       return true;
+        return true;
       }
       if (!(obj instanceof com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig)) {
         return super.equals(obj);
       }
-      com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig other = (com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig) obj;
+      com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig other =
+          (com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig) obj;
 
       if (deliveryRequirement_ != other.deliveryRequirement_) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
@@ -512,87 +580,94 @@ private static final long serialVersionUID = 0L;
     }
 
     public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig parseFrom(
-        java.nio.ByteBuffer data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+        java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
+
     public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig parseFrom(
-        java.nio.ByteBuffer data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
+
     public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
+
     public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+
+    public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig parseFrom(
+        byte[] data) throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
+
     public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
-    }
+
     public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
+        java.io.InputStream input) throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
-    public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig parseDelimitedFrom(java.io.InputStream input)
+
+    public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig parseFrom(
+        java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input);
+      return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
     }
+
     public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+        java.io.InputStream input) throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
     }
+
+    public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig parseDelimitedFrom(
+        java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
     public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
+        com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
+
     public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
     }
 
     @java.lang.Override
-    public Builder newBuilderForType() { return newBuilder(); }
+    public Builder newBuilderForType() {
+      return newBuilder();
+    }
+
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig prototype) {
+
+    public static Builder newBuilder(
+        com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
+
     @java.lang.Override
     public Builder toBuilder() {
-      return this == DEFAULT_INSTANCE
-          ? new Builder() : new Builder().mergeFrom(this);
+      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
     }
 
     @java.lang.Override
@@ -602,27 +677,32 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for a subscription's message delivery.
      * </pre>
      *
      * Protobuf type {@code google.cloud.pubsublite.v1.Subscription.DeliveryConfig}
      */
-    public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+    public static final class Builder
+        extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+        implements
         // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.Subscription.DeliveryConfig)
         com.google.cloud.pubsublite.proto.Subscription.DeliveryConfigOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_descriptor;
+      public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+        return com.google.cloud.pubsublite.proto.CommonProto
+            .internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_fieldAccessorTable
+        return com.google.cloud.pubsublite.proto.CommonProto
+            .internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.class, com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.Builder.class);
+                com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.class,
+                com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.Builder.class);
       }
 
       // Construct using com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.newBuilder()
@@ -630,16 +710,15 @@ private static final long serialVersionUID = 0L;
         maybeForceBuilderInitialization();
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
+
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+        if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
       }
+
       @java.lang.Override
       public Builder clear() {
         super.clear();
@@ -649,13 +728,14 @@ private static final long serialVersionUID = 0L;
       }
 
       @java.lang.Override
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_descriptor;
+      public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+        return com.google.cloud.pubsublite.proto.CommonProto
+            .internal_static_google_cloud_pubsublite_v1_Subscription_DeliveryConfig_descriptor;
       }
 
       @java.lang.Override
-      public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig getDefaultInstanceForType() {
+      public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig
+          getDefaultInstanceForType() {
         return com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.getDefaultInstance();
       }
 
@@ -670,7 +750,8 @@ private static final long serialVersionUID = 0L;
 
       @java.lang.Override
       public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig buildPartial() {
-        com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig result = new com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig(this);
+        com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig result =
+            new com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig(this);
         result.deliveryRequirement_ = deliveryRequirement_;
         onBuilt();
         return result;
@@ -680,46 +761,52 @@ private static final long serialVersionUID = 0L;
       public Builder clone() {
         return super.clone();
       }
+
       @java.lang.Override
       public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
         return super.setField(field, value);
       }
+
       @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
+      public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
+
       @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
+
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
+          int index,
+          java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
+
       @java.lang.Override
       public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
+
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig) {
-          return mergeFrom((com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig)other);
+          return mergeFrom((com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig) other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig other) {
-        if (other == com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.getDefaultInstance()) return this;
+      public Builder mergeFrom(
+          com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig other) {
+        if (other
+            == com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.getDefaultInstance())
+          return this;
         if (other.deliveryRequirement_ != 0) {
           setDeliveryRequirementValue(other.getDeliveryRequirementValue());
         }
@@ -742,7 +829,9 @@ private static final long serialVersionUID = 0L;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig) e.getUnfinishedMessage();
+          parsedMessage =
+              (com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig)
+                  e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -754,22 +843,32 @@ private static final long serialVersionUID = 0L;
 
       private int deliveryRequirement_ = 0;
       /**
+       *
+       *
        * <pre>
        * The DeliveryRequirement for this subscription.
        * </pre>
        *
-       * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;</code>
+       * <code>
+       * .google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;
+       * </code>
+       *
        * @return The enum numeric value on the wire for deliveryRequirement.
        */
       public int getDeliveryRequirementValue() {
         return deliveryRequirement_;
       }
       /**
+       *
+       *
        * <pre>
        * The DeliveryRequirement for this subscription.
        * </pre>
        *
-       * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;</code>
+       * <code>
+       * .google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;
+       * </code>
+       *
        * @param value The enum numeric value on the wire for deliveryRequirement to set.
        * @return This builder for chaining.
        */
@@ -779,50 +878,73 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
+       *
+       *
        * <pre>
        * The DeliveryRequirement for this subscription.
        * </pre>
        *
-       * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;</code>
+       * <code>
+       * .google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;
+       * </code>
+       *
        * @return The deliveryRequirement.
        */
-      public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement getDeliveryRequirement() {
+      public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement
+          getDeliveryRequirement() {
         @SuppressWarnings("deprecation")
-        com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement result = com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement.valueOf(deliveryRequirement_);
-        return result == null ? com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement.UNRECOGNIZED : result;
+        com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement result =
+            com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement
+                .valueOf(deliveryRequirement_);
+        return result == null
+            ? com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement
+                .UNRECOGNIZED
+            : result;
       }
       /**
+       *
+       *
        * <pre>
        * The DeliveryRequirement for this subscription.
        * </pre>
        *
-       * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;</code>
+       * <code>
+       * .google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;
+       * </code>
+       *
        * @param value The deliveryRequirement to set.
        * @return This builder for chaining.
        */
-      public Builder setDeliveryRequirement(com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement value) {
+      public Builder setDeliveryRequirement(
+          com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.DeliveryRequirement value) {
         if (value == null) {
           throw new NullPointerException();
         }
-        
+
         deliveryRequirement_ = value.getNumber();
         onChanged();
         return this;
       }
       /**
+       *
+       *
        * <pre>
        * The DeliveryRequirement for this subscription.
        * </pre>
        *
-       * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;</code>
+       * <code>
+       * .google.cloud.pubsublite.v1.Subscription.DeliveryConfig.DeliveryRequirement delivery_requirement = 3;
+       * </code>
+       *
        * @return This builder for chaining.
        */
       public Builder clearDeliveryRequirement() {
-        
+
         deliveryRequirement_ = 0;
         onChanged();
         return this;
       }
+
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -835,30 +957,32 @@ private static final long serialVersionUID = 0L;
         return super.mergeUnknownFields(unknownFields);
       }
 
-
       // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.Subscription.DeliveryConfig)
     }
 
     // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.Subscription.DeliveryConfig)
-    private static final com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig DEFAULT_INSTANCE;
+    private static final com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig
+        DEFAULT_INSTANCE;
+
     static {
       DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig();
     }
 
-    public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig getDefaultInstance() {
+    public static com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig
+        getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    private static final com.google.protobuf.Parser<DeliveryConfig>
-        PARSER = new com.google.protobuf.AbstractParser<DeliveryConfig>() {
-      @java.lang.Override
-      public DeliveryConfig parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new DeliveryConfig(input, extensionRegistry);
-      }
-    };
+    private static final com.google.protobuf.Parser<DeliveryConfig> PARSER =
+        new com.google.protobuf.AbstractParser<DeliveryConfig>() {
+          @java.lang.Override
+          public DeliveryConfig parsePartialFrom(
+              com.google.protobuf.CodedInputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws com.google.protobuf.InvalidProtocolBufferException {
+            return new DeliveryConfig(input, extensionRegistry);
+          }
+        };
 
     public static com.google.protobuf.Parser<DeliveryConfig> parser() {
       return PARSER;
@@ -870,15 +994,17 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig getDefaultInstanceForType() {
+    public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig
+        getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
-
   }
 
   public static final int NAME_FIELD_NUMBER = 1;
   private volatile java.lang.Object name_;
   /**
+   *
+   *
    * <pre>
    * The name of the subscription.
    * Structured like:
@@ -886,6 +1012,7 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string name = 1;</code>
+   *
    * @return The name.
    */
   public java.lang.String getName() {
@@ -893,14 +1020,15 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       name_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The name of the subscription.
    * Structured like:
@@ -908,15 +1036,14 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string name = 1;</code>
+   *
    * @return The bytes for name.
    */
-  public com.google.protobuf.ByteString
-      getNameBytes() {
+  public com.google.protobuf.ByteString getNameBytes() {
     java.lang.Object ref = name_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       name_ = b;
       return b;
     } else {
@@ -927,6 +1054,8 @@ private static final long serialVersionUID = 0L;
   public static final int TOPIC_FIELD_NUMBER = 2;
   private volatile java.lang.Object topic_;
   /**
+   *
+   *
    * <pre>
    * The name of the topic this subscription is attached to.
    * Structured like:
@@ -934,6 +1063,7 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string topic = 2 [(.google.api.resource_reference) = { ... }</code>
+   *
    * @return The topic.
    */
   public java.lang.String getTopic() {
@@ -941,14 +1071,15 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       topic_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The name of the topic this subscription is attached to.
    * Structured like:
@@ -956,15 +1087,14 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string topic = 2 [(.google.api.resource_reference) = { ... }</code>
+   *
    * @return The bytes for topic.
    */
-  public com.google.protobuf.ByteString
-      getTopicBytes() {
+  public com.google.protobuf.ByteString getTopicBytes() {
     java.lang.Object ref = topic_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       topic_ = b;
       return b;
     } else {
@@ -975,39 +1105,51 @@ private static final long serialVersionUID = 0L;
   public static final int DELIVERY_CONFIG_FIELD_NUMBER = 3;
   private com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig deliveryConfig_;
   /**
+   *
+   *
    * <pre>
    * The settings for this subscription's message delivery.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig delivery_config = 3;</code>
+   *
    * @return Whether the deliveryConfig field is set.
    */
   public boolean hasDeliveryConfig() {
     return deliveryConfig_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * The settings for this subscription's message delivery.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig delivery_config = 3;</code>
+   *
    * @return The deliveryConfig.
    */
   public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig getDeliveryConfig() {
-    return deliveryConfig_ == null ? com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.getDefaultInstance() : deliveryConfig_;
+    return deliveryConfig_ == null
+        ? com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.getDefaultInstance()
+        : deliveryConfig_;
   }
   /**
+   *
+   *
    * <pre>
    * The settings for this subscription's message delivery.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig delivery_config = 3;</code>
    */
-  public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfigOrBuilder getDeliveryConfigOrBuilder() {
+  public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfigOrBuilder
+      getDeliveryConfigOrBuilder() {
     return getDeliveryConfig();
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -1019,8 +1161,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
@@ -1046,8 +1187,7 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, topic_);
     }
     if (deliveryConfig_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(3, getDeliveryConfig());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(3, getDeliveryConfig());
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -1057,21 +1197,19 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.Subscription)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.Subscription other = (com.google.cloud.pubsublite.proto.Subscription) obj;
+    com.google.cloud.pubsublite.proto.Subscription other =
+        (com.google.cloud.pubsublite.proto.Subscription) obj;
 
-    if (!getName()
-        .equals(other.getName())) return false;
-    if (!getTopic()
-        .equals(other.getTopic())) return false;
+    if (!getName().equals(other.getName())) return false;
+    if (!getTopic().equals(other.getTopic())) return false;
     if (hasDeliveryConfig() != other.hasDeliveryConfig()) return false;
     if (hasDeliveryConfig()) {
-      if (!getDeliveryConfig()
-          .equals(other.getDeliveryConfig())) return false;
+      if (!getDeliveryConfig().equals(other.getDeliveryConfig())) return false;
     }
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
@@ -1097,118 +1235,127 @@ private static final long serialVersionUID = 0L;
     return hash;
   }
 
-  public static com.google.cloud.pubsublite.proto.Subscription parseFrom(
-      java.nio.ByteBuffer data)
+  public static com.google.cloud.pubsublite.proto.Subscription parseFrom(java.nio.ByteBuffer data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.Subscription parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.Subscription parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.Subscription parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.Subscription parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.Subscription parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.Subscription parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.Subscription parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.Subscription parseDelimitedFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.Subscription parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.Subscription parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.Subscription parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.Subscription parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.Subscription prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Metadata about a subscription resource.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.Subscription}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.Subscription)
       com.google.cloud.pubsublite.proto.SubscriptionOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Subscription_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_Subscription_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Subscription_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_Subscription_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.Subscription.class, com.google.cloud.pubsublite.proto.Subscription.Builder.class);
+              com.google.cloud.pubsublite.proto.Subscription.class,
+              com.google.cloud.pubsublite.proto.Subscription.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.Subscription.newBuilder()
@@ -1216,16 +1363,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -1243,9 +1389,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Subscription_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_Subscription_descriptor;
     }
 
     @java.lang.Override
@@ -1264,7 +1410,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.Subscription buildPartial() {
-      com.google.cloud.pubsublite.proto.Subscription result = new com.google.cloud.pubsublite.proto.Subscription(this);
+      com.google.cloud.pubsublite.proto.Subscription result =
+          new com.google.cloud.pubsublite.proto.Subscription(this);
       result.name_ = name_;
       result.topic_ = topic_;
       if (deliveryConfigBuilder_ == null) {
@@ -1280,38 +1427,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.Subscription) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.Subscription)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.Subscription) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -1362,6 +1510,8 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object name_ = "";
     /**
+     *
+     *
      * <pre>
      * The name of the subscription.
      * Structured like:
@@ -1369,13 +1519,13 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string name = 1;</code>
+     *
      * @return The name.
      */
     public java.lang.String getName() {
       java.lang.Object ref = name_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         name_ = s;
         return s;
@@ -1384,6 +1534,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The name of the subscription.
      * Structured like:
@@ -1391,15 +1543,14 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string name = 1;</code>
+     *
      * @return The bytes for name.
      */
-    public com.google.protobuf.ByteString
-        getNameBytes() {
+    public com.google.protobuf.ByteString getNameBytes() {
       java.lang.Object ref = name_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         name_ = b;
         return b;
       } else {
@@ -1407,6 +1558,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The name of the subscription.
      * Structured like:
@@ -1414,20 +1567,22 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string name = 1;</code>
+     *
      * @param value The name to set.
      * @return This builder for chaining.
      */
-    public Builder setName(
-        java.lang.String value) {
+    public Builder setName(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       name_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The name of the subscription.
      * Structured like:
@@ -1435,15 +1590,18 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string name = 1;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearName() {
-      
+
       name_ = getDefaultInstance().getName();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The name of the subscription.
      * Structured like:
@@ -1451,16 +1609,16 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string name = 1;</code>
+     *
      * @param value The bytes for name to set.
      * @return This builder for chaining.
      */
-    public Builder setNameBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setNameBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       name_ = value;
       onChanged();
       return this;
@@ -1468,6 +1626,8 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object topic_ = "";
     /**
+     *
+     *
      * <pre>
      * The name of the topic this subscription is attached to.
      * Structured like:
@@ -1475,13 +1635,13 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string topic = 2 [(.google.api.resource_reference) = { ... }</code>
+     *
      * @return The topic.
      */
     public java.lang.String getTopic() {
       java.lang.Object ref = topic_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         topic_ = s;
         return s;
@@ -1490,6 +1650,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic this subscription is attached to.
      * Structured like:
@@ -1497,15 +1659,14 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string topic = 2 [(.google.api.resource_reference) = { ... }</code>
+     *
      * @return The bytes for topic.
      */
-    public com.google.protobuf.ByteString
-        getTopicBytes() {
+    public com.google.protobuf.ByteString getTopicBytes() {
       java.lang.Object ref = topic_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         topic_ = b;
         return b;
       } else {
@@ -1513,6 +1674,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic this subscription is attached to.
      * Structured like:
@@ -1520,20 +1683,22 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string topic = 2 [(.google.api.resource_reference) = { ... }</code>
+     *
      * @param value The topic to set.
      * @return This builder for chaining.
      */
-    public Builder setTopic(
-        java.lang.String value) {
+    public Builder setTopic(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       topic_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic this subscription is attached to.
      * Structured like:
@@ -1541,15 +1706,18 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string topic = 2 [(.google.api.resource_reference) = { ... }</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearTopic() {
-      
+
       topic_ = getDefaultInstance().getTopic();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic this subscription is attached to.
      * Structured like:
@@ -1557,16 +1725,16 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string topic = 2 [(.google.api.resource_reference) = { ... }</code>
+     *
      * @param value The bytes for topic to set.
      * @return This builder for chaining.
      */
-    public Builder setTopicBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setTopicBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       topic_ = value;
       onChanged();
       return this;
@@ -1574,41 +1742,55 @@ private static final long serialVersionUID = 0L;
 
     private com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig deliveryConfig_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig, com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.Builder, com.google.cloud.pubsublite.proto.Subscription.DeliveryConfigOrBuilder> deliveryConfigBuilder_;
+            com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig,
+            com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.Builder,
+            com.google.cloud.pubsublite.proto.Subscription.DeliveryConfigOrBuilder>
+        deliveryConfigBuilder_;
     /**
+     *
+     *
      * <pre>
      * The settings for this subscription's message delivery.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig delivery_config = 3;</code>
+     *
      * @return Whether the deliveryConfig field is set.
      */
     public boolean hasDeliveryConfig() {
       return deliveryConfigBuilder_ != null || deliveryConfig_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this subscription's message delivery.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig delivery_config = 3;</code>
+     *
      * @return The deliveryConfig.
      */
     public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig getDeliveryConfig() {
       if (deliveryConfigBuilder_ == null) {
-        return deliveryConfig_ == null ? com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.getDefaultInstance() : deliveryConfig_;
+        return deliveryConfig_ == null
+            ? com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.getDefaultInstance()
+            : deliveryConfig_;
       } else {
         return deliveryConfigBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this subscription's message delivery.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig delivery_config = 3;</code>
      */
-    public Builder setDeliveryConfig(com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig value) {
+    public Builder setDeliveryConfig(
+        com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig value) {
       if (deliveryConfigBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
@@ -1622,6 +1804,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this subscription's message delivery.
      * </pre>
@@ -1640,17 +1824,23 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this subscription's message delivery.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig delivery_config = 3;</code>
      */
-    public Builder mergeDeliveryConfig(com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig value) {
+    public Builder mergeDeliveryConfig(
+        com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig value) {
       if (deliveryConfigBuilder_ == null) {
         if (deliveryConfig_ != null) {
           deliveryConfig_ =
-            com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.newBuilder(deliveryConfig_).mergeFrom(value).buildPartial();
+              com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.newBuilder(
+                      deliveryConfig_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           deliveryConfig_ = value;
         }
@@ -1662,6 +1852,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this subscription's message delivery.
      * </pre>
@@ -1680,33 +1872,42 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this subscription's message delivery.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig delivery_config = 3;</code>
      */
-    public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.Builder getDeliveryConfigBuilder() {
-      
+    public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.Builder
+        getDeliveryConfigBuilder() {
+
       onChanged();
       return getDeliveryConfigFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this subscription's message delivery.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig delivery_config = 3;</code>
      */
-    public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfigOrBuilder getDeliveryConfigOrBuilder() {
+    public com.google.cloud.pubsublite.proto.Subscription.DeliveryConfigOrBuilder
+        getDeliveryConfigOrBuilder() {
       if (deliveryConfigBuilder_ != null) {
         return deliveryConfigBuilder_.getMessageOrBuilder();
       } else {
-        return deliveryConfig_ == null ?
-            com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.getDefaultInstance() : deliveryConfig_;
+        return deliveryConfig_ == null
+            ? com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.getDefaultInstance()
+            : deliveryConfig_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this subscription's message delivery.
      * </pre>
@@ -1714,21 +1915,24 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig delivery_config = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig, com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.Builder, com.google.cloud.pubsublite.proto.Subscription.DeliveryConfigOrBuilder> 
+            com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig,
+            com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.Builder,
+            com.google.cloud.pubsublite.proto.Subscription.DeliveryConfigOrBuilder>
         getDeliveryConfigFieldBuilder() {
       if (deliveryConfigBuilder_ == null) {
-        deliveryConfigBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig, com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.Builder, com.google.cloud.pubsublite.proto.Subscription.DeliveryConfigOrBuilder>(
-                getDeliveryConfig(),
-                getParentForChildren(),
-                isClean());
+        deliveryConfigBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig,
+                com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig.Builder,
+                com.google.cloud.pubsublite.proto.Subscription.DeliveryConfigOrBuilder>(
+                getDeliveryConfig(), getParentForChildren(), isClean());
         deliveryConfig_ = null;
       }
       return deliveryConfigBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -1738,12 +1942,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.Subscription)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.Subscription)
   private static final com.google.cloud.pubsublite.proto.Subscription DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.Subscription();
   }
@@ -1752,16 +1956,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<Subscription>
-      PARSER = new com.google.protobuf.AbstractParser<Subscription>() {
-    @java.lang.Override
-    public Subscription parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new Subscription(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<Subscription> PARSER =
+      new com.google.protobuf.AbstractParser<Subscription>() {
+        @java.lang.Override
+        public Subscription parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new Subscription(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<Subscription> parser() {
     return PARSER;
@@ -1776,6 +1980,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.Subscription getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SubscriptionOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/SubscriptionOrBuilder.java
@@ -3,11 +3,14 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface SubscriptionOrBuilder extends
+public interface SubscriptionOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.Subscription)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The name of the subscription.
    * Structured like:
@@ -15,10 +18,13 @@ public interface SubscriptionOrBuilder extends
    * </pre>
    *
    * <code>string name = 1;</code>
+   *
    * @return The name.
    */
   java.lang.String getName();
   /**
+   *
+   *
    * <pre>
    * The name of the subscription.
    * Structured like:
@@ -26,12 +32,14 @@ public interface SubscriptionOrBuilder extends
    * </pre>
    *
    * <code>string name = 1;</code>
+   *
    * @return The bytes for name.
    */
-  com.google.protobuf.ByteString
-      getNameBytes();
+  com.google.protobuf.ByteString getNameBytes();
 
   /**
+   *
+   *
    * <pre>
    * The name of the topic this subscription is attached to.
    * Structured like:
@@ -39,10 +47,13 @@ public interface SubscriptionOrBuilder extends
    * </pre>
    *
    * <code>string topic = 2 [(.google.api.resource_reference) = { ... }</code>
+   *
    * @return The topic.
    */
   java.lang.String getTopic();
   /**
+   *
+   *
    * <pre>
    * The name of the topic this subscription is attached to.
    * Structured like:
@@ -50,35 +61,44 @@ public interface SubscriptionOrBuilder extends
    * </pre>
    *
    * <code>string topic = 2 [(.google.api.resource_reference) = { ... }</code>
+   *
    * @return The bytes for topic.
    */
-  com.google.protobuf.ByteString
-      getTopicBytes();
+  com.google.protobuf.ByteString getTopicBytes();
 
   /**
+   *
+   *
    * <pre>
    * The settings for this subscription's message delivery.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig delivery_config = 3;</code>
+   *
    * @return Whether the deliveryConfig field is set.
    */
   boolean hasDeliveryConfig();
   /**
+   *
+   *
    * <pre>
    * The settings for this subscription's message delivery.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig delivery_config = 3;</code>
+   *
    * @return The deliveryConfig.
    */
   com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig getDeliveryConfig();
   /**
+   *
+   *
    * <pre>
    * The settings for this subscription's message delivery.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Subscription.DeliveryConfig delivery_config = 3;</code>
    */
-  com.google.cloud.pubsublite.proto.Subscription.DeliveryConfigOrBuilder getDeliveryConfigOrBuilder();
+  com.google.cloud.pubsublite.proto.Subscription.DeliveryConfigOrBuilder
+      getDeliveryConfigOrBuilder();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/Topic.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/Topic.java
@@ -4,37 +4,39 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Metadata about a topic resource.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.Topic}
  */
-public  final class Topic extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class Topic extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.Topic)
     TopicOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use Topic.newBuilder() to construct.
   private Topic(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
+
   private Topic() {
     name_ = "";
   }
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new Topic();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private Topic(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -53,85 +55,102 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            java.lang.String s = input.readStringRequireUtf8();
+          case 10:
+            {
+              java.lang.String s = input.readStringRequireUtf8();
 
-            name_ = s;
-            break;
-          }
-          case 18: {
-            com.google.cloud.pubsublite.proto.Topic.PartitionConfig.Builder subBuilder = null;
-            if (partitionConfig_ != null) {
-              subBuilder = partitionConfig_.toBuilder();
+              name_ = s;
+              break;
             }
-            partitionConfig_ = input.readMessage(com.google.cloud.pubsublite.proto.Topic.PartitionConfig.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(partitionConfig_);
-              partitionConfig_ = subBuilder.buildPartial();
-            }
+          case 18:
+            {
+              com.google.cloud.pubsublite.proto.Topic.PartitionConfig.Builder subBuilder = null;
+              if (partitionConfig_ != null) {
+                subBuilder = partitionConfig_.toBuilder();
+              }
+              partitionConfig_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Topic.PartitionConfig.parser(),
+                      extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(partitionConfig_);
+                partitionConfig_ = subBuilder.buildPartial();
+              }
 
-            break;
-          }
-          case 26: {
-            com.google.cloud.pubsublite.proto.Topic.RetentionConfig.Builder subBuilder = null;
-            if (retentionConfig_ != null) {
-              subBuilder = retentionConfig_.toBuilder();
+              break;
             }
-            retentionConfig_ = input.readMessage(com.google.cloud.pubsublite.proto.Topic.RetentionConfig.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(retentionConfig_);
-              retentionConfig_ = subBuilder.buildPartial();
-            }
+          case 26:
+            {
+              com.google.cloud.pubsublite.proto.Topic.RetentionConfig.Builder subBuilder = null;
+              if (retentionConfig_ != null) {
+                subBuilder = retentionConfig_.toBuilder();
+              }
+              retentionConfig_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Topic.RetentionConfig.parser(),
+                      extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(retentionConfig_);
+                retentionConfig_ = subBuilder.buildPartial();
+              }
 
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Topic_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.CommonProto
+        .internal_static_google_cloud_pubsublite_v1_Topic_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Topic_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.CommonProto
+        .internal_static_google_cloud_pubsublite_v1_Topic_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.Topic.class, com.google.cloud.pubsublite.proto.Topic.Builder.class);
+            com.google.cloud.pubsublite.proto.Topic.class,
+            com.google.cloud.pubsublite.proto.Topic.Builder.class);
   }
 
-  public interface PartitionConfigOrBuilder extends
+  public interface PartitionConfigOrBuilder
+      extends
       // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.Topic.PartitionConfig)
       com.google.protobuf.MessageOrBuilder {
 
     /**
+     *
+     *
      * <pre>
      * The number of partitions in the topic. Must be at least 1.
      * </pre>
      *
      * <code>int64 count = 1;</code>
+     *
      * @return The count.
      */
     long getCount();
 
     /**
+     *
+     *
      * <pre>
      * Every partition in the topic is allocated throughput equivalent to
      * `scale` times the standard partition throughput (4 MiB/s). This is also
@@ -141,41 +160,43 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int32 scale = 2;</code>
+     *
      * @return The scale.
      */
     int getScale();
   }
   /**
+   *
+   *
    * <pre>
    * The settings for a topic's partitions.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.Topic.PartitionConfig}
    */
-  public  static final class PartitionConfig extends
-      com.google.protobuf.GeneratedMessageV3 implements
+  public static final class PartitionConfig extends com.google.protobuf.GeneratedMessageV3
+      implements
       // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.Topic.PartitionConfig)
       PartitionConfigOrBuilder {
-  private static final long serialVersionUID = 0L;
+    private static final long serialVersionUID = 0L;
     // Use PartitionConfig.newBuilder() to construct.
     private PartitionConfig(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-    private PartitionConfig() {
-    }
+
+    private PartitionConfig() {}
 
     @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected java.lang.Object newInstance(
-        UnusedPrivateParameter unused) {
+    protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
       return new PartitionConfig();
     }
 
     @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
+    public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
       return this.unknownFields;
     }
+
     private PartitionConfig(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -194,56 +215,61 @@ private static final long serialVersionUID = 0L;
             case 0:
               done = true;
               break;
-            case 8: {
-
-              count_ = input.readInt64();
-              break;
-            }
-            case 16: {
-
-              scale_ = input.readInt32();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
+            case 8:
+              {
+                count_ = input.readInt64();
+                break;
               }
-              break;
-            }
+            case 16:
+              {
+                scale_ = input.readInt32();
+                break;
+              }
+            default:
+              {
+                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
+        throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
     }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_descriptor;
+
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.Topic.PartitionConfig.class, com.google.cloud.pubsublite.proto.Topic.PartitionConfig.Builder.class);
+              com.google.cloud.pubsublite.proto.Topic.PartitionConfig.class,
+              com.google.cloud.pubsublite.proto.Topic.PartitionConfig.Builder.class);
     }
 
     public static final int COUNT_FIELD_NUMBER = 1;
     private long count_;
     /**
+     *
+     *
      * <pre>
      * The number of partitions in the topic. Must be at least 1.
      * </pre>
      *
      * <code>int64 count = 1;</code>
+     *
      * @return The count.
      */
     public long getCount() {
@@ -253,6 +279,8 @@ private static final long serialVersionUID = 0L;
     public static final int SCALE_FIELD_NUMBER = 2;
     private int scale_;
     /**
+     *
+     *
      * <pre>
      * Every partition in the topic is allocated throughput equivalent to
      * `scale` times the standard partition throughput (4 MiB/s). This is also
@@ -262,6 +290,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int32 scale = 2;</code>
+     *
      * @return The scale.
      */
     public int getScale() {
@@ -269,6 +298,7 @@ private static final long serialVersionUID = 0L;
     }
 
     private byte memoizedIsInitialized = -1;
+
     @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -280,8 +310,7 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
+    public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
       if (count_ != 0L) {
         output.writeInt64(1, count_);
       }
@@ -298,12 +327,10 @@ private static final long serialVersionUID = 0L;
 
       size = 0;
       if (count_ != 0L) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(1, count_);
+        size += com.google.protobuf.CodedOutputStream.computeInt64Size(1, count_);
       }
       if (scale_ != 0) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(2, scale_);
+        size += com.google.protobuf.CodedOutputStream.computeInt32Size(2, scale_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -313,17 +340,16 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
-       return true;
+        return true;
       }
       if (!(obj instanceof com.google.cloud.pubsublite.proto.Topic.PartitionConfig)) {
         return super.equals(obj);
       }
-      com.google.cloud.pubsublite.proto.Topic.PartitionConfig other = (com.google.cloud.pubsublite.proto.Topic.PartitionConfig) obj;
+      com.google.cloud.pubsublite.proto.Topic.PartitionConfig other =
+          (com.google.cloud.pubsublite.proto.Topic.PartitionConfig) obj;
 
-      if (getCount()
-          != other.getCount()) return false;
-      if (getScale()
-          != other.getScale()) return false;
+      if (getCount() != other.getCount()) return false;
+      if (getScale() != other.getScale()) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -336,8 +362,7 @@ private static final long serialVersionUID = 0L;
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
       hash = (37 * hash) + COUNT_FIELD_NUMBER;
-      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-          getCount());
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(getCount());
       hash = (37 * hash) + SCALE_FIELD_NUMBER;
       hash = (53 * hash) + getScale();
       hash = (29 * hash) + unknownFields.hashCode();
@@ -346,87 +371,94 @@ private static final long serialVersionUID = 0L;
     }
 
     public static com.google.cloud.pubsublite.proto.Topic.PartitionConfig parseFrom(
-        java.nio.ByteBuffer data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+        java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
+
     public static com.google.cloud.pubsublite.proto.Topic.PartitionConfig parseFrom(
-        java.nio.ByteBuffer data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
+
     public static com.google.cloud.pubsublite.proto.Topic.PartitionConfig parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
+
     public static com.google.cloud.pubsublite.proto.Topic.PartitionConfig parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
+
     public static com.google.cloud.pubsublite.proto.Topic.PartitionConfig parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
+
     public static com.google.cloud.pubsublite.proto.Topic.PartitionConfig parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.cloud.pubsublite.proto.Topic.PartitionConfig parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
-    }
+
     public static com.google.cloud.pubsublite.proto.Topic.PartitionConfig parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
+        java.io.InputStream input) throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
-    public static com.google.cloud.pubsublite.proto.Topic.PartitionConfig parseDelimitedFrom(java.io.InputStream input)
+
+    public static com.google.cloud.pubsublite.proto.Topic.PartitionConfig parseFrom(
+        java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input);
+      return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
     }
+
     public static com.google.cloud.pubsublite.proto.Topic.PartitionConfig parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+        java.io.InputStream input) throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
     }
+
+    public static com.google.cloud.pubsublite.proto.Topic.PartitionConfig parseDelimitedFrom(
+        java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
     public static com.google.cloud.pubsublite.proto.Topic.PartitionConfig parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
+        com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
+
     public static com.google.cloud.pubsublite.proto.Topic.PartitionConfig parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
     }
 
     @java.lang.Override
-    public Builder newBuilderForType() { return newBuilder(); }
+    public Builder newBuilderForType() {
+      return newBuilder();
+    }
+
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(com.google.cloud.pubsublite.proto.Topic.PartitionConfig prototype) {
+
+    public static Builder newBuilder(
+        com.google.cloud.pubsublite.proto.Topic.PartitionConfig prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
+
     @java.lang.Override
     public Builder toBuilder() {
-      return this == DEFAULT_INSTANCE
-          ? new Builder() : new Builder().mergeFrom(this);
+      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
     }
 
     @java.lang.Override
@@ -436,27 +468,32 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for a topic's partitions.
      * </pre>
      *
      * Protobuf type {@code google.cloud.pubsublite.v1.Topic.PartitionConfig}
      */
-    public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+    public static final class Builder
+        extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+        implements
         // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.Topic.PartitionConfig)
         com.google.cloud.pubsublite.proto.Topic.PartitionConfigOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_descriptor;
+      public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+        return com.google.cloud.pubsublite.proto.CommonProto
+            .internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_fieldAccessorTable
+        return com.google.cloud.pubsublite.proto.CommonProto
+            .internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                com.google.cloud.pubsublite.proto.Topic.PartitionConfig.class, com.google.cloud.pubsublite.proto.Topic.PartitionConfig.Builder.class);
+                com.google.cloud.pubsublite.proto.Topic.PartitionConfig.class,
+                com.google.cloud.pubsublite.proto.Topic.PartitionConfig.Builder.class);
       }
 
       // Construct using com.google.cloud.pubsublite.proto.Topic.PartitionConfig.newBuilder()
@@ -464,16 +501,15 @@ private static final long serialVersionUID = 0L;
         maybeForceBuilderInitialization();
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
+
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+        if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
       }
+
       @java.lang.Override
       public Builder clear() {
         super.clear();
@@ -485,9 +521,9 @@ private static final long serialVersionUID = 0L;
       }
 
       @java.lang.Override
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_descriptor;
+      public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+        return com.google.cloud.pubsublite.proto.CommonProto
+            .internal_static_google_cloud_pubsublite_v1_Topic_PartitionConfig_descriptor;
       }
 
       @java.lang.Override
@@ -506,7 +542,8 @@ private static final long serialVersionUID = 0L;
 
       @java.lang.Override
       public com.google.cloud.pubsublite.proto.Topic.PartitionConfig buildPartial() {
-        com.google.cloud.pubsublite.proto.Topic.PartitionConfig result = new com.google.cloud.pubsublite.proto.Topic.PartitionConfig(this);
+        com.google.cloud.pubsublite.proto.Topic.PartitionConfig result =
+            new com.google.cloud.pubsublite.proto.Topic.PartitionConfig(this);
         result.count_ = count_;
         result.scale_ = scale_;
         onBuilt();
@@ -517,38 +554,41 @@ private static final long serialVersionUID = 0L;
       public Builder clone() {
         return super.clone();
       }
+
       @java.lang.Override
       public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
         return super.setField(field, value);
       }
+
       @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
+      public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
+
       @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
+
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
+          int index,
+          java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
+
       @java.lang.Override
       public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
+
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.cloud.pubsublite.proto.Topic.PartitionConfig) {
-          return mergeFrom((com.google.cloud.pubsublite.proto.Topic.PartitionConfig)other);
+          return mergeFrom((com.google.cloud.pubsublite.proto.Topic.PartitionConfig) other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -556,7 +596,8 @@ private static final long serialVersionUID = 0L;
       }
 
       public Builder mergeFrom(com.google.cloud.pubsublite.proto.Topic.PartitionConfig other) {
-        if (other == com.google.cloud.pubsublite.proto.Topic.PartitionConfig.getDefaultInstance()) return this;
+        if (other == com.google.cloud.pubsublite.proto.Topic.PartitionConfig.getDefaultInstance())
+          return this;
         if (other.getCount() != 0L) {
           setCount(other.getCount());
         }
@@ -582,7 +623,8 @@ private static final long serialVersionUID = 0L;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (com.google.cloud.pubsublite.proto.Topic.PartitionConfig) e.getUnfinishedMessage();
+          parsedMessage =
+              (com.google.cloud.pubsublite.proto.Topic.PartitionConfig) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -592,50 +634,61 @@ private static final long serialVersionUID = 0L;
         return this;
       }
 
-      private long count_ ;
+      private long count_;
       /**
+       *
+       *
        * <pre>
        * The number of partitions in the topic. Must be at least 1.
        * </pre>
        *
        * <code>int64 count = 1;</code>
+       *
        * @return The count.
        */
       public long getCount() {
         return count_;
       }
       /**
+       *
+       *
        * <pre>
        * The number of partitions in the topic. Must be at least 1.
        * </pre>
        *
        * <code>int64 count = 1;</code>
+       *
        * @param value The count to set.
        * @return This builder for chaining.
        */
       public Builder setCount(long value) {
-        
+
         count_ = value;
         onChanged();
         return this;
       }
       /**
+       *
+       *
        * <pre>
        * The number of partitions in the topic. Must be at least 1.
        * </pre>
        *
        * <code>int64 count = 1;</code>
+       *
        * @return This builder for chaining.
        */
       public Builder clearCount() {
-        
+
         count_ = 0L;
         onChanged();
         return this;
       }
 
-      private int scale_ ;
+      private int scale_;
       /**
+       *
+       *
        * <pre>
        * Every partition in the topic is allocated throughput equivalent to
        * `scale` times the standard partition throughput (4 MiB/s). This is also
@@ -645,12 +698,15 @@ private static final long serialVersionUID = 0L;
        * </pre>
        *
        * <code>int32 scale = 2;</code>
+       *
        * @return The scale.
        */
       public int getScale() {
         return scale_;
       }
       /**
+       *
+       *
        * <pre>
        * Every partition in the topic is allocated throughput equivalent to
        * `scale` times the standard partition throughput (4 MiB/s). This is also
@@ -660,16 +716,19 @@ private static final long serialVersionUID = 0L;
        * </pre>
        *
        * <code>int32 scale = 2;</code>
+       *
        * @param value The scale to set.
        * @return This builder for chaining.
        */
       public Builder setScale(int value) {
-        
+
         scale_ = value;
         onChanged();
         return this;
       }
       /**
+       *
+       *
        * <pre>
        * Every partition in the topic is allocated throughput equivalent to
        * `scale` times the standard partition throughput (4 MiB/s). This is also
@@ -679,14 +738,16 @@ private static final long serialVersionUID = 0L;
        * </pre>
        *
        * <code>int32 scale = 2;</code>
+       *
        * @return This builder for chaining.
        */
       public Builder clearScale() {
-        
+
         scale_ = 0;
         onChanged();
         return this;
       }
+
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -699,12 +760,12 @@ private static final long serialVersionUID = 0L;
         return super.mergeUnknownFields(unknownFields);
       }
 
-
       // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.Topic.PartitionConfig)
     }
 
     // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.Topic.PartitionConfig)
     private static final com.google.cloud.pubsublite.proto.Topic.PartitionConfig DEFAULT_INSTANCE;
+
     static {
       DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.Topic.PartitionConfig();
     }
@@ -713,16 +774,16 @@ private static final long serialVersionUID = 0L;
       return DEFAULT_INSTANCE;
     }
 
-    private static final com.google.protobuf.Parser<PartitionConfig>
-        PARSER = new com.google.protobuf.AbstractParser<PartitionConfig>() {
-      @java.lang.Override
-      public PartitionConfig parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new PartitionConfig(input, extensionRegistry);
-      }
-    };
+    private static final com.google.protobuf.Parser<PartitionConfig> PARSER =
+        new com.google.protobuf.AbstractParser<PartitionConfig>() {
+          @java.lang.Override
+          public PartitionConfig parsePartialFrom(
+              com.google.protobuf.CodedInputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws com.google.protobuf.InvalidProtocolBufferException {
+            return new PartitionConfig(input, extensionRegistry);
+          }
+        };
 
     public static com.google.protobuf.Parser<PartitionConfig> parser() {
       return PARSER;
@@ -737,14 +798,16 @@ private static final long serialVersionUID = 0L;
     public com.google.cloud.pubsublite.proto.Topic.PartitionConfig getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
-
   }
 
-  public interface RetentionConfigOrBuilder extends
+  public interface RetentionConfigOrBuilder
+      extends
       // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.Topic.RetentionConfig)
       com.google.protobuf.MessageOrBuilder {
 
     /**
+     *
+     *
      * <pre>
      * The provisioned storage, in bytes, per partition. If the number of bytes
      * stored in any of the topic's partitions grows beyond this value, older
@@ -753,11 +816,14 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int64 per_partition_bytes = 1;</code>
+     *
      * @return The perPartitionBytes.
      */
     long getPerPartitionBytes();
 
     /**
+     *
+     *
      * <pre>
      * How long a published message is retained. If unset, messages will be
      * retained as long as the bytes retained for each partition is below
@@ -765,10 +831,13 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.Duration period = 2;</code>
+     *
      * @return Whether the period field is set.
      */
     boolean hasPeriod();
     /**
+     *
+     *
      * <pre>
      * How long a published message is retained. If unset, messages will be
      * retained as long as the bytes retained for each partition is below
@@ -776,10 +845,13 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.Duration period = 2;</code>
+     *
      * @return The period.
      */
     com.google.protobuf.Duration getPeriod();
     /**
+     *
+     *
      * <pre>
      * How long a published message is retained. If unset, messages will be
      * retained as long as the bytes retained for each partition is below
@@ -791,36 +863,37 @@ private static final long serialVersionUID = 0L;
     com.google.protobuf.DurationOrBuilder getPeriodOrBuilder();
   }
   /**
+   *
+   *
    * <pre>
    * The settings for a topic's message retention.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.Topic.RetentionConfig}
    */
-  public  static final class RetentionConfig extends
-      com.google.protobuf.GeneratedMessageV3 implements
+  public static final class RetentionConfig extends com.google.protobuf.GeneratedMessageV3
+      implements
       // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.Topic.RetentionConfig)
       RetentionConfigOrBuilder {
-  private static final long serialVersionUID = 0L;
+    private static final long serialVersionUID = 0L;
     // Use RetentionConfig.newBuilder() to construct.
     private RetentionConfig(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-    private RetentionConfig() {
-    }
+
+    private RetentionConfig() {}
 
     @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected java.lang.Object newInstance(
-        UnusedPrivateParameter unused) {
+    protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
       return new RetentionConfig();
     }
 
     @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
+    public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
       return this.unknownFields;
     }
+
     private RetentionConfig(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -839,59 +912,65 @@ private static final long serialVersionUID = 0L;
             case 0:
               done = true;
               break;
-            case 8: {
+            case 8:
+              {
+                perPartitionBytes_ = input.readInt64();
+                break;
+              }
+            case 18:
+              {
+                com.google.protobuf.Duration.Builder subBuilder = null;
+                if (period_ != null) {
+                  subBuilder = period_.toBuilder();
+                }
+                period_ =
+                    input.readMessage(com.google.protobuf.Duration.parser(), extensionRegistry);
+                if (subBuilder != null) {
+                  subBuilder.mergeFrom(period_);
+                  period_ = subBuilder.buildPartial();
+                }
 
-              perPartitionBytes_ = input.readInt64();
-              break;
-            }
-            case 18: {
-              com.google.protobuf.Duration.Builder subBuilder = null;
-              if (period_ != null) {
-                subBuilder = period_.toBuilder();
+                break;
               }
-              period_ = input.readMessage(com.google.protobuf.Duration.parser(), extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(period_);
-                period_ = subBuilder.buildPartial();
+            default:
+              {
+                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
               }
-
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
+        throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
     }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_descriptor;
+
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.Topic.RetentionConfig.class, com.google.cloud.pubsublite.proto.Topic.RetentionConfig.Builder.class);
+              com.google.cloud.pubsublite.proto.Topic.RetentionConfig.class,
+              com.google.cloud.pubsublite.proto.Topic.RetentionConfig.Builder.class);
     }
 
     public static final int PER_PARTITION_BYTES_FIELD_NUMBER = 1;
     private long perPartitionBytes_;
     /**
+     *
+     *
      * <pre>
      * The provisioned storage, in bytes, per partition. If the number of bytes
      * stored in any of the topic's partitions grows beyond this value, older
@@ -900,6 +979,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>int64 per_partition_bytes = 1;</code>
+     *
      * @return The perPartitionBytes.
      */
     public long getPerPartitionBytes() {
@@ -909,6 +989,8 @@ private static final long serialVersionUID = 0L;
     public static final int PERIOD_FIELD_NUMBER = 2;
     private com.google.protobuf.Duration period_;
     /**
+     *
+     *
      * <pre>
      * How long a published message is retained. If unset, messages will be
      * retained as long as the bytes retained for each partition is below
@@ -916,12 +998,15 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.Duration period = 2;</code>
+     *
      * @return Whether the period field is set.
      */
     public boolean hasPeriod() {
       return period_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * How long a published message is retained. If unset, messages will be
      * retained as long as the bytes retained for each partition is below
@@ -929,12 +1014,15 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.Duration period = 2;</code>
+     *
      * @return The period.
      */
     public com.google.protobuf.Duration getPeriod() {
       return period_ == null ? com.google.protobuf.Duration.getDefaultInstance() : period_;
     }
     /**
+     *
+     *
      * <pre>
      * How long a published message is retained. If unset, messages will be
      * retained as long as the bytes retained for each partition is below
@@ -948,6 +1036,7 @@ private static final long serialVersionUID = 0L;
     }
 
     private byte memoizedIsInitialized = -1;
+
     @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -959,8 +1048,7 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
+    public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
       if (perPartitionBytes_ != 0L) {
         output.writeInt64(1, perPartitionBytes_);
       }
@@ -977,12 +1065,10 @@ private static final long serialVersionUID = 0L;
 
       size = 0;
       if (perPartitionBytes_ != 0L) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(1, perPartitionBytes_);
+        size += com.google.protobuf.CodedOutputStream.computeInt64Size(1, perPartitionBytes_);
       }
       if (period_ != null) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(2, getPeriod());
+        size += com.google.protobuf.CodedOutputStream.computeMessageSize(2, getPeriod());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -992,19 +1078,18 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
-       return true;
+        return true;
       }
       if (!(obj instanceof com.google.cloud.pubsublite.proto.Topic.RetentionConfig)) {
         return super.equals(obj);
       }
-      com.google.cloud.pubsublite.proto.Topic.RetentionConfig other = (com.google.cloud.pubsublite.proto.Topic.RetentionConfig) obj;
+      com.google.cloud.pubsublite.proto.Topic.RetentionConfig other =
+          (com.google.cloud.pubsublite.proto.Topic.RetentionConfig) obj;
 
-      if (getPerPartitionBytes()
-          != other.getPerPartitionBytes()) return false;
+      if (getPerPartitionBytes() != other.getPerPartitionBytes()) return false;
       if (hasPeriod() != other.hasPeriod()) return false;
       if (hasPeriod()) {
-        if (!getPeriod()
-            .equals(other.getPeriod())) return false;
+        if (!getPeriod().equals(other.getPeriod())) return false;
       }
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
@@ -1018,8 +1103,7 @@ private static final long serialVersionUID = 0L;
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
       hash = (37 * hash) + PER_PARTITION_BYTES_FIELD_NUMBER;
-      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-          getPerPartitionBytes());
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(getPerPartitionBytes());
       if (hasPeriod()) {
         hash = (37 * hash) + PERIOD_FIELD_NUMBER;
         hash = (53 * hash) + getPeriod().hashCode();
@@ -1030,87 +1114,94 @@ private static final long serialVersionUID = 0L;
     }
 
     public static com.google.cloud.pubsublite.proto.Topic.RetentionConfig parseFrom(
-        java.nio.ByteBuffer data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
+        java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
+
     public static com.google.cloud.pubsublite.proto.Topic.RetentionConfig parseFrom(
-        java.nio.ByteBuffer data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
+
     public static com.google.cloud.pubsublite.proto.Topic.RetentionConfig parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
+
     public static com.google.cloud.pubsublite.proto.Topic.RetentionConfig parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
+
     public static com.google.cloud.pubsublite.proto.Topic.RetentionConfig parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
+
     public static com.google.cloud.pubsublite.proto.Topic.RetentionConfig parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.cloud.pubsublite.proto.Topic.RetentionConfig parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
-    }
+
     public static com.google.cloud.pubsublite.proto.Topic.RetentionConfig parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
+        java.io.InputStream input) throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
-    public static com.google.cloud.pubsublite.proto.Topic.RetentionConfig parseDelimitedFrom(java.io.InputStream input)
+
+    public static com.google.cloud.pubsublite.proto.Topic.RetentionConfig parseFrom(
+        java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input);
+      return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
     }
+
     public static com.google.cloud.pubsublite.proto.Topic.RetentionConfig parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+        java.io.InputStream input) throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
     }
+
+    public static com.google.cloud.pubsublite.proto.Topic.RetentionConfig parseDelimitedFrom(
+        java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
     public static com.google.cloud.pubsublite.proto.Topic.RetentionConfig parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
+        com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
+
     public static com.google.cloud.pubsublite.proto.Topic.RetentionConfig parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
+      return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
     }
 
     @java.lang.Override
-    public Builder newBuilderForType() { return newBuilder(); }
+    public Builder newBuilderForType() {
+      return newBuilder();
+    }
+
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(com.google.cloud.pubsublite.proto.Topic.RetentionConfig prototype) {
+
+    public static Builder newBuilder(
+        com.google.cloud.pubsublite.proto.Topic.RetentionConfig prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
+
     @java.lang.Override
     public Builder toBuilder() {
-      return this == DEFAULT_INSTANCE
-          ? new Builder() : new Builder().mergeFrom(this);
+      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
     }
 
     @java.lang.Override
@@ -1120,27 +1211,32 @@ private static final long serialVersionUID = 0L;
       return builder;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for a topic's message retention.
      * </pre>
      *
      * Protobuf type {@code google.cloud.pubsublite.v1.Topic.RetentionConfig}
      */
-    public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+    public static final class Builder
+        extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+        implements
         // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.Topic.RetentionConfig)
         com.google.cloud.pubsublite.proto.Topic.RetentionConfigOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_descriptor;
+      public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+        return com.google.cloud.pubsublite.proto.CommonProto
+            .internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_fieldAccessorTable
+        return com.google.cloud.pubsublite.proto.CommonProto
+            .internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                com.google.cloud.pubsublite.proto.Topic.RetentionConfig.class, com.google.cloud.pubsublite.proto.Topic.RetentionConfig.Builder.class);
+                com.google.cloud.pubsublite.proto.Topic.RetentionConfig.class,
+                com.google.cloud.pubsublite.proto.Topic.RetentionConfig.Builder.class);
       }
 
       // Construct using com.google.cloud.pubsublite.proto.Topic.RetentionConfig.newBuilder()
@@ -1148,16 +1244,15 @@ private static final long serialVersionUID = 0L;
         maybeForceBuilderInitialization();
       }
 
-      private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
+
       private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
+        if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
       }
+
       @java.lang.Override
       public Builder clear() {
         super.clear();
@@ -1173,9 +1268,9 @@ private static final long serialVersionUID = 0L;
       }
 
       @java.lang.Override
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_descriptor;
+      public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+        return com.google.cloud.pubsublite.proto.CommonProto
+            .internal_static_google_cloud_pubsublite_v1_Topic_RetentionConfig_descriptor;
       }
 
       @java.lang.Override
@@ -1194,7 +1289,8 @@ private static final long serialVersionUID = 0L;
 
       @java.lang.Override
       public com.google.cloud.pubsublite.proto.Topic.RetentionConfig buildPartial() {
-        com.google.cloud.pubsublite.proto.Topic.RetentionConfig result = new com.google.cloud.pubsublite.proto.Topic.RetentionConfig(this);
+        com.google.cloud.pubsublite.proto.Topic.RetentionConfig result =
+            new com.google.cloud.pubsublite.proto.Topic.RetentionConfig(this);
         result.perPartitionBytes_ = perPartitionBytes_;
         if (periodBuilder_ == null) {
           result.period_ = period_;
@@ -1209,38 +1305,41 @@ private static final long serialVersionUID = 0L;
       public Builder clone() {
         return super.clone();
       }
+
       @java.lang.Override
       public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
         return super.setField(field, value);
       }
+
       @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
+      public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
+
       @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+      public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
+
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
+          int index,
+          java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
+
       @java.lang.Override
       public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
+          com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
+
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof com.google.cloud.pubsublite.proto.Topic.RetentionConfig) {
-          return mergeFrom((com.google.cloud.pubsublite.proto.Topic.RetentionConfig)other);
+          return mergeFrom((com.google.cloud.pubsublite.proto.Topic.RetentionConfig) other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -1248,7 +1347,8 @@ private static final long serialVersionUID = 0L;
       }
 
       public Builder mergeFrom(com.google.cloud.pubsublite.proto.Topic.RetentionConfig other) {
-        if (other == com.google.cloud.pubsublite.proto.Topic.RetentionConfig.getDefaultInstance()) return this;
+        if (other == com.google.cloud.pubsublite.proto.Topic.RetentionConfig.getDefaultInstance())
+          return this;
         if (other.getPerPartitionBytes() != 0L) {
           setPerPartitionBytes(other.getPerPartitionBytes());
         }
@@ -1274,7 +1374,8 @@ private static final long serialVersionUID = 0L;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (com.google.cloud.pubsublite.proto.Topic.RetentionConfig) e.getUnfinishedMessage();
+          parsedMessage =
+              (com.google.cloud.pubsublite.proto.Topic.RetentionConfig) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -1284,8 +1385,10 @@ private static final long serialVersionUID = 0L;
         return this;
       }
 
-      private long perPartitionBytes_ ;
+      private long perPartitionBytes_;
       /**
+       *
+       *
        * <pre>
        * The provisioned storage, in bytes, per partition. If the number of bytes
        * stored in any of the topic's partitions grows beyond this value, older
@@ -1294,12 +1397,15 @@ private static final long serialVersionUID = 0L;
        * </pre>
        *
        * <code>int64 per_partition_bytes = 1;</code>
+       *
        * @return The perPartitionBytes.
        */
       public long getPerPartitionBytes() {
         return perPartitionBytes_;
       }
       /**
+       *
+       *
        * <pre>
        * The provisioned storage, in bytes, per partition. If the number of bytes
        * stored in any of the topic's partitions grows beyond this value, older
@@ -1308,16 +1414,19 @@ private static final long serialVersionUID = 0L;
        * </pre>
        *
        * <code>int64 per_partition_bytes = 1;</code>
+       *
        * @param value The perPartitionBytes to set.
        * @return This builder for chaining.
        */
       public Builder setPerPartitionBytes(long value) {
-        
+
         perPartitionBytes_ = value;
         onChanged();
         return this;
       }
       /**
+       *
+       *
        * <pre>
        * The provisioned storage, in bytes, per partition. If the number of bytes
        * stored in any of the topic's partitions grows beyond this value, older
@@ -1326,10 +1435,11 @@ private static final long serialVersionUID = 0L;
        * </pre>
        *
        * <code>int64 per_partition_bytes = 1;</code>
+       *
        * @return This builder for chaining.
        */
       public Builder clearPerPartitionBytes() {
-        
+
         perPartitionBytes_ = 0L;
         onChanged();
         return this;
@@ -1337,8 +1447,13 @@ private static final long serialVersionUID = 0L;
 
       private com.google.protobuf.Duration period_;
       private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.Duration, com.google.protobuf.Duration.Builder, com.google.protobuf.DurationOrBuilder> periodBuilder_;
+              com.google.protobuf.Duration,
+              com.google.protobuf.Duration.Builder,
+              com.google.protobuf.DurationOrBuilder>
+          periodBuilder_;
       /**
+       *
+       *
        * <pre>
        * How long a published message is retained. If unset, messages will be
        * retained as long as the bytes retained for each partition is below
@@ -1346,12 +1461,15 @@ private static final long serialVersionUID = 0L;
        * </pre>
        *
        * <code>.google.protobuf.Duration period = 2;</code>
+       *
        * @return Whether the period field is set.
        */
       public boolean hasPeriod() {
         return periodBuilder_ != null || period_ != null;
       }
       /**
+       *
+       *
        * <pre>
        * How long a published message is retained. If unset, messages will be
        * retained as long as the bytes retained for each partition is below
@@ -1359,6 +1477,7 @@ private static final long serialVersionUID = 0L;
        * </pre>
        *
        * <code>.google.protobuf.Duration period = 2;</code>
+       *
        * @return The period.
        */
       public com.google.protobuf.Duration getPeriod() {
@@ -1369,6 +1488,8 @@ private static final long serialVersionUID = 0L;
         }
       }
       /**
+       *
+       *
        * <pre>
        * How long a published message is retained. If unset, messages will be
        * retained as long as the bytes retained for each partition is below
@@ -1391,6 +1512,8 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
+       *
+       *
        * <pre>
        * How long a published message is retained. If unset, messages will be
        * retained as long as the bytes retained for each partition is below
@@ -1399,8 +1522,7 @@ private static final long serialVersionUID = 0L;
        *
        * <code>.google.protobuf.Duration period = 2;</code>
        */
-      public Builder setPeriod(
-          com.google.protobuf.Duration.Builder builderForValue) {
+      public Builder setPeriod(com.google.protobuf.Duration.Builder builderForValue) {
         if (periodBuilder_ == null) {
           period_ = builderForValue.build();
           onChanged();
@@ -1411,6 +1533,8 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
+       *
+       *
        * <pre>
        * How long a published message is retained. If unset, messages will be
        * retained as long as the bytes retained for each partition is below
@@ -1423,7 +1547,7 @@ private static final long serialVersionUID = 0L;
         if (periodBuilder_ == null) {
           if (period_ != null) {
             period_ =
-              com.google.protobuf.Duration.newBuilder(period_).mergeFrom(value).buildPartial();
+                com.google.protobuf.Duration.newBuilder(period_).mergeFrom(value).buildPartial();
           } else {
             period_ = value;
           }
@@ -1435,6 +1559,8 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
+       *
+       *
        * <pre>
        * How long a published message is retained. If unset, messages will be
        * retained as long as the bytes retained for each partition is below
@@ -1455,6 +1581,8 @@ private static final long serialVersionUID = 0L;
         return this;
       }
       /**
+       *
+       *
        * <pre>
        * How long a published message is retained. If unset, messages will be
        * retained as long as the bytes retained for each partition is below
@@ -1464,11 +1592,13 @@ private static final long serialVersionUID = 0L;
        * <code>.google.protobuf.Duration period = 2;</code>
        */
       public com.google.protobuf.Duration.Builder getPeriodBuilder() {
-        
+
         onChanged();
         return getPeriodFieldBuilder().getBuilder();
       }
       /**
+       *
+       *
        * <pre>
        * How long a published message is retained. If unset, messages will be
        * retained as long as the bytes retained for each partition is below
@@ -1481,11 +1611,12 @@ private static final long serialVersionUID = 0L;
         if (periodBuilder_ != null) {
           return periodBuilder_.getMessageOrBuilder();
         } else {
-          return period_ == null ?
-              com.google.protobuf.Duration.getDefaultInstance() : period_;
+          return period_ == null ? com.google.protobuf.Duration.getDefaultInstance() : period_;
         }
       }
       /**
+       *
+       *
        * <pre>
        * How long a published message is retained. If unset, messages will be
        * retained as long as the bytes retained for each partition is below
@@ -1495,18 +1626,22 @@ private static final long serialVersionUID = 0L;
        * <code>.google.protobuf.Duration period = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.Duration, com.google.protobuf.Duration.Builder, com.google.protobuf.DurationOrBuilder> 
+              com.google.protobuf.Duration,
+              com.google.protobuf.Duration.Builder,
+              com.google.protobuf.DurationOrBuilder>
           getPeriodFieldBuilder() {
         if (periodBuilder_ == null) {
-          periodBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.Duration, com.google.protobuf.Duration.Builder, com.google.protobuf.DurationOrBuilder>(
-                  getPeriod(),
-                  getParentForChildren(),
-                  isClean());
+          periodBuilder_ =
+              new com.google.protobuf.SingleFieldBuilderV3<
+                  com.google.protobuf.Duration,
+                  com.google.protobuf.Duration.Builder,
+                  com.google.protobuf.DurationOrBuilder>(
+                  getPeriod(), getParentForChildren(), isClean());
           period_ = null;
         }
         return periodBuilder_;
       }
+
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -1519,12 +1654,12 @@ private static final long serialVersionUID = 0L;
         return super.mergeUnknownFields(unknownFields);
       }
 
-
       // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.Topic.RetentionConfig)
     }
 
     // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.Topic.RetentionConfig)
     private static final com.google.cloud.pubsublite.proto.Topic.RetentionConfig DEFAULT_INSTANCE;
+
     static {
       DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.Topic.RetentionConfig();
     }
@@ -1533,16 +1668,16 @@ private static final long serialVersionUID = 0L;
       return DEFAULT_INSTANCE;
     }
 
-    private static final com.google.protobuf.Parser<RetentionConfig>
-        PARSER = new com.google.protobuf.AbstractParser<RetentionConfig>() {
-      @java.lang.Override
-      public RetentionConfig parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new RetentionConfig(input, extensionRegistry);
-      }
-    };
+    private static final com.google.protobuf.Parser<RetentionConfig> PARSER =
+        new com.google.protobuf.AbstractParser<RetentionConfig>() {
+          @java.lang.Override
+          public RetentionConfig parsePartialFrom(
+              com.google.protobuf.CodedInputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws com.google.protobuf.InvalidProtocolBufferException {
+            return new RetentionConfig(input, extensionRegistry);
+          }
+        };
 
     public static com.google.protobuf.Parser<RetentionConfig> parser() {
       return PARSER;
@@ -1557,12 +1692,13 @@ private static final long serialVersionUID = 0L;
     public com.google.cloud.pubsublite.proto.Topic.RetentionConfig getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
-
   }
 
   public static final int NAME_FIELD_NUMBER = 1;
   private volatile java.lang.Object name_;
   /**
+   *
+   *
    * <pre>
    * The name of the topic.
    * Structured like:
@@ -1570,6 +1706,7 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string name = 1;</code>
+   *
    * @return The name.
    */
   public java.lang.String getName() {
@@ -1577,14 +1714,15 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
-          (com.google.protobuf.ByteString) ref;
+      com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       name_ = s;
       return s;
     }
   }
   /**
+   *
+   *
    * <pre>
    * The name of the topic.
    * Structured like:
@@ -1592,15 +1730,14 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string name = 1;</code>
+   *
    * @return The bytes for name.
    */
-  public com.google.protobuf.ByteString
-      getNameBytes() {
+  public com.google.protobuf.ByteString getNameBytes() {
     java.lang.Object ref = name_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
-          com.google.protobuf.ByteString.copyFromUtf8(
-              (java.lang.String) ref);
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
       name_ = b;
       return b;
     } else {
@@ -1611,74 +1748,97 @@ private static final long serialVersionUID = 0L;
   public static final int PARTITION_CONFIG_FIELD_NUMBER = 2;
   private com.google.cloud.pubsublite.proto.Topic.PartitionConfig partitionConfig_;
   /**
+   *
+   *
    * <pre>
    * The settings for this topic's partitions.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Topic.PartitionConfig partition_config = 2;</code>
+   *
    * @return Whether the partitionConfig field is set.
    */
   public boolean hasPartitionConfig() {
     return partitionConfig_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * The settings for this topic's partitions.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Topic.PartitionConfig partition_config = 2;</code>
+   *
    * @return The partitionConfig.
    */
   public com.google.cloud.pubsublite.proto.Topic.PartitionConfig getPartitionConfig() {
-    return partitionConfig_ == null ? com.google.cloud.pubsublite.proto.Topic.PartitionConfig.getDefaultInstance() : partitionConfig_;
+    return partitionConfig_ == null
+        ? com.google.cloud.pubsublite.proto.Topic.PartitionConfig.getDefaultInstance()
+        : partitionConfig_;
   }
   /**
+   *
+   *
    * <pre>
    * The settings for this topic's partitions.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Topic.PartitionConfig partition_config = 2;</code>
    */
-  public com.google.cloud.pubsublite.proto.Topic.PartitionConfigOrBuilder getPartitionConfigOrBuilder() {
+  public com.google.cloud.pubsublite.proto.Topic.PartitionConfigOrBuilder
+      getPartitionConfigOrBuilder() {
     return getPartitionConfig();
   }
 
   public static final int RETENTION_CONFIG_FIELD_NUMBER = 3;
   private com.google.cloud.pubsublite.proto.Topic.RetentionConfig retentionConfig_;
   /**
+   *
+   *
    * <pre>
    * The settings for this topic's message retention.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Topic.RetentionConfig retention_config = 3;</code>
+   *
    * @return Whether the retentionConfig field is set.
    */
   public boolean hasRetentionConfig() {
     return retentionConfig_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * The settings for this topic's message retention.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Topic.RetentionConfig retention_config = 3;</code>
+   *
    * @return The retentionConfig.
    */
   public com.google.cloud.pubsublite.proto.Topic.RetentionConfig getRetentionConfig() {
-    return retentionConfig_ == null ? com.google.cloud.pubsublite.proto.Topic.RetentionConfig.getDefaultInstance() : retentionConfig_;
+    return retentionConfig_ == null
+        ? com.google.cloud.pubsublite.proto.Topic.RetentionConfig.getDefaultInstance()
+        : retentionConfig_;
   }
   /**
+   *
+   *
    * <pre>
    * The settings for this topic's message retention.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Topic.RetentionConfig retention_config = 3;</code>
    */
-  public com.google.cloud.pubsublite.proto.Topic.RetentionConfigOrBuilder getRetentionConfigOrBuilder() {
+  public com.google.cloud.pubsublite.proto.Topic.RetentionConfigOrBuilder
+      getRetentionConfigOrBuilder() {
     return getRetentionConfig();
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -1690,8 +1850,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (!getNameBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
     }
@@ -1714,12 +1873,10 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
     }
     if (partitionConfig_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, getPartitionConfig());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(2, getPartitionConfig());
     }
     if (retentionConfig_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(3, getRetentionConfig());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(3, getRetentionConfig());
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -1729,24 +1886,21 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.Topic)) {
       return super.equals(obj);
     }
     com.google.cloud.pubsublite.proto.Topic other = (com.google.cloud.pubsublite.proto.Topic) obj;
 
-    if (!getName()
-        .equals(other.getName())) return false;
+    if (!getName().equals(other.getName())) return false;
     if (hasPartitionConfig() != other.hasPartitionConfig()) return false;
     if (hasPartitionConfig()) {
-      if (!getPartitionConfig()
-          .equals(other.getPartitionConfig())) return false;
+      if (!getPartitionConfig().equals(other.getPartitionConfig())) return false;
     }
     if (hasRetentionConfig() != other.hasRetentionConfig()) return false;
     if (hasRetentionConfig()) {
-      if (!getRetentionConfig()
-          .equals(other.getRetentionConfig())) return false;
+      if (!getRetentionConfig().equals(other.getRetentionConfig())) return false;
     }
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
@@ -1774,118 +1928,127 @@ private static final long serialVersionUID = 0L;
     return hash;
   }
 
-  public static com.google.cloud.pubsublite.proto.Topic parseFrom(
-      java.nio.ByteBuffer data)
+  public static com.google.cloud.pubsublite.proto.Topic parseFrom(java.nio.ByteBuffer data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.Topic parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.Topic parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.Topic parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.Topic parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.Topic parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.Topic parseFrom(java.io.InputStream input)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.Topic parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.Topic parseDelimitedFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.Topic parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.Topic parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.Topic parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.Topic parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.Topic prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Metadata about a topic resource.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.Topic}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.Topic)
       com.google.cloud.pubsublite.proto.TopicOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Topic_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_Topic_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Topic_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_Topic_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.Topic.class, com.google.cloud.pubsublite.proto.Topic.Builder.class);
+              com.google.cloud.pubsublite.proto.Topic.class,
+              com.google.cloud.pubsublite.proto.Topic.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.Topic.newBuilder()
@@ -1893,16 +2056,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -1924,9 +2086,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.CommonProto.internal_static_google_cloud_pubsublite_v1_Topic_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.CommonProto
+          .internal_static_google_cloud_pubsublite_v1_Topic_descriptor;
     }
 
     @java.lang.Override
@@ -1945,7 +2107,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.Topic buildPartial() {
-      com.google.cloud.pubsublite.proto.Topic result = new com.google.cloud.pubsublite.proto.Topic(this);
+      com.google.cloud.pubsublite.proto.Topic result =
+          new com.google.cloud.pubsublite.proto.Topic(this);
       result.name_ = name_;
       if (partitionConfigBuilder_ == null) {
         result.partitionConfig_ = partitionConfig_;
@@ -1965,38 +2128,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.Topic) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.Topic)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.Topic) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -2046,6 +2210,8 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object name_ = "";
     /**
+     *
+     *
      * <pre>
      * The name of the topic.
      * Structured like:
@@ -2053,13 +2219,13 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string name = 1;</code>
+     *
      * @return The name.
      */
     public java.lang.String getName() {
       java.lang.Object ref = name_;
       if (!(ref instanceof java.lang.String)) {
-        com.google.protobuf.ByteString bs =
-            (com.google.protobuf.ByteString) ref;
+        com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         name_ = s;
         return s;
@@ -2068,6 +2234,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic.
      * Structured like:
@@ -2075,15 +2243,14 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string name = 1;</code>
+     *
      * @return The bytes for name.
      */
-    public com.google.protobuf.ByteString
-        getNameBytes() {
+    public com.google.protobuf.ByteString getNameBytes() {
       java.lang.Object ref = name_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
         name_ = b;
         return b;
       } else {
@@ -2091,6 +2258,8 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic.
      * Structured like:
@@ -2098,20 +2267,22 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string name = 1;</code>
+     *
      * @param value The name to set.
      * @return This builder for chaining.
      */
-    public Builder setName(
-        java.lang.String value) {
+    public Builder setName(java.lang.String value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  
+        throw new NullPointerException();
+      }
+
       name_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic.
      * Structured like:
@@ -2119,15 +2290,18 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string name = 1;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearName() {
-      
+
       name_ = getDefaultInstance().getName();
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The name of the topic.
      * Structured like:
@@ -2135,16 +2309,16 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string name = 1;</code>
+     *
      * @param value The bytes for name to set.
      * @return This builder for chaining.
      */
-    public Builder setNameBytes(
-        com.google.protobuf.ByteString value) {
+    public Builder setNameBytes(com.google.protobuf.ByteString value) {
       if (value == null) {
-    throw new NullPointerException();
-  }
-  checkByteStringIsUtf8(value);
-      
+        throw new NullPointerException();
+      }
+      checkByteStringIsUtf8(value);
+
       name_ = value;
       onChanged();
       return this;
@@ -2152,41 +2326,55 @@ private static final long serialVersionUID = 0L;
 
     private com.google.cloud.pubsublite.proto.Topic.PartitionConfig partitionConfig_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Topic.PartitionConfig, com.google.cloud.pubsublite.proto.Topic.PartitionConfig.Builder, com.google.cloud.pubsublite.proto.Topic.PartitionConfigOrBuilder> partitionConfigBuilder_;
+            com.google.cloud.pubsublite.proto.Topic.PartitionConfig,
+            com.google.cloud.pubsublite.proto.Topic.PartitionConfig.Builder,
+            com.google.cloud.pubsublite.proto.Topic.PartitionConfigOrBuilder>
+        partitionConfigBuilder_;
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's partitions.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Topic.PartitionConfig partition_config = 2;</code>
+     *
      * @return Whether the partitionConfig field is set.
      */
     public boolean hasPartitionConfig() {
       return partitionConfigBuilder_ != null || partitionConfig_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's partitions.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Topic.PartitionConfig partition_config = 2;</code>
+     *
      * @return The partitionConfig.
      */
     public com.google.cloud.pubsublite.proto.Topic.PartitionConfig getPartitionConfig() {
       if (partitionConfigBuilder_ == null) {
-        return partitionConfig_ == null ? com.google.cloud.pubsublite.proto.Topic.PartitionConfig.getDefaultInstance() : partitionConfig_;
+        return partitionConfig_ == null
+            ? com.google.cloud.pubsublite.proto.Topic.PartitionConfig.getDefaultInstance()
+            : partitionConfig_;
       } else {
         return partitionConfigBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's partitions.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Topic.PartitionConfig partition_config = 2;</code>
      */
-    public Builder setPartitionConfig(com.google.cloud.pubsublite.proto.Topic.PartitionConfig value) {
+    public Builder setPartitionConfig(
+        com.google.cloud.pubsublite.proto.Topic.PartitionConfig value) {
       if (partitionConfigBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
@@ -2200,6 +2388,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's partitions.
      * </pre>
@@ -2218,17 +2408,22 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's partitions.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Topic.PartitionConfig partition_config = 2;</code>
      */
-    public Builder mergePartitionConfig(com.google.cloud.pubsublite.proto.Topic.PartitionConfig value) {
+    public Builder mergePartitionConfig(
+        com.google.cloud.pubsublite.proto.Topic.PartitionConfig value) {
       if (partitionConfigBuilder_ == null) {
         if (partitionConfig_ != null) {
           partitionConfig_ =
-            com.google.cloud.pubsublite.proto.Topic.PartitionConfig.newBuilder(partitionConfig_).mergeFrom(value).buildPartial();
+              com.google.cloud.pubsublite.proto.Topic.PartitionConfig.newBuilder(partitionConfig_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           partitionConfig_ = value;
         }
@@ -2240,6 +2435,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's partitions.
      * </pre>
@@ -2258,33 +2455,42 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's partitions.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Topic.PartitionConfig partition_config = 2;</code>
      */
-    public com.google.cloud.pubsublite.proto.Topic.PartitionConfig.Builder getPartitionConfigBuilder() {
-      
+    public com.google.cloud.pubsublite.proto.Topic.PartitionConfig.Builder
+        getPartitionConfigBuilder() {
+
       onChanged();
       return getPartitionConfigFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's partitions.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Topic.PartitionConfig partition_config = 2;</code>
      */
-    public com.google.cloud.pubsublite.proto.Topic.PartitionConfigOrBuilder getPartitionConfigOrBuilder() {
+    public com.google.cloud.pubsublite.proto.Topic.PartitionConfigOrBuilder
+        getPartitionConfigOrBuilder() {
       if (partitionConfigBuilder_ != null) {
         return partitionConfigBuilder_.getMessageOrBuilder();
       } else {
-        return partitionConfig_ == null ?
-            com.google.cloud.pubsublite.proto.Topic.PartitionConfig.getDefaultInstance() : partitionConfig_;
+        return partitionConfig_ == null
+            ? com.google.cloud.pubsublite.proto.Topic.PartitionConfig.getDefaultInstance()
+            : partitionConfig_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's partitions.
      * </pre>
@@ -2292,14 +2498,17 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Topic.PartitionConfig partition_config = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Topic.PartitionConfig, com.google.cloud.pubsublite.proto.Topic.PartitionConfig.Builder, com.google.cloud.pubsublite.proto.Topic.PartitionConfigOrBuilder> 
+            com.google.cloud.pubsublite.proto.Topic.PartitionConfig,
+            com.google.cloud.pubsublite.proto.Topic.PartitionConfig.Builder,
+            com.google.cloud.pubsublite.proto.Topic.PartitionConfigOrBuilder>
         getPartitionConfigFieldBuilder() {
       if (partitionConfigBuilder_ == null) {
-        partitionConfigBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Topic.PartitionConfig, com.google.cloud.pubsublite.proto.Topic.PartitionConfig.Builder, com.google.cloud.pubsublite.proto.Topic.PartitionConfigOrBuilder>(
-                getPartitionConfig(),
-                getParentForChildren(),
-                isClean());
+        partitionConfigBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Topic.PartitionConfig,
+                com.google.cloud.pubsublite.proto.Topic.PartitionConfig.Builder,
+                com.google.cloud.pubsublite.proto.Topic.PartitionConfigOrBuilder>(
+                getPartitionConfig(), getParentForChildren(), isClean());
         partitionConfig_ = null;
       }
       return partitionConfigBuilder_;
@@ -2307,41 +2516,55 @@ private static final long serialVersionUID = 0L;
 
     private com.google.cloud.pubsublite.proto.Topic.RetentionConfig retentionConfig_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Topic.RetentionConfig, com.google.cloud.pubsublite.proto.Topic.RetentionConfig.Builder, com.google.cloud.pubsublite.proto.Topic.RetentionConfigOrBuilder> retentionConfigBuilder_;
+            com.google.cloud.pubsublite.proto.Topic.RetentionConfig,
+            com.google.cloud.pubsublite.proto.Topic.RetentionConfig.Builder,
+            com.google.cloud.pubsublite.proto.Topic.RetentionConfigOrBuilder>
+        retentionConfigBuilder_;
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's message retention.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Topic.RetentionConfig retention_config = 3;</code>
+     *
      * @return Whether the retentionConfig field is set.
      */
     public boolean hasRetentionConfig() {
       return retentionConfigBuilder_ != null || retentionConfig_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's message retention.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Topic.RetentionConfig retention_config = 3;</code>
+     *
      * @return The retentionConfig.
      */
     public com.google.cloud.pubsublite.proto.Topic.RetentionConfig getRetentionConfig() {
       if (retentionConfigBuilder_ == null) {
-        return retentionConfig_ == null ? com.google.cloud.pubsublite.proto.Topic.RetentionConfig.getDefaultInstance() : retentionConfig_;
+        return retentionConfig_ == null
+            ? com.google.cloud.pubsublite.proto.Topic.RetentionConfig.getDefaultInstance()
+            : retentionConfig_;
       } else {
         return retentionConfigBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's message retention.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Topic.RetentionConfig retention_config = 3;</code>
      */
-    public Builder setRetentionConfig(com.google.cloud.pubsublite.proto.Topic.RetentionConfig value) {
+    public Builder setRetentionConfig(
+        com.google.cloud.pubsublite.proto.Topic.RetentionConfig value) {
       if (retentionConfigBuilder_ == null) {
         if (value == null) {
           throw new NullPointerException();
@@ -2355,6 +2578,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's message retention.
      * </pre>
@@ -2373,17 +2598,22 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's message retention.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Topic.RetentionConfig retention_config = 3;</code>
      */
-    public Builder mergeRetentionConfig(com.google.cloud.pubsublite.proto.Topic.RetentionConfig value) {
+    public Builder mergeRetentionConfig(
+        com.google.cloud.pubsublite.proto.Topic.RetentionConfig value) {
       if (retentionConfigBuilder_ == null) {
         if (retentionConfig_ != null) {
           retentionConfig_ =
-            com.google.cloud.pubsublite.proto.Topic.RetentionConfig.newBuilder(retentionConfig_).mergeFrom(value).buildPartial();
+              com.google.cloud.pubsublite.proto.Topic.RetentionConfig.newBuilder(retentionConfig_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           retentionConfig_ = value;
         }
@@ -2395,6 +2625,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's message retention.
      * </pre>
@@ -2413,33 +2645,42 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's message retention.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Topic.RetentionConfig retention_config = 3;</code>
      */
-    public com.google.cloud.pubsublite.proto.Topic.RetentionConfig.Builder getRetentionConfigBuilder() {
-      
+    public com.google.cloud.pubsublite.proto.Topic.RetentionConfig.Builder
+        getRetentionConfigBuilder() {
+
       onChanged();
       return getRetentionConfigFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's message retention.
      * </pre>
      *
      * <code>.google.cloud.pubsublite.v1.Topic.RetentionConfig retention_config = 3;</code>
      */
-    public com.google.cloud.pubsublite.proto.Topic.RetentionConfigOrBuilder getRetentionConfigOrBuilder() {
+    public com.google.cloud.pubsublite.proto.Topic.RetentionConfigOrBuilder
+        getRetentionConfigOrBuilder() {
       if (retentionConfigBuilder_ != null) {
         return retentionConfigBuilder_.getMessageOrBuilder();
       } else {
-        return retentionConfig_ == null ?
-            com.google.cloud.pubsublite.proto.Topic.RetentionConfig.getDefaultInstance() : retentionConfig_;
+        return retentionConfig_ == null
+            ? com.google.cloud.pubsublite.proto.Topic.RetentionConfig.getDefaultInstance()
+            : retentionConfig_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The settings for this topic's message retention.
      * </pre>
@@ -2447,21 +2688,24 @@ private static final long serialVersionUID = 0L;
      * <code>.google.cloud.pubsublite.v1.Topic.RetentionConfig retention_config = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Topic.RetentionConfig, com.google.cloud.pubsublite.proto.Topic.RetentionConfig.Builder, com.google.cloud.pubsublite.proto.Topic.RetentionConfigOrBuilder> 
+            com.google.cloud.pubsublite.proto.Topic.RetentionConfig,
+            com.google.cloud.pubsublite.proto.Topic.RetentionConfig.Builder,
+            com.google.cloud.pubsublite.proto.Topic.RetentionConfigOrBuilder>
         getRetentionConfigFieldBuilder() {
       if (retentionConfigBuilder_ == null) {
-        retentionConfigBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Topic.RetentionConfig, com.google.cloud.pubsublite.proto.Topic.RetentionConfig.Builder, com.google.cloud.pubsublite.proto.Topic.RetentionConfigOrBuilder>(
-                getRetentionConfig(),
-                getParentForChildren(),
-                isClean());
+        retentionConfigBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Topic.RetentionConfig,
+                com.google.cloud.pubsublite.proto.Topic.RetentionConfig.Builder,
+                com.google.cloud.pubsublite.proto.Topic.RetentionConfigOrBuilder>(
+                getRetentionConfig(), getParentForChildren(), isClean());
         retentionConfig_ = null;
       }
       return retentionConfigBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -2471,12 +2715,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.Topic)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.Topic)
   private static final com.google.cloud.pubsublite.proto.Topic DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.Topic();
   }
@@ -2485,16 +2729,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<Topic>
-      PARSER = new com.google.protobuf.AbstractParser<Topic>() {
-    @java.lang.Override
-    public Topic parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new Topic(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<Topic> PARSER =
+      new com.google.protobuf.AbstractParser<Topic>() {
+        @java.lang.Override
+        public Topic parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new Topic(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<Topic> parser() {
     return PARSER;
@@ -2509,6 +2753,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.Topic getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/TopicOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/TopicOrBuilder.java
@@ -3,11 +3,14 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface TopicOrBuilder extends
+public interface TopicOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.Topic)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The name of the topic.
    * Structured like:
@@ -15,10 +18,13 @@ public interface TopicOrBuilder extends
    * </pre>
    *
    * <code>string name = 1;</code>
+   *
    * @return The name.
    */
   java.lang.String getName();
   /**
+   *
+   *
    * <pre>
    * The name of the topic.
    * Structured like:
@@ -26,30 +32,38 @@ public interface TopicOrBuilder extends
    * </pre>
    *
    * <code>string name = 1;</code>
+   *
    * @return The bytes for name.
    */
-  com.google.protobuf.ByteString
-      getNameBytes();
+  com.google.protobuf.ByteString getNameBytes();
 
   /**
+   *
+   *
    * <pre>
    * The settings for this topic's partitions.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Topic.PartitionConfig partition_config = 2;</code>
+   *
    * @return Whether the partitionConfig field is set.
    */
   boolean hasPartitionConfig();
   /**
+   *
+   *
    * <pre>
    * The settings for this topic's partitions.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Topic.PartitionConfig partition_config = 2;</code>
+   *
    * @return The partitionConfig.
    */
   com.google.cloud.pubsublite.proto.Topic.PartitionConfig getPartitionConfig();
   /**
+   *
+   *
    * <pre>
    * The settings for this topic's partitions.
    * </pre>
@@ -59,24 +73,32 @@ public interface TopicOrBuilder extends
   com.google.cloud.pubsublite.proto.Topic.PartitionConfigOrBuilder getPartitionConfigOrBuilder();
 
   /**
+   *
+   *
    * <pre>
    * The settings for this topic's message retention.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Topic.RetentionConfig retention_config = 3;</code>
+   *
    * @return Whether the retentionConfig field is set.
    */
   boolean hasRetentionConfig();
   /**
+   *
+   *
    * <pre>
    * The settings for this topic's message retention.
    * </pre>
    *
    * <code>.google.cloud.pubsublite.v1.Topic.RetentionConfig retention_config = 3;</code>
+   *
    * @return The retentionConfig.
    */
   com.google.cloud.pubsublite.proto.Topic.RetentionConfig getRetentionConfig();
   /**
+   *
+   *
    * <pre>
    * The settings for this topic's message retention.
    * </pre>

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/TopicPartitions.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/TopicPartitions.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Response for GetTopicPartitions.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.TopicPartitions}
  */
-public  final class TopicPartitions extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class TopicPartitions extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.TopicPartitions)
     TopicPartitionsOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use TopicPartitions.newBuilder() to construct.
   private TopicPartitions(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private TopicPartitions() {
-  }
+
+  private TopicPartitions() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new TopicPartitions();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private TopicPartitions(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,51 +53,56 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 8: {
-
-            partitionCount_ = input.readInt64();
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+          case 8:
+            {
+              partitionCount_ = input.readInt64();
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_TopicPartitions_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_TopicPartitions_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_TopicPartitions_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_TopicPartitions_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.TopicPartitions.class, com.google.cloud.pubsublite.proto.TopicPartitions.Builder.class);
+            com.google.cloud.pubsublite.proto.TopicPartitions.class,
+            com.google.cloud.pubsublite.proto.TopicPartitions.Builder.class);
   }
 
   public static final int PARTITION_COUNT_FIELD_NUMBER = 1;
   private long partitionCount_;
   /**
+   *
+   *
    * <pre>
    * The number of partitions in the topic.
    * </pre>
    *
    * <code>int64 partition_count = 1;</code>
+   *
    * @return The partitionCount.
    */
   public long getPartitionCount() {
@@ -104,6 +110,7 @@ private static final long serialVersionUID = 0L;
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -115,8 +122,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (partitionCount_ != 0L) {
       output.writeInt64(1, partitionCount_);
     }
@@ -130,8 +136,7 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (partitionCount_ != 0L) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeInt64Size(1, partitionCount_);
+      size += com.google.protobuf.CodedOutputStream.computeInt64Size(1, partitionCount_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -141,15 +146,15 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.TopicPartitions)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.TopicPartitions other = (com.google.cloud.pubsublite.proto.TopicPartitions) obj;
+    com.google.cloud.pubsublite.proto.TopicPartitions other =
+        (com.google.cloud.pubsublite.proto.TopicPartitions) obj;
 
-    if (getPartitionCount()
-        != other.getPartitionCount()) return false;
+    if (getPartitionCount() != other.getPartitionCount()) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -162,125 +167,133 @@ private static final long serialVersionUID = 0L;
     int hash = 41;
     hash = (19 * hash) + getDescriptor().hashCode();
     hash = (37 * hash) + PARTITION_COUNT_FIELD_NUMBER;
-    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
-        getPartitionCount());
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(getPartitionCount());
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
   }
 
   public static com.google.cloud.pubsublite.proto.TopicPartitions parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.TopicPartitions parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.TopicPartitions parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.TopicPartitions parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.TopicPartitions parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.TopicPartitions parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.TopicPartitions parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.TopicPartitions parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.TopicPartitions parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.TopicPartitions parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.TopicPartitions parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.TopicPartitions parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.TopicPartitions parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.TopicPartitions parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.TopicPartitions prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Response for GetTopicPartitions.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.TopicPartitions}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.TopicPartitions)
       com.google.cloud.pubsublite.proto.TopicPartitionsOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_TopicPartitions_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_TopicPartitions_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_TopicPartitions_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_TopicPartitions_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.TopicPartitions.class, com.google.cloud.pubsublite.proto.TopicPartitions.Builder.class);
+              com.google.cloud.pubsublite.proto.TopicPartitions.class,
+              com.google.cloud.pubsublite.proto.TopicPartitions.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.TopicPartitions.newBuilder()
@@ -288,16 +301,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -307,9 +319,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_TopicPartitions_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_TopicPartitions_descriptor;
     }
 
     @java.lang.Override
@@ -328,7 +340,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.TopicPartitions buildPartial() {
-      com.google.cloud.pubsublite.proto.TopicPartitions result = new com.google.cloud.pubsublite.proto.TopicPartitions(this);
+      com.google.cloud.pubsublite.proto.TopicPartitions result =
+          new com.google.cloud.pubsublite.proto.TopicPartitions(this);
       result.partitionCount_ = partitionCount_;
       onBuilt();
       return result;
@@ -338,38 +351,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.TopicPartitions) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.TopicPartitions)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.TopicPartitions) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -377,7 +391,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.TopicPartitions other) {
-      if (other == com.google.cloud.pubsublite.proto.TopicPartitions.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.TopicPartitions.getDefaultInstance())
+        return this;
       if (other.getPartitionCount() != 0L) {
         setPartitionCount(other.getPartitionCount());
       }
@@ -400,7 +415,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.TopicPartitions) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.TopicPartitions) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -410,50 +426,59 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-    private long partitionCount_ ;
+    private long partitionCount_;
     /**
+     *
+     *
      * <pre>
      * The number of partitions in the topic.
      * </pre>
      *
      * <code>int64 partition_count = 1;</code>
+     *
      * @return The partitionCount.
      */
     public long getPartitionCount() {
       return partitionCount_;
     }
     /**
+     *
+     *
      * <pre>
      * The number of partitions in the topic.
      * </pre>
      *
      * <code>int64 partition_count = 1;</code>
+     *
      * @param value The partitionCount to set.
      * @return This builder for chaining.
      */
     public Builder setPartitionCount(long value) {
-      
+
       partitionCount_ = value;
       onChanged();
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The number of partitions in the topic.
      * </pre>
      *
      * <code>int64 partition_count = 1;</code>
+     *
      * @return This builder for chaining.
      */
     public Builder clearPartitionCount() {
-      
+
       partitionCount_ = 0L;
       onChanged();
       return this;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -463,12 +488,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.TopicPartitions)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.TopicPartitions)
   private static final com.google.cloud.pubsublite.proto.TopicPartitions DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.TopicPartitions();
   }
@@ -477,16 +502,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<TopicPartitions>
-      PARSER = new com.google.protobuf.AbstractParser<TopicPartitions>() {
-    @java.lang.Override
-    public TopicPartitions parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new TopicPartitions(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<TopicPartitions> PARSER =
+      new com.google.protobuf.AbstractParser<TopicPartitions>() {
+        @java.lang.Override
+        public TopicPartitions parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new TopicPartitions(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<TopicPartitions> parser() {
     return PARSER;
@@ -501,6 +526,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.TopicPartitions getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/TopicPartitionsOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/TopicPartitionsOrBuilder.java
@@ -3,16 +3,20 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface TopicPartitionsOrBuilder extends
+public interface TopicPartitionsOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.TopicPartitions)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The number of partitions in the topic.
    * </pre>
    *
    * <code>int64 partition_count = 1;</code>
+   *
    * @return The partitionCount.
    */
   long getPartitionCount();

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/UpdateSubscriptionRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/UpdateSubscriptionRequest.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request for UpdateSubscription.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.UpdateSubscriptionRequest}
  */
-public  final class UpdateSubscriptionRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class UpdateSubscriptionRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.UpdateSubscriptionRequest)
     UpdateSubscriptionRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use UpdateSubscriptionRequest.newBuilder() to construct.
   private UpdateSubscriptionRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private UpdateSubscriptionRequest() {
-  }
+
+  private UpdateSubscriptionRequest() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new UpdateSubscriptionRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private UpdateSubscriptionRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,94 +53,117 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            com.google.cloud.pubsublite.proto.Subscription.Builder subBuilder = null;
-            if (subscription_ != null) {
-              subBuilder = subscription_.toBuilder();
-            }
-            subscription_ = input.readMessage(com.google.cloud.pubsublite.proto.Subscription.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(subscription_);
-              subscription_ = subBuilder.buildPartial();
-            }
+          case 10:
+            {
+              com.google.cloud.pubsublite.proto.Subscription.Builder subBuilder = null;
+              if (subscription_ != null) {
+                subBuilder = subscription_.toBuilder();
+              }
+              subscription_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Subscription.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(subscription_);
+                subscription_ = subBuilder.buildPartial();
+              }
 
-            break;
-          }
-          case 18: {
-            com.google.protobuf.FieldMask.Builder subBuilder = null;
-            if (updateMask_ != null) {
-              subBuilder = updateMask_.toBuilder();
+              break;
             }
-            updateMask_ = input.readMessage(com.google.protobuf.FieldMask.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(updateMask_);
-              updateMask_ = subBuilder.buildPartial();
-            }
+          case 18:
+            {
+              com.google.protobuf.FieldMask.Builder subBuilder = null;
+              if (updateMask_ != null) {
+                subBuilder = updateMask_.toBuilder();
+              }
+              updateMask_ =
+                  input.readMessage(com.google.protobuf.FieldMask.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(updateMask_);
+                updateMask_ = subBuilder.buildPartial();
+              }
 
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest.class, com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest.class,
+            com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest.Builder.class);
   }
 
   public static final int SUBSCRIPTION_FIELD_NUMBER = 1;
   private com.google.cloud.pubsublite.proto.Subscription subscription_;
   /**
+   *
+   *
    * <pre>
    * The subscription to update. Its `name` field must be populated.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>
+   * .google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return Whether the subscription field is set.
    */
   public boolean hasSubscription() {
     return subscription_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * The subscription to update. Its `name` field must be populated.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>
+   * .google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return The subscription.
    */
   public com.google.cloud.pubsublite.proto.Subscription getSubscription() {
-    return subscription_ == null ? com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance() : subscription_;
+    return subscription_ == null
+        ? com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance()
+        : subscription_;
   }
   /**
+   *
+   *
    * <pre>
    * The subscription to update. Its `name` field must be populated.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>
+   * .google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
    */
   public com.google.cloud.pubsublite.proto.SubscriptionOrBuilder getSubscriptionOrBuilder() {
     return getSubscription();
@@ -148,39 +172,51 @@ private static final long serialVersionUID = 0L;
   public static final int UPDATE_MASK_FIELD_NUMBER = 2;
   private com.google.protobuf.FieldMask updateMask_;
   /**
+   *
+   *
    * <pre>
    * A mask specifying the subscription fields to change.
    * </pre>
    *
-   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return Whether the updateMask field is set.
    */
   public boolean hasUpdateMask() {
     return updateMask_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * A mask specifying the subscription fields to change.
    * </pre>
    *
-   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return The updateMask.
    */
   public com.google.protobuf.FieldMask getUpdateMask() {
     return updateMask_ == null ? com.google.protobuf.FieldMask.getDefaultInstance() : updateMask_;
   }
   /**
+   *
+   *
    * <pre>
    * A mask specifying the subscription fields to change.
    * </pre>
    *
-   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
    */
   public com.google.protobuf.FieldMaskOrBuilder getUpdateMaskOrBuilder() {
     return getUpdateMask();
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -192,8 +228,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (subscription_ != null) {
       output.writeMessage(1, getSubscription());
     }
@@ -210,12 +245,10 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (subscription_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, getSubscription());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(1, getSubscription());
     }
     if (updateMask_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, getUpdateMask());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(2, getUpdateMask());
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -225,22 +258,21 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest other = (com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest) obj;
+    com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest other =
+        (com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest) obj;
 
     if (hasSubscription() != other.hasSubscription()) return false;
     if (hasSubscription()) {
-      if (!getSubscription()
-          .equals(other.getSubscription())) return false;
+      if (!getSubscription().equals(other.getSubscription())) return false;
     }
     if (hasUpdateMask() != other.hasUpdateMask()) return false;
     if (hasUpdateMask()) {
-      if (!getUpdateMask()
-          .equals(other.getUpdateMask())) return false;
+      if (!getUpdateMask().equals(other.getUpdateMask())) return false;
     }
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
@@ -267,117 +299,127 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest prototype) {
+
+  public static Builder newBuilder(
+      com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-  }
-  @java.lang.Override
-  public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  @java.lang.Override
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request for UpdateSubscription.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.UpdateSubscriptionRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.UpdateSubscriptionRequest)
       com.google.cloud.pubsublite.proto.UpdateSubscriptionRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest.class, com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest.class,
+              com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest.newBuilder()
@@ -385,16 +427,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -414,9 +455,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_UpdateSubscriptionRequest_descriptor;
     }
 
     @java.lang.Override
@@ -435,7 +476,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest result = new com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest(this);
+      com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest result =
+          new com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest(this);
       if (subscriptionBuilder_ == null) {
         result.subscription_ = subscription_;
       } else {
@@ -454,38 +496,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -493,7 +536,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest.getDefaultInstance())
+        return this;
       if (other.hasSubscription()) {
         mergeSubscription(other.getSubscription());
       }
@@ -519,7 +563,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -531,39 +576,58 @@ private static final long serialVersionUID = 0L;
 
     private com.google.cloud.pubsublite.proto.Subscription subscription_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Subscription, com.google.cloud.pubsublite.proto.Subscription.Builder, com.google.cloud.pubsublite.proto.SubscriptionOrBuilder> subscriptionBuilder_;
+            com.google.cloud.pubsublite.proto.Subscription,
+            com.google.cloud.pubsublite.proto.Subscription.Builder,
+            com.google.cloud.pubsublite.proto.SubscriptionOrBuilder>
+        subscriptionBuilder_;
     /**
+     *
+     *
      * <pre>
      * The subscription to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
+     *
      * @return Whether the subscription field is set.
      */
     public boolean hasSubscription() {
       return subscriptionBuilder_ != null || subscription_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * The subscription to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
+     *
      * @return The subscription.
      */
     public com.google.cloud.pubsublite.proto.Subscription getSubscription() {
       if (subscriptionBuilder_ == null) {
-        return subscription_ == null ? com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance() : subscription_;
+        return subscription_ == null
+            ? com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance()
+            : subscription_;
       } else {
         return subscriptionBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * The subscription to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder setSubscription(com.google.cloud.pubsublite.proto.Subscription value) {
       if (subscriptionBuilder_ == null) {
@@ -579,11 +643,15 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The subscription to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder setSubscription(
         com.google.cloud.pubsublite.proto.Subscription.Builder builderForValue) {
@@ -597,17 +665,23 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The subscription to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder mergeSubscription(com.google.cloud.pubsublite.proto.Subscription value) {
       if (subscriptionBuilder_ == null) {
         if (subscription_ != null) {
           subscription_ =
-            com.google.cloud.pubsublite.proto.Subscription.newBuilder(subscription_).mergeFrom(value).buildPartial();
+              com.google.cloud.pubsublite.proto.Subscription.newBuilder(subscription_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           subscription_ = value;
         }
@@ -619,11 +693,15 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The subscription to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder clearSubscription() {
       if (subscriptionBuilder_ == null) {
@@ -637,48 +715,64 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The subscription to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public com.google.cloud.pubsublite.proto.Subscription.Builder getSubscriptionBuilder() {
-      
+
       onChanged();
       return getSubscriptionFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * The subscription to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public com.google.cloud.pubsublite.proto.SubscriptionOrBuilder getSubscriptionOrBuilder() {
       if (subscriptionBuilder_ != null) {
         return subscriptionBuilder_.getMessageOrBuilder();
       } else {
-        return subscription_ == null ?
-            com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance() : subscription_;
+        return subscription_ == null
+            ? com.google.cloud.pubsublite.proto.Subscription.getDefaultInstance()
+            : subscription_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The subscription to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>
+     * .google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Subscription, com.google.cloud.pubsublite.proto.Subscription.Builder, com.google.cloud.pubsublite.proto.SubscriptionOrBuilder> 
+            com.google.cloud.pubsublite.proto.Subscription,
+            com.google.cloud.pubsublite.proto.Subscription.Builder,
+            com.google.cloud.pubsublite.proto.SubscriptionOrBuilder>
         getSubscriptionFieldBuilder() {
       if (subscriptionBuilder_ == null) {
-        subscriptionBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Subscription, com.google.cloud.pubsublite.proto.Subscription.Builder, com.google.cloud.pubsublite.proto.SubscriptionOrBuilder>(
-                getSubscription(),
-                getParentForChildren(),
-                isClean());
+        subscriptionBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Subscription,
+                com.google.cloud.pubsublite.proto.Subscription.Builder,
+                com.google.cloud.pubsublite.proto.SubscriptionOrBuilder>(
+                getSubscription(), getParentForChildren(), isClean());
         subscription_ = null;
       }
       return subscriptionBuilder_;
@@ -686,39 +780,55 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.FieldMask updateMask_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.FieldMask, com.google.protobuf.FieldMask.Builder, com.google.protobuf.FieldMaskOrBuilder> updateMaskBuilder_;
+            com.google.protobuf.FieldMask,
+            com.google.protobuf.FieldMask.Builder,
+            com.google.protobuf.FieldMaskOrBuilder>
+        updateMaskBuilder_;
     /**
+     *
+     *
      * <pre>
      * A mask specifying the subscription fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
+     *
      * @return Whether the updateMask field is set.
      */
     public boolean hasUpdateMask() {
       return updateMaskBuilder_ != null || updateMask_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * A mask specifying the subscription fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
+     *
      * @return The updateMask.
      */
     public com.google.protobuf.FieldMask getUpdateMask() {
       if (updateMaskBuilder_ == null) {
-        return updateMask_ == null ? com.google.protobuf.FieldMask.getDefaultInstance() : updateMask_;
+        return updateMask_ == null
+            ? com.google.protobuf.FieldMask.getDefaultInstance()
+            : updateMask_;
       } else {
         return updateMaskBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * A mask specifying the subscription fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder setUpdateMask(com.google.protobuf.FieldMask value) {
       if (updateMaskBuilder_ == null) {
@@ -734,14 +844,16 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A mask specifying the subscription fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
-    public Builder setUpdateMask(
-        com.google.protobuf.FieldMask.Builder builderForValue) {
+    public Builder setUpdateMask(com.google.protobuf.FieldMask.Builder builderForValue) {
       if (updateMaskBuilder_ == null) {
         updateMask_ = builderForValue.build();
         onChanged();
@@ -752,17 +864,20 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A mask specifying the subscription fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder mergeUpdateMask(com.google.protobuf.FieldMask value) {
       if (updateMaskBuilder_ == null) {
         if (updateMask_ != null) {
           updateMask_ =
-            com.google.protobuf.FieldMask.newBuilder(updateMask_).mergeFrom(value).buildPartial();
+              com.google.protobuf.FieldMask.newBuilder(updateMask_).mergeFrom(value).buildPartial();
         } else {
           updateMask_ = value;
         }
@@ -774,11 +889,14 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A mask specifying the subscription fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder clearUpdateMask() {
       if (updateMaskBuilder_ == null) {
@@ -792,55 +910,68 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A mask specifying the subscription fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public com.google.protobuf.FieldMask.Builder getUpdateMaskBuilder() {
-      
+
       onChanged();
       return getUpdateMaskFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * A mask specifying the subscription fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public com.google.protobuf.FieldMaskOrBuilder getUpdateMaskOrBuilder() {
       if (updateMaskBuilder_ != null) {
         return updateMaskBuilder_.getMessageOrBuilder();
       } else {
-        return updateMask_ == null ?
-            com.google.protobuf.FieldMask.getDefaultInstance() : updateMask_;
+        return updateMask_ == null
+            ? com.google.protobuf.FieldMask.getDefaultInstance()
+            : updateMask_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A mask specifying the subscription fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.FieldMask, com.google.protobuf.FieldMask.Builder, com.google.protobuf.FieldMaskOrBuilder> 
+            com.google.protobuf.FieldMask,
+            com.google.protobuf.FieldMask.Builder,
+            com.google.protobuf.FieldMaskOrBuilder>
         getUpdateMaskFieldBuilder() {
       if (updateMaskBuilder_ == null) {
-        updateMaskBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.protobuf.FieldMask, com.google.protobuf.FieldMask.Builder, com.google.protobuf.FieldMaskOrBuilder>(
-                getUpdateMask(),
-                getParentForChildren(),
-                isClean());
+        updateMaskBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.protobuf.FieldMask,
+                com.google.protobuf.FieldMask.Builder,
+                com.google.protobuf.FieldMaskOrBuilder>(
+                getUpdateMask(), getParentForChildren(), isClean());
         updateMask_ = null;
       }
       return updateMaskBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -850,12 +981,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.UpdateSubscriptionRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.UpdateSubscriptionRequest)
   private static final com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest();
   }
@@ -864,16 +995,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<UpdateSubscriptionRequest>
-      PARSER = new com.google.protobuf.AbstractParser<UpdateSubscriptionRequest>() {
-    @java.lang.Override
-    public UpdateSubscriptionRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new UpdateSubscriptionRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<UpdateSubscriptionRequest> PARSER =
+      new com.google.protobuf.AbstractParser<UpdateSubscriptionRequest>() {
+        @java.lang.Override
+        public UpdateSubscriptionRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new UpdateSubscriptionRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<UpdateSubscriptionRequest> parser() {
     return PARSER;
@@ -888,6 +1019,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.UpdateSubscriptionRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/UpdateSubscriptionRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/UpdateSubscriptionRequestOrBuilder.java
@@ -3,61 +3,87 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface UpdateSubscriptionRequestOrBuilder extends
+public interface UpdateSubscriptionRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.UpdateSubscriptionRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The subscription to update. Its `name` field must be populated.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>
+   * .google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return Whether the subscription field is set.
    */
   boolean hasSubscription();
   /**
+   *
+   *
    * <pre>
    * The subscription to update. Its `name` field must be populated.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>
+   * .google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return The subscription.
    */
   com.google.cloud.pubsublite.proto.Subscription getSubscription();
   /**
+   *
+   *
    * <pre>
    * The subscription to update. Its `name` field must be populated.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>
+   * .google.cloud.pubsublite.v1.Subscription subscription = 1 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
    */
   com.google.cloud.pubsublite.proto.SubscriptionOrBuilder getSubscriptionOrBuilder();
 
   /**
+   *
+   *
    * <pre>
    * A mask specifying the subscription fields to change.
    * </pre>
    *
-   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return Whether the updateMask field is set.
    */
   boolean hasUpdateMask();
   /**
+   *
+   *
    * <pre>
    * A mask specifying the subscription fields to change.
    * </pre>
    *
-   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return The updateMask.
    */
   com.google.protobuf.FieldMask getUpdateMask();
   /**
+   *
+   *
    * <pre>
    * A mask specifying the subscription fields to change.
    * </pre>
    *
-   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
    */
   com.google.protobuf.FieldMaskOrBuilder getUpdateMaskOrBuilder();
 }

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/UpdateTopicRequest.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/UpdateTopicRequest.java
@@ -4,36 +4,37 @@
 package com.google.cloud.pubsublite.proto;
 
 /**
+ *
+ *
  * <pre>
  * Request for UpdateTopic.
  * </pre>
  *
  * Protobuf type {@code google.cloud.pubsublite.v1.UpdateTopicRequest}
  */
-public  final class UpdateTopicRequest extends
-    com.google.protobuf.GeneratedMessageV3 implements
+public final class UpdateTopicRequest extends com.google.protobuf.GeneratedMessageV3
+    implements
     // @@protoc_insertion_point(message_implements:google.cloud.pubsublite.v1.UpdateTopicRequest)
     UpdateTopicRequestOrBuilder {
-private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   // Use UpdateTopicRequest.newBuilder() to construct.
   private UpdateTopicRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private UpdateTopicRequest() {
-  }
+
+  private UpdateTopicRequest() {}
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
-  protected java.lang.Object newInstance(
-      UnusedPrivateParameter unused) {
+  protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
     return new UpdateTopicRequest();
   }
 
   @java.lang.Override
-  public final com.google.protobuf.UnknownFieldSet
-  getUnknownFields() {
+  public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
     return this.unknownFields;
   }
+
   private UpdateTopicRequest(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -52,94 +53,112 @@ private static final long serialVersionUID = 0L;
           case 0:
             done = true;
             break;
-          case 10: {
-            com.google.cloud.pubsublite.proto.Topic.Builder subBuilder = null;
-            if (topic_ != null) {
-              subBuilder = topic_.toBuilder();
-            }
-            topic_ = input.readMessage(com.google.cloud.pubsublite.proto.Topic.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(topic_);
-              topic_ = subBuilder.buildPartial();
-            }
+          case 10:
+            {
+              com.google.cloud.pubsublite.proto.Topic.Builder subBuilder = null;
+              if (topic_ != null) {
+                subBuilder = topic_.toBuilder();
+              }
+              topic_ =
+                  input.readMessage(
+                      com.google.cloud.pubsublite.proto.Topic.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(topic_);
+                topic_ = subBuilder.buildPartial();
+              }
 
-            break;
-          }
-          case 18: {
-            com.google.protobuf.FieldMask.Builder subBuilder = null;
-            if (updateMask_ != null) {
-              subBuilder = updateMask_.toBuilder();
+              break;
             }
-            updateMask_ = input.readMessage(com.google.protobuf.FieldMask.parser(), extensionRegistry);
-            if (subBuilder != null) {
-              subBuilder.mergeFrom(updateMask_);
-              updateMask_ = subBuilder.buildPartial();
-            }
+          case 18:
+            {
+              com.google.protobuf.FieldMask.Builder subBuilder = null;
+              if (updateMask_ != null) {
+                subBuilder = updateMask_.toBuilder();
+              }
+              updateMask_ =
+                  input.readMessage(com.google.protobuf.FieldMask.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(updateMask_);
+                updateMask_ = subBuilder.buildPartial();
+              }
 
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
+              break;
             }
-            break;
-          }
+          default:
+            {
+              if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
         }
       }
     } catch (com.google.protobuf.InvalidProtocolBufferException e) {
       throw e.setUnfinishedMessage(this);
     } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
+      throw new com.google.protobuf.InvalidProtocolBufferException(e).setUnfinishedMessage(this);
     } finally {
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
   }
-  public static final com.google.protobuf.Descriptors.Descriptor
-      getDescriptor() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_descriptor;
+
+  public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_fieldAccessorTable
+    return com.google.cloud.pubsublite.proto.AdminProto
+        .internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            com.google.cloud.pubsublite.proto.UpdateTopicRequest.class, com.google.cloud.pubsublite.proto.UpdateTopicRequest.Builder.class);
+            com.google.cloud.pubsublite.proto.UpdateTopicRequest.class,
+            com.google.cloud.pubsublite.proto.UpdateTopicRequest.Builder.class);
   }
 
   public static final int TOPIC_FIELD_NUMBER = 1;
   private com.google.cloud.pubsublite.proto.Topic topic_;
   /**
+   *
+   *
    * <pre>
    * The topic to update. Its `name` field must be populated.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return Whether the topic field is set.
    */
   public boolean hasTopic() {
     return topic_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * The topic to update. Its `name` field must be populated.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return The topic.
    */
   public com.google.cloud.pubsublite.proto.Topic getTopic() {
     return topic_ == null ? com.google.cloud.pubsublite.proto.Topic.getDefaultInstance() : topic_;
   }
   /**
+   *
+   *
    * <pre>
    * The topic to update. Its `name` field must be populated.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
    */
   public com.google.cloud.pubsublite.proto.TopicOrBuilder getTopicOrBuilder() {
     return getTopic();
@@ -148,39 +167,51 @@ private static final long serialVersionUID = 0L;
   public static final int UPDATE_MASK_FIELD_NUMBER = 2;
   private com.google.protobuf.FieldMask updateMask_;
   /**
+   *
+   *
    * <pre>
    * A mask specifying the topic fields to change.
    * </pre>
    *
-   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return Whether the updateMask field is set.
    */
   public boolean hasUpdateMask() {
     return updateMask_ != null;
   }
   /**
+   *
+   *
    * <pre>
    * A mask specifying the topic fields to change.
    * </pre>
    *
-   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return The updateMask.
    */
   public com.google.protobuf.FieldMask getUpdateMask() {
     return updateMask_ == null ? com.google.protobuf.FieldMask.getDefaultInstance() : updateMask_;
   }
   /**
+   *
+   *
    * <pre>
    * A mask specifying the topic fields to change.
    * </pre>
    *
-   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
    */
   public com.google.protobuf.FieldMaskOrBuilder getUpdateMaskOrBuilder() {
     return getUpdateMask();
   }
 
   private byte memoizedIsInitialized = -1;
+
   @java.lang.Override
   public final boolean isInitialized() {
     byte isInitialized = memoizedIsInitialized;
@@ -192,8 +223,7 @@ private static final long serialVersionUID = 0L;
   }
 
   @java.lang.Override
-  public void writeTo(com.google.protobuf.CodedOutputStream output)
-                      throws java.io.IOException {
+  public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
     if (topic_ != null) {
       output.writeMessage(1, getTopic());
     }
@@ -210,12 +240,10 @@ private static final long serialVersionUID = 0L;
 
     size = 0;
     if (topic_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(1, getTopic());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(1, getTopic());
     }
     if (updateMask_ != null) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeMessageSize(2, getUpdateMask());
+      size += com.google.protobuf.CodedOutputStream.computeMessageSize(2, getUpdateMask());
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -225,22 +253,21 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public boolean equals(final java.lang.Object obj) {
     if (obj == this) {
-     return true;
+      return true;
     }
     if (!(obj instanceof com.google.cloud.pubsublite.proto.UpdateTopicRequest)) {
       return super.equals(obj);
     }
-    com.google.cloud.pubsublite.proto.UpdateTopicRequest other = (com.google.cloud.pubsublite.proto.UpdateTopicRequest) obj;
+    com.google.cloud.pubsublite.proto.UpdateTopicRequest other =
+        (com.google.cloud.pubsublite.proto.UpdateTopicRequest) obj;
 
     if (hasTopic() != other.hasTopic()) return false;
     if (hasTopic()) {
-      if (!getTopic()
-          .equals(other.getTopic())) return false;
+      if (!getTopic().equals(other.getTopic())) return false;
     }
     if (hasUpdateMask() != other.hasUpdateMask()) return false;
     if (hasUpdateMask()) {
-      if (!getUpdateMask()
-          .equals(other.getUpdateMask())) return false;
+      if (!getUpdateMask().equals(other.getUpdateMask())) return false;
     }
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
@@ -267,117 +294,126 @@ private static final long serialVersionUID = 0L;
   }
 
   public static com.google.cloud.pubsublite.proto.UpdateTopicRequest parseFrom(
-      java.nio.ByteBuffer data)
-      throws com.google.protobuf.InvalidProtocolBufferException {
+      java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.UpdateTopicRequest parseFrom(
-      java.nio.ByteBuffer data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.UpdateTopicRequest parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.UpdateTopicRequest parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.UpdateTopicRequest parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
+
   public static com.google.cloud.pubsublite.proto.UpdateTopicRequest parseFrom(
-      byte[] data,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static com.google.cloud.pubsublite.proto.UpdateTopicRequest parseFrom(java.io.InputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
-  }
+
   public static com.google.cloud.pubsublite.proto.UpdateTopicRequest parseFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
-  public static com.google.cloud.pubsublite.proto.UpdateTopicRequest parseDelimitedFrom(java.io.InputStream input)
+
+  public static com.google.cloud.pubsublite.proto.UpdateTopicRequest parseFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
+
   public static com.google.cloud.pubsublite.proto.UpdateTopicRequest parseDelimitedFrom(
-      java.io.InputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      java.io.InputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
   }
+
+  public static com.google.cloud.pubsublite.proto.UpdateTopicRequest parseDelimitedFrom(
+      java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+      throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+        PARSER, input, extensionRegistry);
+  }
+
   public static com.google.cloud.pubsublite.proto.UpdateTopicRequest parseFrom(
-      com.google.protobuf.CodedInputStream input)
-      throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input);
+      com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
   }
+
   public static com.google.cloud.pubsublite.proto.UpdateTopicRequest parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
-    return com.google.protobuf.GeneratedMessageV3
-        .parseWithIOException(PARSER, input, extensionRegistry);
+    return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+        PARSER, input, extensionRegistry);
   }
 
   @java.lang.Override
-  public Builder newBuilderForType() { return newBuilder(); }
+  public Builder newBuilderForType() {
+    return newBuilder();
+  }
+
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
+
   public static Builder newBuilder(com.google.cloud.pubsublite.proto.UpdateTopicRequest prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
+
   @java.lang.Override
   public Builder toBuilder() {
-    return this == DEFAULT_INSTANCE
-        ? new Builder() : new Builder().mergeFrom(this);
+    return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
   }
 
   @java.lang.Override
-  protected Builder newBuilderForType(
-      com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+  protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
     Builder builder = new Builder(parent);
     return builder;
   }
   /**
+   *
+   *
    * <pre>
    * Request for UpdateTopic.
    * </pre>
    *
    * Protobuf type {@code google.cloud.pubsublite.v1.UpdateTopicRequest}
    */
-  public static final class Builder extends
-      com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+  public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+      implements
       // @@protoc_insertion_point(builder_implements:google.cloud.pubsublite.v1.UpdateTopicRequest)
       com.google.cloud.pubsublite.proto.UpdateTopicRequestOrBuilder {
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_descriptor;
+    public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_fieldAccessorTable
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.cloud.pubsublite.proto.UpdateTopicRequest.class, com.google.cloud.pubsublite.proto.UpdateTopicRequest.Builder.class);
+              com.google.cloud.pubsublite.proto.UpdateTopicRequest.class,
+              com.google.cloud.pubsublite.proto.UpdateTopicRequest.Builder.class);
     }
 
     // Construct using com.google.cloud.pubsublite.proto.UpdateTopicRequest.newBuilder()
@@ -385,16 +421,15 @@ private static final long serialVersionUID = 0L;
       maybeForceBuilderInitialization();
     }
 
-    private Builder(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+    private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
       maybeForceBuilderInitialization();
     }
+
     private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+      if (com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders) {}
     }
+
     @java.lang.Override
     public Builder clear() {
       super.clear();
@@ -414,9 +449,9 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Descriptors.Descriptor
-        getDescriptorForType() {
-      return com.google.cloud.pubsublite.proto.AdminProto.internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_descriptor;
+    public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      return com.google.cloud.pubsublite.proto.AdminProto
+          .internal_static_google_cloud_pubsublite_v1_UpdateTopicRequest_descriptor;
     }
 
     @java.lang.Override
@@ -435,7 +470,8 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.cloud.pubsublite.proto.UpdateTopicRequest buildPartial() {
-      com.google.cloud.pubsublite.proto.UpdateTopicRequest result = new com.google.cloud.pubsublite.proto.UpdateTopicRequest(this);
+      com.google.cloud.pubsublite.proto.UpdateTopicRequest result =
+          new com.google.cloud.pubsublite.proto.UpdateTopicRequest(this);
       if (topicBuilder_ == null) {
         result.topic_ = topic_;
       } else {
@@ -454,38 +490,39 @@ private static final long serialVersionUID = 0L;
     public Builder clone() {
       return super.clone();
     }
+
     @java.lang.Override
     public Builder setField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.setField(field, value);
     }
+
     @java.lang.Override
-    public Builder clearField(
-        com.google.protobuf.Descriptors.FieldDescriptor field) {
+    public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
       return super.clearField(field);
     }
+
     @java.lang.Override
-    public Builder clearOneof(
-        com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+    public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
       return super.clearOneof(oneof);
     }
+
     @java.lang.Override
     public Builder setRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        int index, java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, int index, java.lang.Object value) {
       return super.setRepeatedField(field, index, value);
     }
+
     @java.lang.Override
     public Builder addRepeatedField(
-        com.google.protobuf.Descriptors.FieldDescriptor field,
-        java.lang.Object value) {
+        com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
       return super.addRepeatedField(field, value);
     }
+
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
       if (other instanceof com.google.cloud.pubsublite.proto.UpdateTopicRequest) {
-        return mergeFrom((com.google.cloud.pubsublite.proto.UpdateTopicRequest)other);
+        return mergeFrom((com.google.cloud.pubsublite.proto.UpdateTopicRequest) other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -493,7 +530,8 @@ private static final long serialVersionUID = 0L;
     }
 
     public Builder mergeFrom(com.google.cloud.pubsublite.proto.UpdateTopicRequest other) {
-      if (other == com.google.cloud.pubsublite.proto.UpdateTopicRequest.getDefaultInstance()) return this;
+      if (other == com.google.cloud.pubsublite.proto.UpdateTopicRequest.getDefaultInstance())
+        return this;
       if (other.hasTopic()) {
         mergeTopic(other.getTopic());
       }
@@ -519,7 +557,8 @@ private static final long serialVersionUID = 0L;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (com.google.cloud.pubsublite.proto.UpdateTopicRequest) e.getUnfinishedMessage();
+        parsedMessage =
+            (com.google.cloud.pubsublite.proto.UpdateTopicRequest) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -531,39 +570,55 @@ private static final long serialVersionUID = 0L;
 
     private com.google.cloud.pubsublite.proto.Topic topic_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Topic, com.google.cloud.pubsublite.proto.Topic.Builder, com.google.cloud.pubsublite.proto.TopicOrBuilder> topicBuilder_;
+            com.google.cloud.pubsublite.proto.Topic,
+            com.google.cloud.pubsublite.proto.Topic.Builder,
+            com.google.cloud.pubsublite.proto.TopicOrBuilder>
+        topicBuilder_;
     /**
+     *
+     *
      * <pre>
      * The topic to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
+     *
      * @return Whether the topic field is set.
      */
     public boolean hasTopic() {
       return topicBuilder_ != null || topic_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * The topic to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
+     *
      * @return The topic.
      */
     public com.google.cloud.pubsublite.proto.Topic getTopic() {
       if (topicBuilder_ == null) {
-        return topic_ == null ? com.google.cloud.pubsublite.proto.Topic.getDefaultInstance() : topic_;
+        return topic_ == null
+            ? com.google.cloud.pubsublite.proto.Topic.getDefaultInstance()
+            : topic_;
       } else {
         return topicBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * The topic to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder setTopic(com.google.cloud.pubsublite.proto.Topic value) {
       if (topicBuilder_ == null) {
@@ -579,14 +634,16 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The topic to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
-    public Builder setTopic(
-        com.google.cloud.pubsublite.proto.Topic.Builder builderForValue) {
+    public Builder setTopic(com.google.cloud.pubsublite.proto.Topic.Builder builderForValue) {
       if (topicBuilder_ == null) {
         topic_ = builderForValue.build();
         onChanged();
@@ -597,17 +654,22 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The topic to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder mergeTopic(com.google.cloud.pubsublite.proto.Topic value) {
       if (topicBuilder_ == null) {
         if (topic_ != null) {
           topic_ =
-            com.google.cloud.pubsublite.proto.Topic.newBuilder(topic_).mergeFrom(value).buildPartial();
+              com.google.cloud.pubsublite.proto.Topic.newBuilder(topic_)
+                  .mergeFrom(value)
+                  .buildPartial();
         } else {
           topic_ = value;
         }
@@ -619,11 +681,14 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The topic to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder clearTopic() {
       if (topicBuilder_ == null) {
@@ -637,48 +702,61 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * The topic to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public com.google.cloud.pubsublite.proto.Topic.Builder getTopicBuilder() {
-      
+
       onChanged();
       return getTopicFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * The topic to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public com.google.cloud.pubsublite.proto.TopicOrBuilder getTopicOrBuilder() {
       if (topicBuilder_ != null) {
         return topicBuilder_.getMessageOrBuilder();
       } else {
-        return topic_ == null ?
-            com.google.cloud.pubsublite.proto.Topic.getDefaultInstance() : topic_;
+        return topic_ == null
+            ? com.google.cloud.pubsublite.proto.Topic.getDefaultInstance()
+            : topic_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * The topic to update. Its `name` field must be populated.
      * </pre>
      *
-     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.cloud.pubsublite.proto.Topic, com.google.cloud.pubsublite.proto.Topic.Builder, com.google.cloud.pubsublite.proto.TopicOrBuilder> 
+            com.google.cloud.pubsublite.proto.Topic,
+            com.google.cloud.pubsublite.proto.Topic.Builder,
+            com.google.cloud.pubsublite.proto.TopicOrBuilder>
         getTopicFieldBuilder() {
       if (topicBuilder_ == null) {
-        topicBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.cloud.pubsublite.proto.Topic, com.google.cloud.pubsublite.proto.Topic.Builder, com.google.cloud.pubsublite.proto.TopicOrBuilder>(
-                getTopic(),
-                getParentForChildren(),
-                isClean());
+        topicBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.cloud.pubsublite.proto.Topic,
+                com.google.cloud.pubsublite.proto.Topic.Builder,
+                com.google.cloud.pubsublite.proto.TopicOrBuilder>(
+                getTopic(), getParentForChildren(), isClean());
         topic_ = null;
       }
       return topicBuilder_;
@@ -686,39 +764,55 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.FieldMask updateMask_;
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.FieldMask, com.google.protobuf.FieldMask.Builder, com.google.protobuf.FieldMaskOrBuilder> updateMaskBuilder_;
+            com.google.protobuf.FieldMask,
+            com.google.protobuf.FieldMask.Builder,
+            com.google.protobuf.FieldMaskOrBuilder>
+        updateMaskBuilder_;
     /**
+     *
+     *
      * <pre>
      * A mask specifying the topic fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
+     *
      * @return Whether the updateMask field is set.
      */
     public boolean hasUpdateMask() {
       return updateMaskBuilder_ != null || updateMask_ != null;
     }
     /**
+     *
+     *
      * <pre>
      * A mask specifying the topic fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
+     *
      * @return The updateMask.
      */
     public com.google.protobuf.FieldMask getUpdateMask() {
       if (updateMaskBuilder_ == null) {
-        return updateMask_ == null ? com.google.protobuf.FieldMask.getDefaultInstance() : updateMask_;
+        return updateMask_ == null
+            ? com.google.protobuf.FieldMask.getDefaultInstance()
+            : updateMask_;
       } else {
         return updateMaskBuilder_.getMessage();
       }
     }
     /**
+     *
+     *
      * <pre>
      * A mask specifying the topic fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder setUpdateMask(com.google.protobuf.FieldMask value) {
       if (updateMaskBuilder_ == null) {
@@ -734,14 +828,16 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A mask specifying the topic fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
-    public Builder setUpdateMask(
-        com.google.protobuf.FieldMask.Builder builderForValue) {
+    public Builder setUpdateMask(com.google.protobuf.FieldMask.Builder builderForValue) {
       if (updateMaskBuilder_ == null) {
         updateMask_ = builderForValue.build();
         onChanged();
@@ -752,17 +848,20 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A mask specifying the topic fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder mergeUpdateMask(com.google.protobuf.FieldMask value) {
       if (updateMaskBuilder_ == null) {
         if (updateMask_ != null) {
           updateMask_ =
-            com.google.protobuf.FieldMask.newBuilder(updateMask_).mergeFrom(value).buildPartial();
+              com.google.protobuf.FieldMask.newBuilder(updateMask_).mergeFrom(value).buildPartial();
         } else {
           updateMask_ = value;
         }
@@ -774,11 +873,14 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A mask specifying the topic fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public Builder clearUpdateMask() {
       if (updateMaskBuilder_ == null) {
@@ -792,55 +894,68 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     *
+     *
      * <pre>
      * A mask specifying the topic fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public com.google.protobuf.FieldMask.Builder getUpdateMaskBuilder() {
-      
+
       onChanged();
       return getUpdateMaskFieldBuilder().getBuilder();
     }
     /**
+     *
+     *
      * <pre>
      * A mask specifying the topic fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     public com.google.protobuf.FieldMaskOrBuilder getUpdateMaskOrBuilder() {
       if (updateMaskBuilder_ != null) {
         return updateMaskBuilder_.getMessageOrBuilder();
       } else {
-        return updateMask_ == null ?
-            com.google.protobuf.FieldMask.getDefaultInstance() : updateMask_;
+        return updateMask_ == null
+            ? com.google.protobuf.FieldMask.getDefaultInstance()
+            : updateMask_;
       }
     }
     /**
+     *
+     *
      * <pre>
      * A mask specifying the topic fields to change.
      * </pre>
      *
-     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+     * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+     * </code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.FieldMask, com.google.protobuf.FieldMask.Builder, com.google.protobuf.FieldMaskOrBuilder> 
+            com.google.protobuf.FieldMask,
+            com.google.protobuf.FieldMask.Builder,
+            com.google.protobuf.FieldMaskOrBuilder>
         getUpdateMaskFieldBuilder() {
       if (updateMaskBuilder_ == null) {
-        updateMaskBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.protobuf.FieldMask, com.google.protobuf.FieldMask.Builder, com.google.protobuf.FieldMaskOrBuilder>(
-                getUpdateMask(),
-                getParentForChildren(),
-                isClean());
+        updateMaskBuilder_ =
+            new com.google.protobuf.SingleFieldBuilderV3<
+                com.google.protobuf.FieldMask,
+                com.google.protobuf.FieldMask.Builder,
+                com.google.protobuf.FieldMaskOrBuilder>(
+                getUpdateMask(), getParentForChildren(), isClean());
         updateMask_ = null;
       }
       return updateMaskBuilder_;
     }
+
     @java.lang.Override
-    public final Builder setUnknownFields(
-        final com.google.protobuf.UnknownFieldSet unknownFields) {
+    public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
       return super.setUnknownFields(unknownFields);
     }
 
@@ -850,12 +965,12 @@ private static final long serialVersionUID = 0L;
       return super.mergeUnknownFields(unknownFields);
     }
 
-
     // @@protoc_insertion_point(builder_scope:google.cloud.pubsublite.v1.UpdateTopicRequest)
   }
 
   // @@protoc_insertion_point(class_scope:google.cloud.pubsublite.v1.UpdateTopicRequest)
   private static final com.google.cloud.pubsublite.proto.UpdateTopicRequest DEFAULT_INSTANCE;
+
   static {
     DEFAULT_INSTANCE = new com.google.cloud.pubsublite.proto.UpdateTopicRequest();
   }
@@ -864,16 +979,16 @@ private static final long serialVersionUID = 0L;
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<UpdateTopicRequest>
-      PARSER = new com.google.protobuf.AbstractParser<UpdateTopicRequest>() {
-    @java.lang.Override
-    public UpdateTopicRequest parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return new UpdateTopicRequest(input, extensionRegistry);
-    }
-  };
+  private static final com.google.protobuf.Parser<UpdateTopicRequest> PARSER =
+      new com.google.protobuf.AbstractParser<UpdateTopicRequest>() {
+        @java.lang.Override
+        public UpdateTopicRequest parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new UpdateTopicRequest(input, extensionRegistry);
+        }
+      };
 
   public static com.google.protobuf.Parser<UpdateTopicRequest> parser() {
     return PARSER;
@@ -888,6 +1003,4 @@ private static final long serialVersionUID = 0L;
   public com.google.cloud.pubsublite.proto.UpdateTopicRequest getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
-
 }
-

--- a/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/UpdateTopicRequestOrBuilder.java
+++ b/proto-google-cloud-pubsublite-v1/src/main/java/com/google/cloud/pubsublite/proto/UpdateTopicRequestOrBuilder.java
@@ -3,61 +3,84 @@
 
 package com.google.cloud.pubsublite.proto;
 
-public interface UpdateTopicRequestOrBuilder extends
+public interface UpdateTopicRequestOrBuilder
+    extends
     // @@protoc_insertion_point(interface_extends:google.cloud.pubsublite.v1.UpdateTopicRequest)
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   *
+   *
    * <pre>
    * The topic to update. Its `name` field must be populated.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return Whether the topic field is set.
    */
   boolean hasTopic();
   /**
+   *
+   *
    * <pre>
    * The topic to update. Its `name` field must be populated.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return The topic.
    */
   com.google.cloud.pubsublite.proto.Topic getTopic();
   /**
+   *
+   *
    * <pre>
    * The topic to update. Its `name` field must be populated.
    * </pre>
    *
-   * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.cloud.pubsublite.v1.Topic topic = 1 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
    */
   com.google.cloud.pubsublite.proto.TopicOrBuilder getTopicOrBuilder();
 
   /**
+   *
+   *
    * <pre>
    * A mask specifying the topic fields to change.
    * </pre>
    *
-   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return Whether the updateMask field is set.
    */
   boolean hasUpdateMask();
   /**
+   *
+   *
    * <pre>
    * A mask specifying the topic fields to change.
    * </pre>
    *
-   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
+   *
    * @return The updateMask.
    */
   com.google.protobuf.FieldMask getUpdateMask();
   /**
+   *
+   *
    * <pre>
    * A mask specifying the topic fields to change.
    * </pre>
    *
-   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];</code>
+   * <code>.google.protobuf.FieldMask update_mask = 2 [(.google.api.field_behavior) = REQUIRED];
+   * </code>
    */
   com.google.protobuf.FieldMaskOrBuilder getUpdateMaskOrBuilder();
 }


### PR DESCRIPTION
Fixes "Kokoro - Test: Code Format" test failure. Ran `mvn com.coveo:fmt-maven-plugin:format`.

Kokoro - CI seems stuck. Kokoro - Test: Java8 and Kokoro - Test: Integration both failed because of `com.google.cloud.pubsublite.beam.PubsubLiteSinkTest`. Other libraries have migrated to using GitHub Actions for all three plus Kokoro - Test: Java 11 and a few more.