### PR TITLE
fix: keep track of internal seek

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberImpl.java
@@ -143,6 +143,7 @@ public class SubscriberImpl extends ProxyService
       checkState(!inFlightSeek.isPresent(), "Seeked while seek is already in flight.");
       SettableApiFuture<Offset> future = SettableApiFuture.create();
       inFlightSeek = Optional.of(new InFlightSeek(request, future));
+      tokenCounter.onClientSeek();
       connection.modifyConnection(
           connectedSubscriber ->
               connectedSubscriber.ifPresent(subscriber -> subscriber.seek(request)));

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberImpl.java
@@ -134,7 +134,7 @@ public class SubscriberImpl extends ProxyService
             new Monitor.Guard(monitor.monitor) {
               @Override
               public boolean isSatisfied() {
-                return !internalSeekInFlight;
+                return !internalSeekInFlight || shutdown;
               }
             })) {
       checkArgument(

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/TokenCounter.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/TokenCounter.java
@@ -50,6 +50,11 @@ class TokenCounter {
     messages -= received.size();
   }
 
+  void onClientSeek() {
+    bytes = 0;
+    messages = 0;
+  }
+
   Optional<FlowControlRequest> requestForRestart() {
     if (bytes == 0 && messages == 0) return Optional.empty();
     return Optional.of(

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/SubscriberImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/SubscriberImplTest.java
@@ -229,9 +229,7 @@ public class SubscriberImplTest {
   public void reinitialize_resendsInFlightSeek() {
     Offset offset = Offset.of(1);
     SeekRequest seekRequest =
-        SeekRequest.newBuilder()
-            .setCursor(Cursor.newBuilder().setOffset(offset.value()))
-            .build();
+        SeekRequest.newBuilder().setCursor(Cursor.newBuilder().setOffset(offset.value())).build();
     ApiFuture<Offset> future = subscriber.seek(seekRequest);
     assertThat(subscriber.seekInFlight()).isTrue();
 
@@ -254,10 +252,8 @@ public class SubscriberImplTest {
     verify(mockMessageConsumer).accept(messages);
 
     subscriber.triggerReinitialize();
-    verify(mockConnectedSubscriber).seek(
-        SeekRequest.newBuilder()
-            .setCursor(Cursor.newBuilder().setOffset(2))
-            .build());
+    verify(mockConnectedSubscriber)
+        .seek(SeekRequest.newBuilder().setCursor(Cursor.newBuilder().setOffset(2)).build());
     assertThat(subscriber.seekInFlight()).isFalse();
     leakedResponseObserver.onNext(Response.ofSeekOffset(Offset.of(2)));
   }


### PR DESCRIPTION
If a seek is inFlight and a stream is retried, retrying the inFlight seek.

If an internal seek is in flight, and a client initiates a seek, block until the internal seek completes.