### PR TITLE
fix: use appropriate x-version-update tag

### DIFF
--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -48,11 +48,13 @@
       <version>0.1.7-SNAPSHOT</version>
     </dependency>
     <!-- {x-version-update-end} -->
+    <!-- {x-version-update-start:google-cloud-pubsublite:released} -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
       <version>1.105.0</version>
     </dependency>
+    <!-- {x-version-update-end} -->
 
     <!-- A logging dependency used by the underlying library  -->
     <dependency>

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -48,7 +48,7 @@
       <version>0.1.7-SNAPSHOT</version>
     </dependency>
     <!-- {x-version-update-end} -->
-    <!-- {x-version-update-start:google-cloud-pubsublite:released} -->
+    <!-- {x-version-update-start:google-cloud-pubsub:released} -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -42,6 +42,7 @@
 
   <dependencies>
     <!-- {x-version-update-start:google-cloud-pubsublite:released} -->
+    <!-- {x-version-update-start:google-cloud-pubsub:released} -->
     <!-- [START pubsublite_install_without_bom] -->
     <!-- [START pubsublite_java_dependencies] -->
     <dependency>
@@ -63,6 +64,7 @@
     </dependency>
     <!-- [END pubsublite_java_dependencies] -->
     <!-- [END pubsublite_install_without_bom] -->
+    <!-- {x-version-update-end} -->
     <!-- {x-version-update-end} -->
 
     <dependency>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -41,6 +41,7 @@
   </properties>
 
   <dependencies>
+    <!-- {x-version-update-start:google-cloud-pubsublite:released} -->
     <!-- [START pubsublite_install_without_bom] -->
     <!-- [START pubsublite_java_dependencies] -->
     <dependency>
@@ -62,6 +63,7 @@
     </dependency>
     <!-- [END pubsublite_java_dependencies] -->
     <!-- [END pubsublite_install_without_bom] -->
+    <!-- {x-version-update-end} -->
 
     <dependency>
       <groupId>junit</groupId>

--- a/versions.txt
+++ b/versions.txt
@@ -2,3 +2,4 @@
 # module:released-version:current-version
 
 google-cloud-pubsublite:0.1.6:0.1.7-SNAPSHOT
+google-cloud-pubsub:1.106.0


### PR DESCRIPTION
Add `<!-- {x-version-update-start} -->` and `<!-- {x-version-update-end} -->` in places where they were missed. 

This is probably the reason versions weren't updated in samples POM and the reason autosynth couldn't update README.

---
Renovate bot is supposed to update samples POM. Why is it not?