### PR TITLE
samples: update lib version

### DIFF
--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
-      <version>1.105.0</version>
+      <version>1.106.0</version>
     </dependency>
 
     <!-- A logging dependency used by the underlying library  -->

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -46,12 +46,12 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsublite</artifactId>
-      <version>0.1.5</version>
+      <version>0.1.6</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
-      <version>1.105.0</version>
+      <version>1.106.0</version>
     </dependency>
     <!-- A logging dependency used by the underlying library  -->
     <dependency>


### PR DESCRIPTION
Manually update library versions in snippets and snapshot pom because Renovate Bot isn't updating them. 

Autosynth should trigger README update today or tomorrow. 