### PR TITLE
samples: add post-preview samples and reformat

### DIFF
--- a/samples/snippets/src/main/java/pubsublite/DeleteSubscriptionExample.java
+++ b/samples/snippets/src/main/java/pubsublite/DeleteSubscriptionExample.java
@@ -17,7 +17,6 @@
 package pubsublite;
 
 // [START pubsublite_delete_subscription]
-
 import com.google.cloud.pubsublite.AdminClient;
 import com.google.cloud.pubsublite.AdminClientSettings;
 import com.google.cloud.pubsublite.CloudRegion;
@@ -26,52 +25,36 @@ import com.google.cloud.pubsublite.ProjectNumber;
 import com.google.cloud.pubsublite.SubscriptionName;
 import com.google.cloud.pubsublite.SubscriptionPath;
 import com.google.cloud.pubsublite.SubscriptionPaths;
-import io.grpc.StatusException;
 
 public class DeleteSubscriptionExample {
 
   public static void main(String... args) throws Exception {
     // TODO(developer): Replace these variables before running the sample.
-    String CLOUD_REGION = "Your Cloud Region";
-    char ZONE_ID = 'b';
-    long PROJECT_NUMBER = Long.parseLong("123456789");
-    String SUBSCRIPTION_NAME = "Your Subscription Name";
+    String cloudRegion = "your-cloud-region";
+    char zoneId = 'b';
+    // Choose an existing subscription.
+    String subscriptionId = "your-subscription-id";
+    long projectNumber = Long.parseLong("123456789");
 
-    DeleteSubscriptionExample.deleteSubscriptionExample(
-        CLOUD_REGION, ZONE_ID, PROJECT_NUMBER, SUBSCRIPTION_NAME);
+    deleteSubscriptionExample(cloudRegion, zoneId, projectNumber, subscriptionId);
   }
 
   public static void deleteSubscriptionExample(
-      String CLOUD_REGION, char ZONE_ID, long PROJECT_NUMBER, String SUBSCRIPTION_NAME)
-      throws Exception {
+      String cloudRegion, char zoneId, long projectNumber, String subscriptionId) throws Exception {
 
-    try {
-      CloudRegion cloudRegion = CloudRegion.of(CLOUD_REGION);
-      CloudZone zone = CloudZone.of(cloudRegion, ZONE_ID);
-      ProjectNumber projectNum = ProjectNumber.of(PROJECT_NUMBER);
-      SubscriptionName subscriptionName = SubscriptionName.of(SUBSCRIPTION_NAME);
+    SubscriptionPath subscriptionPath =
+        SubscriptionPaths.newBuilder()
+            .setZone(CloudZone.of(CloudRegion.of(cloudRegion), zoneId))
+            .setProjectNumber(ProjectNumber.of(projectNumber))
+            .setSubscriptionName(SubscriptionName.of(subscriptionId))
+            .build();
 
-      SubscriptionPath subscriptionPath =
-          SubscriptionPaths.newBuilder()
-              .setZone(zone)
-              .setProjectNumber(projectNum)
-              .setSubscriptionName(subscriptionName)
-              .build();
+    AdminClientSettings adminClientSettings =
+        AdminClientSettings.newBuilder().setRegion(CloudRegion.of(cloudRegion)).build();
 
-      AdminClientSettings adminClientSettings =
-          AdminClientSettings.newBuilder().setRegion(cloudRegion).build();
-
-      try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
-
-        adminClient.deleteSubscription(subscriptionPath).get();
-
-        System.out.println(subscriptionPath.value() + " deleted successfully.");
-      }
-    } catch (StatusException statusException) {
-      System.out.println("Failed to delete the subscription: " + statusException);
-      System.out.println(statusException.getStatus().getCode());
-      System.out.println(statusException.getStatus());
-      throw statusException;
+    try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
+      adminClient.deleteSubscription(subscriptionPath).get();
+      System.out.println(subscriptionPath.value() + " deleted successfully.");
     }
   }
 }

--- a/samples/snippets/src/main/java/pubsublite/DeleteTopicExample.java
+++ b/samples/snippets/src/main/java/pubsublite/DeleteTopicExample.java
@@ -17,7 +17,6 @@
 package pubsublite;
 
 // [START pubsublite_delete_topic]
-
 import com.google.cloud.pubsublite.AdminClient;
 import com.google.cloud.pubsublite.AdminClientSettings;
 import com.google.cloud.pubsublite.CloudRegion;
@@ -26,50 +25,35 @@ import com.google.cloud.pubsublite.ProjectNumber;
 import com.google.cloud.pubsublite.TopicName;
 import com.google.cloud.pubsublite.TopicPath;
 import com.google.cloud.pubsublite.TopicPaths;
-import io.grpc.StatusException;
 
 public class DeleteTopicExample {
 
   public static void main(String... args) throws Exception {
     // TODO(developer): Replace these variables before running the sample.
-    String CLOUD_REGION = "Your Cloud Region";
-    char ZONE_ID = 'b';
-    String TOPIC_NAME = "Your Topic Name";
-    long PROJECT_NUMBER = Long.parseLong("123456789");
+    String cloudRegion = "your-cloud-region";
+    char zoneId = 'b';
+    // Choose an existing topic.
+    String topicId = "your-topic-id";
+    long projectNumber = Long.parseLong("123456789");
 
-    DeleteTopicExample.deleteTopicExample(CLOUD_REGION, ZONE_ID, PROJECT_NUMBER, TOPIC_NAME);
+    deleteTopicExample(cloudRegion, zoneId, projectNumber, topicId);
   }
 
   public static void deleteTopicExample(
-      String CLOUD_REGION, char ZONE_ID, long PROJECT_NUMBER, String TOPIC_NAME) throws Exception {
+      String cloudRegion, char zoneId, long projectNumber, String topicId) throws Exception {
+    TopicPath topicPath =
+        TopicPaths.newBuilder()
+            .setProjectNumber(ProjectNumber.of(projectNumber))
+            .setZone(CloudZone.of(CloudRegion.of(cloudRegion), zoneId))
+            .setTopicName(TopicName.of(topicId))
+            .build();
 
-    try {
-      CloudRegion cloudRegion = CloudRegion.of(CLOUD_REGION);
-      CloudZone zone = CloudZone.of(cloudRegion, ZONE_ID);
-      ProjectNumber projectNum = ProjectNumber.of(PROJECT_NUMBER);
-      TopicName topicName = TopicName.of(TOPIC_NAME);
+    AdminClientSettings adminClientSettings =
+        AdminClientSettings.newBuilder().setRegion(CloudRegion.of(cloudRegion)).build();
 
-      TopicPath topicPath =
-          TopicPaths.newBuilder()
-              .setZone(zone)
-              .setProjectNumber(projectNum)
-              .setTopicName(topicName)
-              .build();
-
-      AdminClientSettings adminClientSettings =
-          AdminClientSettings.newBuilder().setRegion(cloudRegion).build();
-
-      try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
-        adminClient.deleteTopic(topicPath).get();
-
-        System.out.println(topicPath.value() + " deleted successfully.");
-      }
-
-    } catch (StatusException statusException) {
-      System.out.println("Failed to delete the topic: " + statusException);
-      System.out.println(statusException.getStatus().getCode());
-      System.out.println(statusException.getStatus());
-      throw statusException;
+    try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
+      adminClient.deleteTopic(topicPath).get();
+      System.out.println(topicPath.value() + " deleted successfully.");
     }
   }
 } // [END pubsublite_delete_topic]

--- a/samples/snippets/src/main/java/pubsublite/GetSubscriptionExample.java
+++ b/samples/snippets/src/main/java/pubsublite/GetSubscriptionExample.java
@@ -17,7 +17,6 @@
 package pubsublite;
 
 // [START pubsublite_get_subscription]
-
 import com.google.cloud.pubsublite.AdminClient;
 import com.google.cloud.pubsublite.AdminClientSettings;
 import com.google.cloud.pubsublite.CloudRegion;
@@ -27,53 +26,36 @@ import com.google.cloud.pubsublite.SubscriptionName;
 import com.google.cloud.pubsublite.SubscriptionPath;
 import com.google.cloud.pubsublite.SubscriptionPaths;
 import com.google.cloud.pubsublite.proto.Subscription;
-import io.grpc.StatusException;
 
 public class GetSubscriptionExample {
 
   public static void main(String... args) throws Exception {
     // TODO(developer): Replace these variables before running the sample.
-    String CLOUD_REGION = "Your Cloud Region";
-    char ZONE_ID = 'b';
-    long PROJECT_NUMBER = Long.parseLong("123456789");
-    String SUBSCRIPTION_NAME = "Your Lite Subscription Name";
+    String cloudRegion = "your-cloud-region";
+    char zoneId = 'b';
+    // Choose an existing subscription.
+    String subscriptionId = "your-subscription-id";
+    long projectNumber = Long.parseLong("123456789");
 
-    GetSubscriptionExample.getSubscriptionExample(
-        CLOUD_REGION, ZONE_ID, PROJECT_NUMBER, SUBSCRIPTION_NAME);
+    getSubscriptionExample(cloudRegion, zoneId, projectNumber, subscriptionId);
   }
 
   public static void getSubscriptionExample(
-      String CLOUD_REGION, char ZONE_ID, long PROJECT_NUMBER, String SUBSCRIPTION_NAME)
-      throws Exception {
+      String cloudRegion, char zoneId, long projectNumber, String subscriptionId) throws Exception {
 
-    try {
-      CloudRegion cloudRegion = CloudRegion.of(CLOUD_REGION);
-      CloudZone zone = CloudZone.of(cloudRegion, ZONE_ID);
-      ProjectNumber projectNum = ProjectNumber.of(PROJECT_NUMBER);
-      SubscriptionName subscriptionName = SubscriptionName.of(SUBSCRIPTION_NAME);
+    SubscriptionPath subscriptionPath =
+        SubscriptionPaths.newBuilder()
+            .setZone(CloudZone.of(CloudRegion.of(cloudRegion), zoneId))
+            .setProjectNumber(ProjectNumber.of(projectNumber))
+            .setSubscriptionName(SubscriptionName.of(subscriptionId))
+            .build();
 
-      SubscriptionPath subscriptionPath =
-          SubscriptionPaths.newBuilder()
-              .setZone(zone)
-              .setProjectNumber(projectNum)
-              .setSubscriptionName(subscriptionName)
-              .build();
+    AdminClientSettings adminClientSettings =
+        AdminClientSettings.newBuilder().setRegion(CloudRegion.of(cloudRegion)).build();
 
-      AdminClientSettings adminClientSettings =
-          AdminClientSettings.newBuilder().setRegion(cloudRegion).build();
-
-      try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
-
-        Subscription subscription = adminClient.getSubscription(subscriptionPath).get();
-
-        System.out.println("Subscription: " + subscription.getAllFields());
-      }
-
-    } catch (StatusException statusException) {
-      System.out.println("Failed to get the subscription: " + statusException);
-      System.out.println(statusException.getStatus().getCode());
-      System.out.println(statusException.getStatus());
-      throw statusException;
+    try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
+      Subscription subscription = adminClient.getSubscription(subscriptionPath).get();
+      System.out.println("Subscription: " + subscription.getAllFields());
     }
   }
 }

--- a/samples/snippets/src/main/java/pubsublite/GetTopicExample.java
+++ b/samples/snippets/src/main/java/pubsublite/GetTopicExample.java
@@ -17,7 +17,6 @@
 package pubsublite;
 
 // [START pubsublite_get_topic]
-
 import com.google.cloud.pubsublite.AdminClient;
 import com.google.cloud.pubsublite.AdminClientSettings;
 import com.google.cloud.pubsublite.CloudRegion;
@@ -27,53 +26,36 @@ import com.google.cloud.pubsublite.TopicName;
 import com.google.cloud.pubsublite.TopicPath;
 import com.google.cloud.pubsublite.TopicPaths;
 import com.google.cloud.pubsublite.proto.Topic;
-import io.grpc.StatusException;
 
 public class GetTopicExample {
 
   public static void main(String... args) throws Exception {
     // TODO(developer): Replace these variables before running the sample.
-    String CLOUD_REGION = "Your Cloud Region";
-    char ZONE_ID = 'b';
-    long PROJECT_NUMBER = Long.parseLong("123456789");
-    String TOPIC_NAME = "Your Lite Topic Name";
+    String cloudRegion = "your-cloud-region";
+    char zoneId = 'b';
+    // Choose an existing topic.
+    String topicId = "your-topic-id";
+    long projectNumber = Long.parseLong("123456789");
 
-    GetTopicExample.getTopicExample(CLOUD_REGION, ZONE_ID, PROJECT_NUMBER, TOPIC_NAME);
+    getTopicExample(cloudRegion, zoneId, projectNumber, topicId);
   }
 
   public static void getTopicExample(
-      String CLOUD_REGION, char ZONE_ID, long PROJECT_NUMBER, String TOPIC_NAME) throws Exception {
+      String cloudRegion, char zoneId, long projectNumber, String topicId) throws Exception {
+    TopicPath topicPath =
+        TopicPaths.newBuilder()
+            .setProjectNumber(ProjectNumber.of(projectNumber))
+            .setZone(CloudZone.of(CloudRegion.of(cloudRegion), zoneId))
+            .setTopicName(TopicName.of(topicId))
+            .build();
 
-    try {
-      CloudRegion cloudRegion = CloudRegion.of(CLOUD_REGION);
-      CloudZone zone = CloudZone.of(cloudRegion, ZONE_ID);
-      ProjectNumber projectNum = ProjectNumber.of(PROJECT_NUMBER);
-      TopicName topicName = TopicName.of(TOPIC_NAME);
+    AdminClientSettings adminClientSettings =
+        AdminClientSettings.newBuilder().setRegion(CloudRegion.of(cloudRegion)).build();
 
-      TopicPath topicPath =
-          TopicPaths.newBuilder()
-              .setZone(zone)
-              .setProjectNumber(projectNum)
-              .setTopicName(topicName)
-              .build();
-
-      AdminClientSettings adminClientSettings =
-          AdminClientSettings.newBuilder().setRegion(cloudRegion).build();
-
-      try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
-
-        Topic topic = adminClient.getTopic(topicPath).get();
-        long numPartitions = adminClient.getTopicPartitionCount(topicPath).get();
-
-        System.out.println(
-            "Topic: " + topic.getAllFields() + " has " + numPartitions + " partition(s).");
-      }
-
-    } catch (StatusException statusException) {
-      System.out.println("Failed to get the topic: " + statusException);
-      System.out.println(statusException.getStatus().getCode());
-      System.out.println(statusException.getStatus());
-      throw statusException;
+    try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
+      Topic topic = adminClient.getTopic(topicPath).get();
+      long numPartitions = adminClient.getTopicPartitionCount(topicPath).get();
+      System.out.println(topic.getAllFields() + "\nhas " + numPartitions + " partition(s).");
     }
   }
 }

--- a/samples/snippets/src/main/java/pubsublite/ListSubscriptionsInProjectExample.java
+++ b/samples/snippets/src/main/java/pubsublite/ListSubscriptionsInProjectExample.java
@@ -17,7 +17,6 @@
 package pubsublite;
 
 // [START pubsublite_list_subscriptions_in_project]
-
 import com.google.cloud.pubsublite.AdminClient;
 import com.google.cloud.pubsublite.AdminClientSettings;
 import com.google.cloud.pubsublite.CloudRegion;
@@ -26,48 +25,37 @@ import com.google.cloud.pubsublite.LocationPath;
 import com.google.cloud.pubsublite.LocationPaths;
 import com.google.cloud.pubsublite.ProjectNumber;
 import com.google.cloud.pubsublite.proto.Subscription;
-import io.grpc.StatusException;
 import java.util.List;
 
 public class ListSubscriptionsInProjectExample {
 
   public static void main(String... args) throws Exception {
     // TODO(developer): Replace these variables before running the sample.
-    String CLOUD_REGION = "Your Cloud Region";
-    char ZONE_ID = 'b';
-    long PROJECT_NUMBER = Long.parseLong("123456789");
+    String cloudRegion = "your-cloud-region";
+    char zoneId = 'b';
+    long projectNumber = Long.parseLong("123456789");
 
-    ListSubscriptionsInProjectExample.listSubscriptionsInProjectExample(
-        CLOUD_REGION, ZONE_ID, PROJECT_NUMBER);
+    listSubscriptionsInProjectExample(cloudRegion, zoneId, projectNumber);
   }
 
   public static void listSubscriptionsInProjectExample(
-      String CLOUD_REGION, char ZONE_ID, long PROJECT_NUMBER) throws Exception {
+      String cloudRegion, char zoneId, long projectNumber) throws Exception {
 
-    try {
-      CloudRegion cloudRegion = CloudRegion.of(CLOUD_REGION);
-      CloudZone zone = CloudZone.of(cloudRegion, ZONE_ID);
-      ProjectNumber projectNum = ProjectNumber.of(PROJECT_NUMBER);
+    AdminClientSettings adminClientSettings =
+        AdminClientSettings.newBuilder().setRegion(CloudRegion.of(cloudRegion)).build();
 
-      LocationPath locationPath =
-          LocationPaths.newBuilder().setProjectNumber(projectNum).setZone(zone).build();
+    LocationPath locationPath =
+        LocationPaths.newBuilder()
+            .setProjectNumber(ProjectNumber.of(projectNumber))
+            .setZone(CloudZone.of(CloudRegion.of(cloudRegion), zoneId))
+            .build();
 
-      AdminClientSettings adminClientSettings =
-          AdminClientSettings.newBuilder().setRegion(cloudRegion).build();
-
-      try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
-        List<Subscription> subscriptions = adminClient.listSubscriptions(locationPath).get();
-        for (Subscription subscription : subscriptions) {
-          System.out.println(subscription.getAllFields());
-        }
-        System.out.println(subscriptions.size() + " subscription(s) listed.");
+    try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
+      List<Subscription> subscriptions = adminClient.listSubscriptions(locationPath).get();
+      for (Subscription subscription : subscriptions) {
+        System.out.println(subscription.getAllFields());
       }
-
-    } catch (StatusException statusException) {
-      System.out.println("Failed to list subscriptions in the project: " + statusException);
-      System.out.println(statusException.getStatus().getCode());
-      System.out.println(statusException.getStatus());
-      throw statusException;
+      System.out.println(subscriptions.size() + " subscription(s) listed.");
     }
   }
 }

--- a/samples/snippets/src/main/java/pubsublite/ListSubscriptionsInTopicExample.java
+++ b/samples/snippets/src/main/java/pubsublite/ListSubscriptionsInTopicExample.java
@@ -17,7 +17,6 @@
 package pubsublite;
 
 // [START pubsublite_list_subscriptions_in_topic]
-
 import com.google.cloud.pubsublite.AdminClient;
 import com.google.cloud.pubsublite.AdminClientSettings;
 import com.google.cloud.pubsublite.CloudRegion;
@@ -27,60 +26,40 @@ import com.google.cloud.pubsublite.SubscriptionPath;
 import com.google.cloud.pubsublite.TopicName;
 import com.google.cloud.pubsublite.TopicPath;
 import com.google.cloud.pubsublite.TopicPaths;
-import io.grpc.StatusException;
 import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 
 public class ListSubscriptionsInTopicExample {
 
   public static void main(String... args) throws Exception {
     // TODO(developer): Replace these variables before running the sample.
-    String CLOUD_REGION = "Your Cloud Region";
-    char ZONE_ID = 'b';
-    long PROJECT_NUMBER = Long.parseLong("123456789");
-    String TOPIC_NAME = "Your Lite Topic Name";
+    String cloudRegion = "your-cloud-region";
+    char zoneId = 'b';
+    long projectNumber = Long.parseLong("123456789");
+    String topicId = "your-topic-id";
 
-    ListSubscriptionsInTopicExample.listSubscriptionsInTopicExample(
-        CLOUD_REGION, ZONE_ID, PROJECT_NUMBER, TOPIC_NAME);
+    listSubscriptionsInTopicExample(cloudRegion, zoneId, projectNumber, topicId);
   }
 
   public static void listSubscriptionsInTopicExample(
-      String CLOUD_REGION, char ZONE_ID, long PROJECT_NUMBER, String TOPIC_NAME) throws Exception {
+      String cloudRegion, char zoneId, long projectNumber, String topicId) throws Exception {
 
-    ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+    TopicPath topicPath =
+        TopicPaths.newBuilder()
+            .setProjectNumber(ProjectNumber.of(projectNumber))
+            .setZone(CloudZone.of(CloudRegion.of(cloudRegion), zoneId))
+            .setTopicName(TopicName.of(topicId))
+            .build();
 
-    try {
-      CloudRegion cloudRegion = CloudRegion.of(CLOUD_REGION);
-      CloudZone zone = CloudZone.of(cloudRegion, ZONE_ID);
-      ProjectNumber projectNum = ProjectNumber.of(PROJECT_NUMBER);
-      TopicName topicName = TopicName.of(TOPIC_NAME);
+    AdminClientSettings adminClientSettings =
+        AdminClientSettings.newBuilder().setRegion(CloudRegion.of(cloudRegion)).build();
 
-      TopicPath topicPath =
-          TopicPaths.newBuilder()
-              .setProjectNumber(projectNum)
-              .setZone(zone)
-              .setTopicName(topicName)
-              .build();
-
-      AdminClientSettings adminClientSettings =
-          AdminClientSettings.newBuilder().setRegion(cloudRegion).build();
-
-      try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
-
-        List<SubscriptionPath> subscriptionPaths =
-            adminClient.listTopicSubscriptions(topicPath).get();
-        for (SubscriptionPath subscription : subscriptionPaths) {
-          System.out.println(subscription.value());
-        }
-        System.out.println(subscriptionPaths.size() + " subscription(s) listed.");
+    try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
+      List<SubscriptionPath> subscriptionPaths =
+          adminClient.listTopicSubscriptions(topicPath).get();
+      for (SubscriptionPath subscription : subscriptionPaths) {
+        System.out.println(subscription.value());
       }
-
-    } catch (StatusException statusException) {
-      System.out.println("Failed to list subscriptions in the topic: " + statusException);
-      System.out.println(statusException.getStatus().getCode());
-      System.out.println(statusException.getStatus());
-      throw statusException;
+      System.out.println(subscriptionPaths.size() + " subscription(s) listed.");
     }
   }
 }

--- a/samples/snippets/src/main/java/pubsublite/ListTopicsExample.java
+++ b/samples/snippets/src/main/java/pubsublite/ListTopicsExample.java
@@ -17,7 +17,6 @@
 package pubsublite;
 
 // [START pubsublite_list_topics]
-
 import com.google.cloud.pubsublite.AdminClient;
 import com.google.cloud.pubsublite.AdminClientSettings;
 import com.google.cloud.pubsublite.CloudRegion;
@@ -26,47 +25,37 @@ import com.google.cloud.pubsublite.LocationPath;
 import com.google.cloud.pubsublite.LocationPaths;
 import com.google.cloud.pubsublite.ProjectNumber;
 import com.google.cloud.pubsublite.proto.Topic;
-import io.grpc.StatusException;
 import java.util.List;
 
 public class ListTopicsExample {
 
   public static void main(String... args) throws Exception {
     // TODO(developer): Replace these variables before running the sample.
-    String CLOUD_REGION = "Your Cloud Region";
-    char ZONE_ID = 'b';
-    long PROJECT_NUMBER = Long.parseLong("123456789");
+    String cloudRegion = "your-cloud-region";
+    char zoneId = 'b';
+    long projectNumber = Long.parseLong("123456789");
 
-    ListTopicsExample.listTopicsExample(CLOUD_REGION, ZONE_ID, PROJECT_NUMBER);
+    listTopicsExample(cloudRegion, zoneId, projectNumber);
   }
 
-  public static void listTopicsExample(String CLOUD_REGION, char ZONE_ID, long PROJECT_NUMBER)
+  public static void listTopicsExample(String cloudRegion, char zoneId, long projectNumber)
       throws Exception {
 
-    try {
-      CloudRegion cloudRegion = CloudRegion.of(CLOUD_REGION);
-      CloudZone zone = CloudZone.of(cloudRegion, ZONE_ID);
-      ProjectNumber projectNum = ProjectNumber.of(PROJECT_NUMBER);
+    AdminClientSettings adminClientSettings =
+        AdminClientSettings.newBuilder().setRegion(CloudRegion.of(cloudRegion)).build();
 
-      LocationPath locationPath =
-          LocationPaths.newBuilder().setProjectNumber(projectNum).setZone(zone).build();
+    LocationPath locationPath =
+        LocationPaths.newBuilder()
+            .setProjectNumber(ProjectNumber.of(projectNumber))
+            .setZone(CloudZone.of(CloudRegion.of(cloudRegion), zoneId))
+            .build();
 
-      AdminClientSettings adminClientSettings =
-          AdminClientSettings.newBuilder().setRegion(cloudRegion).build();
-
-      try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
-        List<Topic> topics = adminClient.listTopics(locationPath).get();
-        for (Topic t : topics) {
-          System.out.println(t.getAllFields());
-        }
-        System.out.println(topics.size() + " topic(s) listed.");
+    try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
+      List<Topic> topics = adminClient.listTopics(locationPath).get();
+      for (Topic topic : topics) {
+        System.out.println(topic.getAllFields());
       }
-
-    } catch (StatusException statusException) {
-      System.out.println("Failed to list topics: " + statusException);
-      System.out.println(statusException.getStatus().getCode());
-      System.out.println(statusException.getStatus());
-      throw statusException;
+      System.out.println(topics.size() + " topic(s) listed.");
     }
   }
 }

--- a/samples/snippets/src/main/java/pubsublite/PublishWithBatchSettingsExample.java
+++ b/samples/snippets/src/main/java/pubsublite/PublishWithBatchSettingsExample.java
@@ -17,7 +17,6 @@
 package pubsublite;
 
 // [START pubsublite_publish_batch]
-
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.gax.batching.BatchingSettings;
@@ -94,10 +93,7 @@ public class PublishWithBatchSettingsExample {
 
         // Convert the message to a byte string.
         ByteString data = ByteString.copyFromUtf8(message);
-        PubsubMessage pubsubMessage =
-            PubsubMessage.newBuilder()
-                .setData(data)
-                .build();
+        PubsubMessage pubsubMessage = PubsubMessage.newBuilder().setData(data).build();
 
         // Schedule a message to be published.
         ApiFuture<String> future = publisher.publish(pubsubMessage);
@@ -106,7 +102,7 @@ public class PublishWithBatchSettingsExample {
     } finally {
       ArrayList<PublishMetadata> metadata = new ArrayList<>();
       List<String> ackIds = ApiFutures.allAsList(futures).get();
-      System.out.println("Published " + ackIds.size() + "  messages with batch settings.");
+      System.out.println("Published " + ackIds.size() + " messages with batch settings.");
 
       if (publisher != null) {
         // Shut down the publisher.

--- a/samples/snippets/src/main/java/pubsublite/PublishWithBatchSettingsExample.java
+++ b/samples/snippets/src/main/java/pubsublite/PublishWithBatchSettingsExample.java
@@ -95,7 +95,7 @@ public class PublishWithBatchSettingsExample {
         ByteString data = ByteString.copyFromUtf8(message);
         PubsubMessage pubsubMessage = PubsubMessage.newBuilder().setData(data).build();
 
-        // Schedule a message to be published.
+        // Publish a message.
         ApiFuture<String> future = publisher.publish(pubsubMessage);
         futures.add(future);
       }

--- a/samples/snippets/src/main/java/pubsublite/PublishWithBatchSettingsExample.java
+++ b/samples/snippets/src/main/java/pubsublite/PublishWithBatchSettingsExample.java
@@ -31,8 +31,10 @@ import com.google.cloud.pubsublite.cloudpubsub.Publisher;
 import com.google.cloud.pubsublite.cloudpubsub.PublisherSettings;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
+import io.grpc.StatusException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import org.threeten.bp.Duration;
 
 public class PublishWithBatchSettingsExample {
@@ -51,7 +53,7 @@ public class PublishWithBatchSettingsExample {
   // Publish messages to a topic with batch settings.
   public static void publishWithBatchSettingsExample(
       String cloudRegion, char zoneId, long projectNumber, String topicId, int messageCount)
-      throws Exception {
+      throws StatusException, ExecutionException, InterruptedException {
 
     TopicPath topicPath =
         TopicPaths.newBuilder()

--- a/samples/snippets/src/main/java/pubsublite/PublishWithCustomAttributesExample.java
+++ b/samples/snippets/src/main/java/pubsublite/PublishWithCustomAttributesExample.java
@@ -73,7 +73,7 @@ public class PublishWithCustomAttributesExample {
             .putAllAttributes(ImmutableMap.of("year", "2020", "author", "unknown"))
             .build();
 
-    // Schedule a message to be published.
+    // Publish a message.
     ApiFuture<String> future = publisher.publish(pubsubMessage);
 
     // Shut down the publisher.

--- a/samples/snippets/src/main/java/pubsublite/PublishWithCustomAttributesExample.java
+++ b/samples/snippets/src/main/java/pubsublite/PublishWithCustomAttributesExample.java
@@ -17,7 +17,6 @@
 package pubsublite;
 
 // [START pubsublite_publish_custom_attributes]
-
 import com.google.api.core.ApiFuture;
 import com.google.cloud.pubsublite.CloudRegion;
 import com.google.cloud.pubsublite.CloudZone;
@@ -83,7 +82,6 @@ public class PublishWithCustomAttributesExample {
     String ackId = future.get();
     PublishMetadata metadata = PublishMetadata.decode(ackId);
     System.out.println("Published a message with custom attributes:\n" + metadata);
- }
+  }
 }
 // [END pubsublite_publish_custom_attributes]
-

--- a/samples/snippets/src/main/java/pubsublite/PublishWithCustomAttributesExample.java
+++ b/samples/snippets/src/main/java/pubsublite/PublishWithCustomAttributesExample.java
@@ -30,6 +30,8 @@ import com.google.cloud.pubsublite.cloudpubsub.PublisherSettings;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
+import io.grpc.StatusException;
+import java.util.concurrent.ExecutionException;
 
 public class PublishWithCustomAttributesExample {
   public static void main(String... args) throws Exception {
@@ -45,7 +47,8 @@ public class PublishWithCustomAttributesExample {
 
   // Publish messages to a topic with custom attributes.
   public static void publishWithCustomAttributesExample(
-      String cloudRegion, char zoneId, long projectNumber, String topicId) throws Exception {
+      String cloudRegion, char zoneId, long projectNumber, String topicId)
+      throws StatusException, ExecutionException, InterruptedException {
 
     TopicPath topicPath =
         TopicPaths.newBuilder()

--- a/samples/snippets/src/main/java/pubsublite/PublishWithCustomAttributesExample.java
+++ b/samples/snippets/src/main/java/pubsublite/PublishWithCustomAttributesExample.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsublite;
+
+// [START pubsublite_publish_custom_attributes]
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.pubsublite.CloudRegion;
+import com.google.cloud.pubsublite.CloudZone;
+import com.google.cloud.pubsublite.ProjectNumber;
+import com.google.cloud.pubsublite.PublishMetadata;
+import com.google.cloud.pubsublite.TopicName;
+import com.google.cloud.pubsublite.TopicPath;
+import com.google.cloud.pubsublite.TopicPaths;
+import com.google.cloud.pubsublite.cloudpubsub.Publisher;
+import com.google.cloud.pubsublite.cloudpubsub.PublisherSettings;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+
+public class PublishWithCustomAttributesExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String cloudRegion = "your-cloud-region";
+    char zoneId = 'b';
+    // Choose an existing topic for the publish example to work.
+    String topicId = "your-topic-id";
+    long projectNumber = Long.parseLong("123456789");
+
+    publishWithCustomAttributesExample(cloudRegion, zoneId, projectNumber, topicId);
+  }
+
+  // Publish messages to a topic with custom attributes.
+  public static void publishWithCustomAttributesExample(
+      String cloudRegion, char zoneId, long projectNumber, String topicId) throws Exception {
+
+    TopicPath topicPath =
+        TopicPaths.newBuilder()
+            .setProjectNumber(ProjectNumber.of(projectNumber))
+            .setZone(CloudZone.of(CloudRegion.of(cloudRegion), zoneId))
+            .setTopicName(TopicName.of(topicId))
+            .build();
+
+    PublisherSettings publisherSettings =
+        PublisherSettings.newBuilder().setTopicPath(topicPath).build();
+
+    Publisher publisher = Publisher.create(publisherSettings);
+
+    // Start the publisher. Upon successful starting, its state will become RUNNING.
+    publisher.startAsync().awaitRunning();
+
+    String message = "message-with-custom-attributes";
+
+    // Convert the message to a byte string.
+    ByteString data = ByteString.copyFromUtf8(message);
+    PubsubMessage pubsubMessage =
+        PubsubMessage.newBuilder()
+            .setData(data)
+            // Add two sets of custom attributes to the message.
+            .putAllAttributes(ImmutableMap.of("year", "2020", "author", "unknown"))
+            .build();
+
+    // Schedule a message to be published.
+    ApiFuture<String> future = publisher.publish(pubsubMessage);
+
+    // Shut down the publisher.
+    publisher.stopAsync().awaitTerminated();
+
+    String ackId = future.get();
+    PublishMetadata metadata = PublishMetadata.decode(ackId);
+    System.out.println("Published a message with custom attributes:\n" + metadata);
+ }
+}
+// [END pubsublite_publish_custom_attributes]
+

--- a/samples/snippets/src/main/java/pubsublite/PublishWithOrderingKeyExample.java
+++ b/samples/snippets/src/main/java/pubsublite/PublishWithOrderingKeyExample.java
@@ -70,11 +70,11 @@ public class PublishWithOrderingKeyExample {
             .setData(data)
             // Messages of the same ordering key will always get published to the
             // same partition. When OrderingKey is unset, messages can get published
-            // to different partitions if more than one partition exist for the topic.
+            // to different partitions if more than one partition exists for the topic.
             .setOrderingKey("testing")
             .build();
 
-    // Schedule a message to be published.
+    // Publish a message.
     ApiFuture<String> future = publisher.publish(pubsubMessage);
 
     // Shut down the publisher.

--- a/samples/snippets/src/main/java/pubsublite/PublishWithOrderingKeyExample.java
+++ b/samples/snippets/src/main/java/pubsublite/PublishWithOrderingKeyExample.java
@@ -17,7 +17,6 @@
 package pubsublite;
 
 // [START pubsublite_publish_ordering_key]
-
 import com.google.api.core.ApiFuture;
 import com.google.cloud.pubsublite.CloudRegion;
 import com.google.cloud.pubsublite.CloudZone;

--- a/samples/snippets/src/main/java/pubsublite/PublishWithOrderingKeyExample.java
+++ b/samples/snippets/src/main/java/pubsublite/PublishWithOrderingKeyExample.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsublite;
+
+// [START pubsublite_publish_ordering_key]
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.pubsublite.CloudRegion;
+import com.google.cloud.pubsublite.CloudZone;
+import com.google.cloud.pubsublite.ProjectNumber;
+import com.google.cloud.pubsublite.PublishMetadata;
+import com.google.cloud.pubsublite.TopicName;
+import com.google.cloud.pubsublite.TopicPath;
+import com.google.cloud.pubsublite.TopicPaths;
+import com.google.cloud.pubsublite.cloudpubsub.Publisher;
+import com.google.cloud.pubsublite.cloudpubsub.PublisherSettings;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+
+public class PublishWithOrderingKeyExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String cloudRegion = "your-cloud-region";
+    char zoneId = 'b';
+    // Choose an existing topic for the publish example to work.
+    String topicId = "your-topic-id";
+    long projectNumber = Long.parseLong("123456789");
+
+    publishWithOrderingKeyExample(cloudRegion, zoneId, projectNumber, topicId);
+  }
+
+  // Publish a message to a topic with an ordering key.
+  public static void publishWithOrderingKeyExample(
+      String cloudRegion, char zoneId, long projectNumber, String topicId) throws Exception {
+
+    TopicPath topicPath =
+        TopicPaths.newBuilder()
+            .setProjectNumber(ProjectNumber.of(projectNumber))
+            .setZone(CloudZone.of(CloudRegion.of(cloudRegion), zoneId))
+            .setTopicName(TopicName.of(topicId))
+            .build();
+
+    PublisherSettings publisherSettings =
+        PublisherSettings.newBuilder().setTopicPath(topicPath).build();
+
+    Publisher publisher = Publisher.create(publisherSettings);
+
+    // Start the publisher. Upon successful starting, its state will become RUNNING.
+    publisher.startAsync().awaitRunning();
+
+    String message = "message-with-ordering-key";
+
+    // Convert the message to a byte string.
+    ByteString data = ByteString.copyFromUtf8(message);
+    PubsubMessage pubsubMessage =
+        PubsubMessage.newBuilder()
+            .setData(data)
+            // Messages of the same ordering key will always get published to the
+            // same partition. When OrderingKey is unset, messages can get published
+            // to different partitions if more than one partition exist for the topic.
+            .setOrderingKey("testing")
+            .build();
+
+    // Schedule a message to be published.
+    ApiFuture<String> future = publisher.publish(pubsubMessage);
+
+    // Shut down the publisher.
+    publisher.stopAsync().awaitTerminated();
+
+    String ackId = future.get();
+    PublishMetadata metadata = PublishMetadata.decode(ackId);
+    System.out.println("Published a message with ordering key:\n" + metadata);
+  }
+}
+// [END pubsublite_publish_ordering_key]

--- a/samples/snippets/src/main/java/pubsublite/PublishWithOrderingKeyExample.java
+++ b/samples/snippets/src/main/java/pubsublite/PublishWithOrderingKeyExample.java
@@ -29,6 +29,8 @@ import com.google.cloud.pubsublite.cloudpubsub.Publisher;
 import com.google.cloud.pubsublite.cloudpubsub.PublisherSettings;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
+import io.grpc.StatusException;
+import java.util.concurrent.ExecutionException;
 
 public class PublishWithOrderingKeyExample {
   public static void main(String... args) throws Exception {
@@ -44,7 +46,8 @@ public class PublishWithOrderingKeyExample {
 
   // Publish a message to a topic with an ordering key.
   public static void publishWithOrderingKeyExample(
-      String cloudRegion, char zoneId, long projectNumber, String topicId) throws Exception {
+      String cloudRegion, char zoneId, long projectNumber, String topicId)
+      throws StatusException, ExecutionException, InterruptedException {
 
     TopicPath topicPath =
         TopicPaths.newBuilder()

--- a/samples/snippets/src/main/java/pubsublite/PublisherExample.java
+++ b/samples/snippets/src/main/java/pubsublite/PublisherExample.java
@@ -17,7 +17,6 @@
 package pubsublite;
 
 // [START pubsublite_quickstart_publisher]
-
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.pubsublite.CloudRegion;
@@ -45,13 +44,13 @@ public class PublisherExample {
     long projectNumber = Long.parseLong("123456789");
     int messageCount = 100;
 
-    PublisherExample.publisherExample(
-        cloudRegion, zoneId, projectNumber, topicId, messageCount);
+    publisherExample(cloudRegion, zoneId, projectNumber, topicId, messageCount);
   }
 
   // Publish messages to a topic.
   public static void publisherExample(
-      String cloudRegion, char zoneId, long projectNumber, String topicId, int messageCount) throws Exception {
+      String cloudRegion, char zoneId, long projectNumber, String topicId, int messageCount)
+      throws Exception {
 
     TopicPath topicPath =
         TopicPaths.newBuilder()
@@ -76,10 +75,7 @@ public class PublisherExample {
 
         // Convert the message to a byte string.
         ByteString data = ByteString.copyFromUtf8(message);
-        PubsubMessage pubsubMessage =
-            PubsubMessage.newBuilder()
-                .setData(data)
-                .build();
+        PubsubMessage pubsubMessage = PubsubMessage.newBuilder().setData(data).build();
 
         // Schedule a message to be published. Messages are automatically batched.
         ApiFuture<String> future = publisher.publish(pubsubMessage);
@@ -92,7 +88,7 @@ public class PublisherExample {
         // Decoded metadata contains partition and offset.
         metadata.add(PublishMetadata.decode(id));
       }
-      System.out.println(metadata + "\nPublished " + ackIds.size() + "  messages.");
+      System.out.println(metadata + "\nPublished " + ackIds.size() + " messages.");
 
       if (publisher != null) {
         // Shut down the publisher.

--- a/samples/snippets/src/main/java/pubsublite/PublisherExample.java
+++ b/samples/snippets/src/main/java/pubsublite/PublisherExample.java
@@ -77,7 +77,7 @@ public class PublisherExample {
         ByteString data = ByteString.copyFromUtf8(message);
         PubsubMessage pubsubMessage = PubsubMessage.newBuilder().setData(data).build();
 
-        // Schedule a message to be published. Messages are automatically batched.
+        // Publish a message. Messages are automatically batched.
         ApiFuture<String> future = publisher.publish(pubsubMessage);
         futures.add(future);
       }

--- a/samples/snippets/src/main/java/pubsublite/PublisherExample.java
+++ b/samples/snippets/src/main/java/pubsublite/PublisherExample.java
@@ -30,8 +30,10 @@ import com.google.cloud.pubsublite.cloudpubsub.Publisher;
 import com.google.cloud.pubsublite.cloudpubsub.PublisherSettings;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
+import io.grpc.StatusException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 public class PublisherExample {
 
@@ -50,7 +52,7 @@ public class PublisherExample {
   // Publish messages to a topic.
   public static void publisherExample(
       String cloudRegion, char zoneId, long projectNumber, String topicId, int messageCount)
-      throws Exception {
+      throws StatusException, ExecutionException, InterruptedException {
 
     TopicPath topicPath =
         TopicPaths.newBuilder()

--- a/samples/snippets/src/main/java/pubsublite/SubscriberExample.java
+++ b/samples/snippets/src/main/java/pubsublite/SubscriberExample.java
@@ -17,7 +17,6 @@
 package pubsublite;
 
 // [START pubsublite_quickstart_subscriber]
-
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsublite.CloudRegion;

--- a/samples/snippets/src/main/java/pubsublite/SubscriberExample.java
+++ b/samples/snippets/src/main/java/pubsublite/SubscriberExample.java
@@ -103,7 +103,7 @@ public class SubscriberExample {
     // Start the subscriber. Upon successful starting, its state will become RUNNING.
     subscriber.startAsync().awaitRunning();
 
-    System.out.println("Listening to messages on " + subscriptionPath.value() + " ...");
+    System.out.println("Listening to messages on " + subscriptionPath.value() + "...");
 
     try {
       // Wait 30 seconds for the subscriber to reach TERMINATED state. If it encounters
@@ -112,7 +112,7 @@ public class SubscriberExample {
       subscriber.awaitTerminated(30, TimeUnit.SECONDS);
     } catch (TimeoutException t) {
       // Shut down the subscriber. This will change the state of the subscriber to TERMINATED.
-      subscriber.stopAsync();
+      subscriber.stopAsync().awaitTerminated();
       System.out.println("Subscriber is shut down: " + subscriber.state());
     }
   }

--- a/samples/snippets/src/main/java/pubsublite/SubscriberExample.java
+++ b/samples/snippets/src/main/java/pubsublite/SubscriberExample.java
@@ -67,13 +67,13 @@ public class SubscriberExample {
             .setSubscriptionName(SubscriptionName.of(subscriptionId))
             .build();
 
+    // The message stream is paused based on the maximum size or number of messages that the
+    // subscriber has already received, whichever condition is met first.
     FlowControlSettings flowControlSettings =
         FlowControlSettings.builder()
-            // 10 MiB. Must be >0. It controls the maximum size of messages the subscriber
-            // receives before pausing the message stream.
+            // 10 MiB. Must be greater than the size of the largest message.
             .setBytesOutstanding(10 * 1024 * 1024L)
-            // 1,000 outstanding messages. Must be >0. It controls the maximum number of messages
-            // the subscriber receives before pausing the message stream.
+            // 1,000 outstanding messages. Must be >0.
             .setMessagesOutstanding(1000L)
             .build();
 

--- a/samples/snippets/src/main/java/pubsublite/SubscriberExample.java
+++ b/samples/snippets/src/main/java/pubsublite/SubscriberExample.java
@@ -31,6 +31,7 @@ import com.google.cloud.pubsublite.cloudpubsub.Subscriber;
 import com.google.cloud.pubsublite.cloudpubsub.SubscriberSettings;
 import com.google.common.collect.ImmutableList;
 import com.google.pubsub.v1.PubsubMessage;
+import io.grpc.StatusException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -58,7 +59,7 @@ public class SubscriberExample {
       long projectNumber,
       String subscriptionId,
       List<Integer> partitionNumbers)
-      throws Exception {
+      throws StatusException {
 
     SubscriptionPath subscriptionPath =
         SubscriptionPaths.newBuilder()
@@ -71,7 +72,7 @@ public class SubscriberExample {
     // subscriber has already received, whichever condition is met first.
     FlowControlSettings flowControlSettings =
         FlowControlSettings.builder()
-            // 10 MiB. Must be greater than the size of the largest message.
+            // 10 MiB. Must be greater than the allowed size of the largest message (1 MiB).
             .setBytesOutstanding(10 * 1024 * 1024L)
             // 1,000 outstanding messages. Must be >0.
             .setMessagesOutstanding(1000L)

--- a/samples/snippets/src/main/java/pubsublite/UpdateTopicExample.java
+++ b/samples/snippets/src/main/java/pubsublite/UpdateTopicExample.java
@@ -17,7 +17,6 @@
 package pubsublite;
 
 // [START pubsublite_update_topic]
-
 import com.google.cloud.pubsublite.AdminClient;
 import com.google.cloud.pubsublite.AdminClientSettings;
 import com.google.cloud.pubsublite.CloudRegion;
@@ -31,83 +30,69 @@ import com.google.cloud.pubsublite.proto.Topic.PartitionConfig;
 import com.google.cloud.pubsublite.proto.Topic.RetentionConfig;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.util.Durations;
-import io.grpc.StatusException;
 import java.util.Arrays;
 
 public class UpdateTopicExample {
 
   public static void main(String... args) throws Exception {
     // TODO(developer): Replace these variables before running the sample.
-    String CLOUD_REGION = "Your Cloud Region";
-    char ZONE_ID = 'b';
-    String TOPIC_NAME = "Your Topic Name"; // Please use an existing topic
-    long PROJECT_NUMBER = Long.parseLong("123456789");
+    String cloudRegion = "your-cloud-region";
+    char zoneId = 'b';
+    String topicId = "your-topic-id";
+    long projectNumber = Long.parseLong("123456789");
 
-    UpdateTopicExample.updateTopicExample(CLOUD_REGION, ZONE_ID, PROJECT_NUMBER, TOPIC_NAME);
+    updateTopicExample(cloudRegion, zoneId, projectNumber, topicId);
   }
 
   public static void updateTopicExample(
-      String CLOUD_REGION, char ZONE_ID, long PROJECT_NUMBER, String TOPIC_NAME) throws Exception {
+      String cloudRegion, char zoneId, long projectNumber, String topicId) throws Exception {
 
-    try {
-      CloudRegion cloudRegion = CloudRegion.of(CLOUD_REGION);
-      CloudZone zone = CloudZone.of(cloudRegion, ZONE_ID);
-      ProjectNumber projectNum = ProjectNumber.of(PROJECT_NUMBER);
-      TopicName topicName = TopicName.of(TOPIC_NAME);
-      Iterable<String> iterablePaths =
-          Arrays.asList(
-              "partition_config.scale",
-              "retention_config.per_partition_bytes",
-              "retention_config.period");
+    TopicPath topicPath =
+        TopicPaths.newBuilder()
+            .setProjectNumber(ProjectNumber.of(projectNumber))
+            .setZone(CloudZone.of(CloudRegion.of(cloudRegion), zoneId))
+            .setTopicName(TopicName.of(topicId))
+            .build();
 
-      // TODO: add a link to documentation.
-      FieldMask MASK = FieldMask.newBuilder().addAllPaths(iterablePaths).build();
+    Iterable<String> iterablePaths =
+        Arrays.asList(
+            "partition_config.scale",
+            "retention_config.per_partition_bytes",
+            "retention_config.period");
 
-      TopicPath topicPath =
-          TopicPaths.newBuilder()
-              .setZone(zone)
-              .setProjectNumber(projectNum)
-              .setTopicName(topicName)
-              .build();
+    FieldMask MASK = FieldMask.newBuilder().addAllPaths(iterablePaths).build();
 
-      Topic topic =
-          Topic.newBuilder()
-              .setPartitionConfig(
-                  PartitionConfig.newBuilder()
-                      // Set publishing throughput to 4 times the standard partition
-                      // throughput of 4 MiB per sec. This must be in the range [1,4]. A
-                      // topic with `scale` of 2 and count of 10 is charged for 20 partitions.
-                      .setScale(4)
-                      .build())
-              .setRetentionConfig(
-                  RetentionConfig.newBuilder()
-                      // Set storage per partition to 200 GiB. This must be 30 GiB-10 TiB.
-                      // If the number of bytes stored in any of the topic's partitions grows
-                      // beyond this value, older messages will be dropped to make room for
-                      // newer ones, regardless of the value of `period`.
-                      // Be careful when decreasing storage per partition as it may cause
-                      // lost messages.
-                      .setPerPartitionBytes(200 * 1024 * 1024 * 1024L)
-                      .setPeriod(Durations.fromDays(7)))
-              .setName(topicPath.value())
-              .build();
+    Topic topic =
+        Topic.newBuilder()
+            .setPartitionConfig(
+                PartitionConfig.newBuilder()
+                    // Set publishing throughput to 4 times the standard partition
+                    // throughput of 4 MiB per sec. This must be in the range [1,4]. A
+                    // topic with `scale` of 2 and count of 10 is charged for 20 partitions.
+                    .setScale(4)
+                    .build())
+            .setRetentionConfig(
+                RetentionConfig.newBuilder()
+                    // Set storage per partition to 200 GiB. This must be 30 GiB-10 TiB.
+                    // If the number of bytes stored in any of the topic's partitions grows
+                    // beyond this value, older messages will be dropped to make room for
+                    // newer ones, regardless of the value of `period`.
+                    // Be careful when decreasing storage per partition as it may cause
+                    // lost messages.
+                    .setPerPartitionBytes(200 * 1024 * 1024 * 1024L)
+                    .setPeriod(Durations.fromDays(7)))
+            .setName(topicPath.value())
+            .build();
 
-      AdminClientSettings adminClientSettings =
-          AdminClientSettings.newBuilder().setRegion(cloudRegion).build();
+    AdminClientSettings adminClientSettings =
+        AdminClientSettings.newBuilder().setRegion(CloudRegion.of(cloudRegion)).build();
 
-      try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
-        Topic topicBeforeUpdate = adminClient.getTopic(topicPath).get();
-        System.out.println("Before update: " + topicBeforeUpdate.getAllFields());
+    try (AdminClient adminClient = AdminClient.create(adminClientSettings)) {
+      Topic topicBeforeUpdate = adminClient.getTopic(topicPath).get();
+      System.out.println("Before update: " + topicBeforeUpdate.getAllFields());
 
-        Topic topicAfterUpdate = adminClient.updateTopic(topic, MASK).get();
-        System.out.println("After update: " + topicAfterUpdate.getAllFields());
-      }
-
-    } catch (StatusException statusException) {
-      System.out.println("Failed to update topic: " + statusException);
-      System.out.println(statusException.getStatus().getCode());
-      System.out.println(statusException.getStatus());
-      throw statusException;
+      Topic topicAfterUpdate = adminClient.updateTopic(topic, MASK).get();
+      System.out.println("After update: " + topicAfterUpdate.getAllFields());
     }
   }
 }

--- a/samples/snippets/src/test/java/pubsublite/QuickStartIT.java
+++ b/samples/snippets/src/test/java/pubsublite/QuickStartIT.java
@@ -133,7 +133,26 @@ public class QuickStartIT {
     // Publish.
     PublisherExample.publisherExample(
         CLOUD_REGION, ZONE_ID, PROJECT_NUMBER, TOPIC_NAME, MESSAGE_COUNT);
-    assertThat(bout.toString()).contains("Published " + MESSAGE_COUNT);
+    assertThat(bout.toString()).contains("Published " + MESSAGE_COUNT + " messages.");
+
+    bout.reset();
+    // Publish with ordering key.
+    PublishWithOrderingKeyExample.publishWithOrderingKeyExample(
+        CLOUD_REGION, ZONE_ID, PROJECT_NUMBER, TOPIC_NAME);
+    assertThat(bout.toString()).contains("Published a message with ordering key:");
+
+    bout.reset();
+    // Publish messages with custom attributes.
+    PublishWithCustomAttributesExample.publishWithCustomAttributesExample(
+        CLOUD_REGION, ZONE_ID, PROJECT_NUMBER, TOPIC_NAME);
+    assertThat(bout.toString()).contains("Published a message with custom attributes:");
+
+    bout.reset();
+    // Publish with batch settings.
+    PublishWithBatchSettingsExample.publishWithBatchSettingsExample(
+        CLOUD_REGION, ZONE_ID, PROJECT_NUMBER, TOPIC_NAME, MESSAGE_COUNT);
+    assertThat(bout.toString())
+        .contains("Published " + MESSAGE_COUNT + " messages with batch settings.");
 
     bout.reset();
     // Subscribe.
@@ -141,6 +160,7 @@ public class QuickStartIT {
         CLOUD_REGION, ZONE_ID, PROJECT_NUMBER, SUBSCRIPTION_NAME, PARTITION_NOS);
     assertThat(bout.toString()).contains("Listening");
     assertThat(bout.toString()).contains("Data : message-0");
+    assertThat(bout.toString()).contains("Subscriber is shut down: TERMINATED");
 
     bout.reset();
     // Delete a subscription.


### PR DESCRIPTION
Add 3 post-Public Preview publish samples for the Pub/Sub Lite publish [docs](https://cloud.google.com/pubsub/lite/docs/publishing) (currently have links to Java documentation as placeholders):

Internal b/157257388: publish with ordering key
Internal b/154738648: publish messages with custom attributes
Internal b/154738314: publish with batch settings

Also made some formatting changes to existing samples.