### PR TITLE
feat: Add the TopicStats client

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/AdminClientSettings.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/AdminClientSettings.java
@@ -25,29 +25,21 @@ import io.grpc.Status;
 import io.grpc.StatusException;
 import java.io.IOException;
 import java.util.Optional;
-import org.threeten.bp.Duration;
 
 @AutoValue
 public abstract class AdminClientSettings {
-  public static final RetrySettings DEFAULT_RETRY_SETTINGS =
-      RetrySettings.newBuilder()
-          .setInitialRetryDelay(Duration.ofMillis(100))
-          .setRetryDelayMultiplier(1.3)
-          .setMaxRetryDelay(Duration.ofSeconds(60))
-          .setJittered(true)
-          .setTotalTimeout(Duration.ofMinutes(10))
-          .build();
 
   // Required parameters.
   abstract CloudRegion region();
 
-  // Optional parameters.
-  abstract Optional<RetrySettings> retrySettings();
+  abstract RetrySettings retrySettings();
 
+  // Optional parameters.
   abstract Optional<AdminServiceBlockingStub> stub();
 
   public static Builder newBuilder() {
-    return new AutoValue_AdminClientSettings.Builder();
+    return new AutoValue_AdminClientSettings.Builder()
+        .setRetrySettings(Constants.DEFAULT_RETRY_SETTINGS);
   }
 
   @AutoValue.Builder
@@ -79,6 +71,6 @@ public abstract class AdminClientSettings {
             .asException();
       }
     }
-    return new AdminClientImpl(region(), stub, retrySettings().orElse(DEFAULT_RETRY_SETTINGS));
+    return new AdminClientImpl(region(), stub, retrySettings());
   }
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/AdminClientSettings.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/AdminClientSettings.java
@@ -32,9 +32,9 @@ public abstract class AdminClientSettings {
   // Required parameters.
   abstract CloudRegion region();
 
+  // Optional parameters.
   abstract RetrySettings retrySettings();
 
-  // Optional parameters.
   abstract Optional<AdminServiceBlockingStub> stub();
 
   public static Builder newBuilder() {

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/Constants.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/Constants.java
@@ -16,7 +16,19 @@
 
 package com.google.cloud.pubsublite;
 
+import com.google.api.gax.retrying.RetrySettings;
+import org.threeten.bp.Duration;
+
 public class Constants {
+  public static final RetrySettings DEFAULT_RETRY_SETTINGS =
+      RetrySettings.newBuilder()
+          .setInitialRetryDelay(Duration.ofMillis(100))
+          .setRetryDelayMultiplier(1.3)
+          .setMaxRetryDelay(Duration.ofSeconds(60))
+          .setJittered(true)
+          .setTotalTimeout(Duration.ofMinutes(10))
+          .build();
+
   public static final long MAX_PUBLISH_BATCH_COUNT = 1_000;
   public static final long MAX_PUBLISH_MESSAGE_BYTES = 1_000_000;
   public static final long MAX_PUBLISH_BATCH_BYTES = 3_500_000;

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/RetryingExecutorUtil.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/RetryingExecutorUtil.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.pubsublite.internal;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.NanoClock;
+import com.google.api.gax.retrying.ExponentialRetryAlgorithm;
+import com.google.api.gax.retrying.ResultRetryAlgorithm;
+import com.google.api.gax.retrying.RetryAlgorithm;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.retrying.RetryingExecutor;
+import com.google.api.gax.retrying.RetryingFuture;
+import com.google.api.gax.retrying.ScheduledRetryingExecutor;
+import com.google.api.gax.retrying.TimedAttemptSettings;
+import com.google.cloud.pubsublite.ErrorCodes;
+import io.grpc.Status;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+
+public final class RetryingExecutorUtil {
+
+  private RetryingExecutorUtil() {}
+
+  public static <T> RetryingExecutor<T> retryingExecutor(
+      RetrySettings settings, ScheduledExecutorService executor) {
+    return new ScheduledRetryingExecutor<>(retryAlgorithm(settings), executor);
+  }
+
+  public static <T> ApiFuture<T> runWithRetries(
+      Callable<T> callable, RetryingExecutor<T> executor) {
+    RetryingFuture<T> retryingFuture = executor.createFuture(callable);
+    retryingFuture.setAttemptFuture(executor.submit(retryingFuture));
+    return retryingFuture;
+  }
+
+  private static <T> RetryAlgorithm<T> retryAlgorithm(RetrySettings retrySettings) {
+    return new RetryAlgorithm<>(
+        resultRetryAlgorithm(),
+        new ExponentialRetryAlgorithm(retrySettings, NanoClock.getDefaultClock()));
+  }
+
+  private static <T> ResultRetryAlgorithm<T> resultRetryAlgorithm() {
+    return new ResultRetryAlgorithm<T>() {
+      @Override
+      public TimedAttemptSettings createNextAttempt(
+          Throwable prevThrowable, T prevResponse, TimedAttemptSettings prevSettings) {
+        return null; // Null means no specific settings.
+      }
+
+      @Override
+      public boolean shouldRetry(Throwable prevThrowable, T prevResponse) {
+        if (null != prevResponse) {
+          return false;
+        }
+        Optional<Status> statusOr = ExtractStatus.extract(prevThrowable);
+        if (!statusOr.isPresent()) {
+          return false; // Received a non-grpc error.
+        }
+        return ErrorCodes.IsRetryable(statusOr.get().getCode());
+      }
+    };
+  }
+}

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/TopicStatsClient.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/TopicStatsClient.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.pubsublite.internal;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.cloud.pubsublite.CloudRegion;
+import com.google.cloud.pubsublite.Offset;
+import com.google.cloud.pubsublite.Partition;
+import com.google.cloud.pubsublite.TopicPath;
+import com.google.cloud.pubsublite.proto.ComputeMessageStatsResponse;
+import io.grpc.StatusException;
+
+public interface TopicStatsClient extends BackgroundResource {
+
+  static TopicStatsClient create(TopicStatsClientSettings settings) throws StatusException {
+    return settings.instantiate();
+  }
+
+  /** The Google Cloud region this client operates on. */
+  CloudRegion region();
+
+  /**
+   * Compute statistics about the messages between two cursors in a topic partition.
+   *
+   * @param path The topic to compute statistics on
+   * @param partition The partition to compute statistics for
+   * @param start The start cursor
+   * @param end The end cursor
+   * @return A future that will have either an error {@link io.grpc.StatusException} or the
+   *     ComputeMessageStatistics on success.
+   */
+  ApiFuture<ComputeMessageStatsResponse> computeMessageStats(
+      TopicPath path, Partition partition, Offset start, Offset end);
+}

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/TopicStatsClient.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/TopicStatsClient.java
@@ -45,4 +45,11 @@ public interface TopicStatsClient extends BackgroundResource {
    */
   ApiFuture<ComputeMessageStatsResponse> computeMessageStats(
       TopicPath path, Partition partition, Offset start, Offset end);
+
+  /**
+   * Tear down this admin client.
+   *
+   * @throws StatusException on a failure to properly terminate.
+   */
+  void close() throws StatusException;
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/TopicStatsClientImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/TopicStatsClientImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.pubsublite.internal;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.core.BackgroundResourceAggregation;
+import com.google.api.gax.core.ExecutorAsBackgroundResource;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.retrying.RetryingExecutor;
+import com.google.cloud.pubsublite.CloudRegion;
+import com.google.cloud.pubsublite.Offset;
+import com.google.cloud.pubsublite.Partition;
+import com.google.cloud.pubsublite.TopicPath;
+import com.google.cloud.pubsublite.proto.ComputeMessageStatsRequest;
+import com.google.cloud.pubsublite.proto.ComputeMessageStatsResponse;
+import com.google.cloud.pubsublite.proto.Cursor;
+import com.google.cloud.pubsublite.proto.TopicStatsServiceGrpc;
+import com.google.common.collect.ImmutableList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class TopicStatsClientImpl extends BackgroundResourceAggregation
+    implements TopicStatsClient {
+  private final CloudRegion region;
+  private final TopicStatsServiceGrpc.TopicStatsServiceBlockingStub stub;
+  private final RetryingExecutor<ComputeMessageStatsResponse> retryingExecutor;
+
+  public TopicStatsClientImpl(
+      CloudRegion region,
+      TopicStatsServiceGrpc.TopicStatsServiceBlockingStub stub,
+      RetrySettings retrySettings) {
+    this(
+        region,
+        stub,
+        retrySettings,
+        // TODO: Consider allowing tuning in the future.
+        Executors.newScheduledThreadPool(6));
+  }
+
+  private TopicStatsClientImpl(
+      CloudRegion region,
+      TopicStatsServiceGrpc.TopicStatsServiceBlockingStub stub,
+      RetrySettings retrySettings,
+      ScheduledExecutorService executor) {
+    super(ImmutableList.of(new ExecutorAsBackgroundResource(executor)));
+    this.region = region;
+    this.stub = stub;
+    this.retryingExecutor = RetryingExecutorUtil.retryingExecutor(retrySettings, executor);
+  }
+
+  @Override
+  public CloudRegion region() {
+    return region;
+  }
+
+  @Override
+  public ApiFuture<ComputeMessageStatsResponse> computeMessageStats(
+      TopicPath path, Partition partition, Offset start, Offset end) {
+    return RetryingExecutorUtil.runWithRetries(
+        () -> {
+          return stub.computeMessageStats(
+              ComputeMessageStatsRequest.newBuilder()
+                  .setTopic(path.toString())
+                  .setPartition(partition.value())
+                  .setStartCursor(Cursor.newBuilder().setOffset(start.value()).build())
+                  .setEndCursor(Cursor.newBuilder().setOffset(end.value()).build())
+                  .build());
+        },
+        retryingExecutor);
+  }
+}

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/TopicStatsClientSettings.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/TopicStatsClientSettings.java
@@ -18,6 +18,7 @@ package com.google.cloud.pubsublite.internal;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.pubsublite.CloudRegion;
+import com.google.cloud.pubsublite.Constants;
 import com.google.cloud.pubsublite.Endpoints;
 import com.google.cloud.pubsublite.Stubs;
 import com.google.cloud.pubsublite.proto.TopicStatsServiceGrpc;
@@ -26,30 +27,21 @@ import io.grpc.Status;
 import io.grpc.StatusException;
 import java.io.IOException;
 import java.util.Optional;
-import org.threeten.bp.Duration;
 
 @AutoValue
 public abstract class TopicStatsClientSettings {
-
-  public static final RetrySettings DEFAULT_RETRY_SETTINGS =
-      RetrySettings.newBuilder()
-          .setInitialRetryDelay(Duration.ofMillis(100))
-          .setRetryDelayMultiplier(1.3)
-          .setMaxRetryDelay(Duration.ofSeconds(60))
-          .setJittered(true)
-          .setTotalTimeout(Duration.ofMinutes(10))
-          .build();
 
   // Required parameters.
   abstract CloudRegion region();
 
   // Optional parameters.
-  abstract Optional<RetrySettings> retrySettings();
+  abstract RetrySettings retrySettings();
 
   abstract Optional<TopicStatsServiceBlockingStub> stub();
 
   public static Builder newBuilder() {
-    return new AutoValue_TopicStatsClientSettings.Builder();
+    return new AutoValue_TopicStatsClientSettings.Builder()
+        .setRetrySettings(Constants.DEFAULT_RETRY_SETTINGS);
   }
 
   @AutoValue.Builder
@@ -58,9 +50,9 @@ public abstract class TopicStatsClientSettings {
     // Required parameters.
     public abstract Builder setRegion(CloudRegion region);
 
-    // Optional parameters.
     public abstract Builder setRetrySettings(RetrySettings retrySettings);
 
+    // Optional parameters.
     public abstract Builder setStub(TopicStatsServiceBlockingStub stub);
 
     public abstract TopicStatsClientSettings build();
@@ -82,6 +74,6 @@ public abstract class TopicStatsClientSettings {
             .asException();
       }
     }
-    return new TopicStatsClientImpl(region(), stub, retrySettings().orElse(DEFAULT_RETRY_SETTINGS));
+    return new TopicStatsClientImpl(region(), stub, retrySettings());
   }
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/TopicStatsClientSettings.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/TopicStatsClientSettings.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.pubsublite.internal;
+
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.auto.value.AutoValue;
+import com.google.cloud.pubsublite.CloudRegion;
+import com.google.cloud.pubsublite.Endpoints;
+import com.google.cloud.pubsublite.Stubs;
+import com.google.cloud.pubsublite.proto.TopicStatsServiceGrpc;
+import com.google.cloud.pubsublite.proto.TopicStatsServiceGrpc.TopicStatsServiceBlockingStub;
+import io.grpc.Status;
+import io.grpc.StatusException;
+import java.io.IOException;
+import java.util.Optional;
+import org.threeten.bp.Duration;
+
+@AutoValue
+public abstract class TopicStatsClientSettings {
+
+  public static final RetrySettings DEFAULT_RETRY_SETTINGS =
+      RetrySettings.newBuilder()
+          .setInitialRetryDelay(Duration.ofMillis(100))
+          .setRetryDelayMultiplier(1.3)
+          .setMaxRetryDelay(Duration.ofSeconds(60))
+          .setJittered(true)
+          .setTotalTimeout(Duration.ofMinutes(10))
+          .build();
+
+  // Required parameters.
+  abstract CloudRegion region();
+
+  // Optional parameters.
+  abstract Optional<RetrySettings> retrySettings();
+
+  abstract Optional<TopicStatsServiceBlockingStub> stub();
+
+  public static Builder newBuilder() {
+    return new AutoValue_TopicStatsClientSettings.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    // Required parameters.
+    public abstract Builder setRegion(CloudRegion region);
+
+    // Optional parameters.
+    public abstract Builder setRetrySettings(RetrySettings retrySettings);
+
+    public abstract Builder setStub(TopicStatsServiceBlockingStub stub);
+
+    public abstract TopicStatsClientSettings build();
+  }
+
+  TopicStatsClient instantiate() throws StatusException {
+    TopicStatsServiceBlockingStub stub;
+    if (stub().isPresent()) {
+      stub = stub().get();
+    } else {
+      try {
+        stub =
+            Stubs.defaultStub(
+                Endpoints.regionalEndpoint(region()), TopicStatsServiceGrpc::newBlockingStub);
+      } catch (IOException e) {
+        throw Status.INTERNAL
+            .withCause(e)
+            .withDescription("Creating topic stats stub failed.")
+            .asException();
+      }
+    }
+    return new TopicStatsClientImpl(region(), stub, retrySettings().orElse(DEFAULT_RETRY_SETTINGS));
+  }
+}

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/TestUtil.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/TestUtil.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.pubsublite.internal;
+
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.mockito.stubbing.Answer;
+
+public class TestUtil {
+
+  public static <T> Answer<Void> answerWith(T response) {
+    return invocation -> {
+      StreamObserver<T> responseObserver = invocation.getArgument(1);
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+      return null;
+    };
+  }
+
+  public static Answer<Void> answerWith(Status status) {
+    return invocation -> {
+      StreamObserver<?> responseObserver = invocation.getArgument(1);
+      responseObserver.onError(status.asRuntimeException());
+      return null;
+    };
+  }
+
+  public static Answer<Void> inOrder(Answer<Void>... answers) {
+    AtomicInteger count = new AtomicInteger(0);
+    return invocation -> {
+      int index = count.getAndIncrement();
+
+      return answers[index].answer(invocation);
+    };
+  }
+}

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/TopicStatsClientImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/TopicStatsClientImplTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.pubsublite.CloudRegion;
+import com.google.cloud.pubsublite.CloudZone;
+import com.google.cloud.pubsublite.ErrorCodes;
+import com.google.cloud.pubsublite.Offset;
+import com.google.cloud.pubsublite.Partition;
+import com.google.cloud.pubsublite.ProjectNumber;
+import com.google.cloud.pubsublite.TopicName;
+import com.google.cloud.pubsublite.TopicPath;
+import com.google.cloud.pubsublite.TopicPaths;
+import com.google.cloud.pubsublite.proto.ComputeMessageStatsRequest;
+import com.google.cloud.pubsublite.proto.ComputeMessageStatsResponse;
+import com.google.cloud.pubsublite.proto.Cursor;
+import com.google.cloud.pubsublite.proto.TopicStatsServiceGrpc;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.StatusException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.stubbing.Answer;
+
+@RunWith(JUnit4.class)
+public class TopicStatsClientImplTest {
+
+  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+  private static final CloudRegion REGION = CloudRegion.of("us-east1");
+
+  private static TopicPath path() {
+    try {
+      return TopicPaths.newBuilder()
+          .setTopicName(TopicName.of("a"))
+          .setProjectNumber(ProjectNumber.of(4))
+          .setZone(CloudZone.of(REGION, 'a'))
+          .build();
+
+    } catch (StatusException e) {
+      throw e.getStatus().asRuntimeException();
+    }
+  }
+
+  private static Partition partition() {
+    try {
+      return Partition.of(0);
+    } catch (StatusException e) {
+      throw e.getStatus().asRuntimeException();
+    }
+  }
+
+  private static Offset start() {
+    return Offset.of(1);
+  }
+
+  private static Offset end() {
+    return Offset.of(2);
+  }
+
+  private static ComputeMessageStatsRequest request() {
+    return ComputeMessageStatsRequest.newBuilder()
+        .setTopic(path().toString())
+        .setPartition(partition().value())
+        .setStartCursor(Cursor.newBuilder().setOffset(start().value()).build())
+        .setEndCursor(Cursor.newBuilder().setOffset(end().value()).build())
+        .build();
+  }
+
+  private static ComputeMessageStatsResponse response() {
+    return ComputeMessageStatsResponse.newBuilder().setMessageBytes(1).setMessageCount(2).build();
+  }
+
+  private final TopicStatsServiceGrpc.TopicStatsServiceImplBase serviceImpl =
+      mock(
+          TopicStatsServiceGrpc.TopicStatsServiceImplBase.class,
+          delegatesTo(new TopicStatsServiceGrpc.TopicStatsServiceImplBase() {}));
+
+  private TopicStatsClientImpl client;
+
+  @Before
+  public void setUp() throws IOException {
+    String serverName = InProcessServerBuilder.generateName();
+    grpcCleanup.register(
+        InProcessServerBuilder.forName(serverName)
+            .directExecutor()
+            .addService(serviceImpl)
+            .build()
+            .start());
+    ManagedChannel channel =
+        grpcCleanup.register(InProcessChannelBuilder.forName(serverName).directExecutor().build());
+    TopicStatsServiceGrpc.TopicStatsServiceBlockingStub stub =
+        TopicStatsServiceGrpc.newBlockingStub(channel);
+    client =
+        new TopicStatsClientImpl(REGION, stub, TopicStatsClientSettings.DEFAULT_RETRY_SETTINGS);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    client.shutdownNow();
+    Preconditions.checkArgument(client.awaitTermination(10, SECONDS));
+  }
+
+  @Test
+  public void region_isConstructedRegion() {
+    assertThat(client.region()).isEqualTo(REGION);
+  }
+
+  private static <T> Answer<Void> answerWith(T response) {
+    return invocation -> {
+      StreamObserver<T> responseObserver = invocation.getArgument(1);
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+      return null;
+    };
+  }
+
+  private static Answer<Void> answerWith(Status status) {
+    return invocation -> {
+      StreamObserver<?> responseObserver = invocation.getArgument(1);
+      responseObserver.onError(status.asRuntimeException());
+      return null;
+    };
+  }
+
+  private static Answer<Void> inOrder(Answer<Void>... answers) {
+    AtomicInteger count = new AtomicInteger(0);
+    return invocation -> {
+      int index = count.getAndIncrement();
+
+      return answers[index].answer(invocation);
+    };
+  }
+
+  @Test
+  public void computeMessageStats_Ok() throws Exception {
+    doAnswer(answerWith(response())).when(serviceImpl).computeMessageStats(eq(request()), any());
+    assertThat(client.computeMessageStats(path(), partition(), start(), end()).get())
+        .isEqualTo(response());
+  }
+
+  @Test
+  public void computeMessageStats_NonRetryableError() {
+    assertThat(ErrorCodes.IsRetryable(Code.FAILED_PRECONDITION)).isFalse();
+
+    doAnswer(answerWith(Status.FAILED_PRECONDITION))
+        .when(serviceImpl)
+        .computeMessageStats(eq(request()), any());
+
+    ApiFuture<ComputeMessageStatsResponse> future =
+        client.computeMessageStats(path(), partition(), start(), end());
+    ExecutionException exception = assertThrows(ExecutionException.class, future::get);
+    Optional<Status> statusOr = ExtractStatus.extract(exception.getCause());
+    assertThat(statusOr).isPresent();
+    assertThat(statusOr.get().getCode()).isEqualTo(Code.FAILED_PRECONDITION);
+  }
+
+  @Test
+  public void computeMessageStats_RetryableError() throws Exception {
+    for (Code code : ErrorCodes.RETRYABLE_CODES) {
+      assertThat(ErrorCodes.IsRetryable(code)).isTrue();
+      doAnswer(inOrder(answerWith(Status.fromCode(code)), answerWith(response())))
+          .when(serviceImpl)
+          .computeMessageStats(eq(request()), any());
+
+      assertThat(client.computeMessageStats(path(), partition(), start(), end()).get())
+          .isEqualTo(response());
+    }
+  }
+
+  @Test
+  public void computeMessageStats_MultipleRetryableErrors() throws Exception {
+    assertThat(ErrorCodes.IsRetryable(Code.DEADLINE_EXCEEDED)).isTrue();
+    doAnswer(
+            inOrder(
+                answerWith(Status.DEADLINE_EXCEEDED),
+                answerWith(Status.DEADLINE_EXCEEDED),
+                answerWith(response())))
+        .when(serviceImpl)
+        .computeMessageStats(eq(request()), any());
+
+    assertThat(client.computeMessageStats(path(), partition(), start(), end()).get())
+        .isEqualTo(response());
+  }
+}


### PR DESCRIPTION
Adds an interface and implementation for the TopicStatsClient. I've kept
them both in internal for now since we don't yet expose an API for
interacting with the CursorService.
