### PR TITLE
fix: Implement DefaultRoutingPolicyTest

### DIFF
--- a/google-cloud-pubsublite/pom.xml
+++ b/google-cloud-pubsublite/pom.xml
@@ -150,6 +150,11 @@
       <version>2.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- Need testing utility classes for generated gRPC clients tests -->
     <dependency>
       <groupId>com.google.api</groupId>

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/DefaultRoutingPolicyTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/DefaultRoutingPolicyTest.java
@@ -1,0 +1,46 @@
+package com.google.cloud.pubsublite.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.pubsublite.Partition;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.protobuf.ByteString;
+import io.grpc.StatusException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.junit.Test;
+
+public class DefaultRoutingPolicyTest {
+  private static final int NUM_PARTITIONS = 29;
+  private static final RoutingPolicy policy = ((Supplier<RoutingPolicy>)() -> {
+    try {
+      return new DefaultRoutingPolicy(NUM_PARTITIONS);
+    } catch (StatusException e) {
+      throw e.getStatus().asRuntimeException();
+    }
+  }).get();
+
+  private static Map<ByteString, Partition> loadTestCases() throws Exception {
+    Gson gson = new Gson();
+    String json = new String(Files.readAllBytes(Paths.get(DefaultRoutingPolicyTest.class.getResource("/routing_tests.json").toURI())));
+    Map<String, Double> map = gson.fromJson(json, Map.class);
+    ImmutableMap.Builder<ByteString, Partition> output = ImmutableMap.builder();
+    for (String key : map.keySet()) {
+      output.put(ByteString.copyFromUtf8(key), Partition.of((int)map.get(key).doubleValue()));
+    }
+    return output.build();
+  }
+
+  @Test
+  public void routingPerformedCorrectly() throws Exception {
+    Map<ByteString, Partition> map = loadTestCases();
+    ImmutableMap.Builder<ByteString, Partition> results = ImmutableMap.builder();
+    for (ByteString key : map.keySet()) {
+      results.put(key, policy.route(key));
+    }
+    assertThat(results.build()).containsExactlyEntriesIn(map);
+  }
+}

--- a/google-cloud-pubsublite/src/test/resources/routing_tests.json
+++ b/google-cloud-pubsublite/src/test/resources/routing_tests.json
@@ -1,0 +1,20 @@
+// File defining a map from routing keys to the expected partition in a 29
+// partition topic for test purposes. This file should be copied into all client
+// library test suites.
+{
+  "oaisdhfoiahsd": 18,
+  "P(#*YNPOIUDF": 9,
+  "LCIUNDFPOASIUN":8,
+  ";odsfiupoius": 9,
+  "OPISUDfpoiu": 2,
+  "dokjwO:IDf": 21,
+  "%^&*": 19,
+  "XXXXXXXXX": 15,
+  "dpcollins": 28,
+  "#()&$IJHLOIURF": 2,
+  "dfasiduyf": 6,
+  "983u2poer": 3,
+  "8888888": 6,
+  "OPUIPOUYPOIOPUIOIPUOUIPJOP": 2,
+  "x": 16
+}


### PR DESCRIPTION
This has a fixed set of test cases to ensure that all client libraries route the same keys to the same partitions.
