### PR TITLE
feat: Use TopicStats to implement getSplitBacklog

### DIFF
--- a/pubsublite-beam-io/pom.xml
+++ b/pubsublite-beam-io/pom.xml
@@ -77,6 +77,11 @@
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-pubsub-v1</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.30</version>
+    </dependency>
     <!--test dependencies-->
     <dependency>
       <groupId>junit</groupId>

--- a/pubsublite-beam-io/pom.xml
+++ b/pubsublite-beam-io/pom.xml
@@ -77,12 +77,13 @@
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-pubsub-v1</artifactId>
     </dependency>
+    <!--test dependencies-->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.30</version>
+      <scope>test</scope>
     </dependency>
-    <!--test dependencies-->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/pubsublite-beam-io/pom.xml
+++ b/pubsublite-beam-io/pom.xml
@@ -77,11 +77,17 @@
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-pubsub-v1</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.flogger</groupId>
+      <artifactId>google-extensions</artifactId>
+      <version>0.5.1</version>
+    </dependency>
+
     <!--test dependencies-->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
+      <groupId>com.google.flogger</groupId>
+      <artifactId>flogger-system-backend</artifactId>
+      <version>0.5.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -137,6 +143,7 @@
             <ignoredUnusedDeclaredDependencies>
               <ignoredUnusedDeclaredDependency>org.hamcrest:hamcrest</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>io.grpc:grpc-testing</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>com.google.flogger:flogger-system-backend</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.apache.beam:beam-runners-direct-java</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>
             </ignoredUnusedDeclaredDependencies>

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReader.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReader.java
@@ -31,6 +31,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.flogger.GoogleLogger;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
@@ -54,12 +55,10 @@ import org.apache.beam.sdk.io.UnboundedSource.CheckpointMark;
 import org.apache.beam.sdk.io.UnboundedSource.UnboundedReader;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.joda.time.Instant;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class PubsubLiteUnboundedReader extends UnboundedReader<SequencedMessage>
     implements OffsetFinalizer {
-  private static final Logger logger = LoggerFactory.getLogger(PubsubLiteUnboundedReader.class);
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
   private final UnboundedSource<SequencedMessage, ?> source;
   private final TopicBacklogReader backlogReader;
   private final LoadingCache<String, Long> backlogCache;
@@ -301,7 +300,7 @@ class PubsubLiteUnboundedReader extends UnboundedReader<SequencedMessage>
       // and expire the value after a maximum staleness, but there is only ever one key.
       return backlogCache.get("Backlog");
     } catch (ExecutionException e) {
-      logger.warn(
+      logger.atWarning().log(
           "Failed to retrieve backlog information, reporting the backlog size as UNKNOWN: {}",
           e.getCause().getMessage());
       return BACKLOG_UNKNOWN;

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReader.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReader.java
@@ -135,7 +135,7 @@ class PubsubLiteUnboundedReader extends UnboundedReader<SequencedMessage>
     try (CloseableMonitor.Hold h = monitor.enter()) {
       subscriberMap.forEach(
           (partition, subscriberState) ->
-              builder.put(partition, subscriberState.lastDelivered.orElse(Offset.of(0))));
+              subscriberState.lastDelivered.ifPresent(offset -> builder.put(partition, offset)));
     }
     return backlogReader.computeMessageStats(builder.build());
   }
@@ -304,9 +304,6 @@ class PubsubLiteUnboundedReader extends UnboundedReader<SequencedMessage>
       logger.warn(
           "Failed to retrieve backlog information, reporting the backlog size as UNKNOWN: {}",
           e.getCause().getMessage());
-      if (e.getCause() instanceof InterruptedException) {
-        Thread.currentThread().interrupt();
-      }
       return BACKLOG_UNKNOWN;
     }
   }

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedSource.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedSource.java
@@ -23,6 +23,7 @@ import com.google.cloud.pubsublite.Partition;
 import com.google.cloud.pubsublite.SequencedMessage;
 import com.google.cloud.pubsublite.internal.wire.Committer;
 import com.google.cloud.pubsublite.internal.wire.SubscriberFactory;
+import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -93,7 +94,11 @@ class PubsubLiteUnboundedSource extends UnboundedSource<SequencedMessage, Offset
         }
         statesBuilder.put(partition, state);
       }
-      return new PubsubLiteUnboundedReader(this, statesBuilder.build());
+      return new PubsubLiteUnboundedReader(
+          this,
+          statesBuilder.build(),
+          subscriberOptions.topicBacklogReader(),
+          Ticker.systemTicker());
     } catch (StatusException e) {
       throw new IOException(e);
     }

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/SubscriberOptions.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/SubscriberOptions.java
@@ -17,10 +17,17 @@
 package com.google.cloud.pubsublite.beam;
 
 import com.google.auto.value.AutoValue;
+import com.google.cloud.pubsublite.AdminClient;
+import com.google.cloud.pubsublite.AdminClientSettings;
 import com.google.cloud.pubsublite.Partition;
 import com.google.cloud.pubsublite.PartitionLookupUtils;
 import com.google.cloud.pubsublite.SubscriptionPath;
+import com.google.cloud.pubsublite.SubscriptionPaths;
+import com.google.cloud.pubsublite.TopicPath;
 import com.google.cloud.pubsublite.cloudpubsub.FlowControlSettings;
+import com.google.cloud.pubsublite.internal.ExtractStatus;
+import com.google.cloud.pubsublite.internal.TopicStatsClient;
+import com.google.cloud.pubsublite.internal.TopicStatsClientSettings;
 import com.google.cloud.pubsublite.internal.wire.Committer;
 import com.google.cloud.pubsublite.internal.wire.CommitterBuilder;
 import com.google.cloud.pubsublite.internal.wire.PubsubContext;
@@ -34,6 +41,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.grpc.StatusException;
 import java.io.Serializable;
+import java.util.concurrent.ExecutionException;
 
 @AutoValue
 public abstract class SubscriberOptions implements Serializable {
@@ -49,6 +57,9 @@ public abstract class SubscriberOptions implements Serializable {
   // Optional parameters.
   /** A set of partitions. If empty, retrieve the set of partitions using an admin client. */
   public abstract ImmutableSet<Partition> partitions();
+
+  /** The class used to read backlog for the subscription described by subscriptionPath() */
+  public abstract TopicBacklogReader topicBacklogReader();
 
   /** A supplier for the subscriber stub to be used. */
   public abstract Optional<SerializableSupplier<SubscriberServiceStub>> subscriberStubSupplier();
@@ -67,6 +78,8 @@ public abstract class SubscriberOptions implements Serializable {
    * useful for testing.
    */
   abstract Optional<SerializableSupplier<Committer>> committerSupplier();
+
+
 
   public static Builder newBuilder() {
     Builder builder = new AutoValue_SubscriberOptions.Builder();
@@ -133,24 +146,56 @@ public abstract class SubscriberOptions implements Serializable {
     public abstract Builder setCommitterStubSupplier(
         SerializableSupplier<CursorServiceStub> stubSupplier);
 
+    public abstract Builder setTopicBacklogReader(TopicBacklogReader topicBacklogReader);
+
+    // Used in unit tests
     abstract Builder setSubscriberFactory(SubscriberFactory subscriberFactory);
 
     abstract Builder setCommitterSupplier(SerializableSupplier<Committer> committerSupplier);
 
+
+    // Used for implementing build();
+    abstract SubscriptionPath subscriptionPath();
+
+    abstract ImmutableSet<Partition> partitions();
+
+    abstract Optional<TopicBacklogReader> topicBacklogReader();
+
     abstract SubscriberOptions autoBuild();
 
     public SubscriberOptions build() throws StatusException {
-      SubscriberOptions built = autoBuild();
-      if (!built.partitions().isEmpty()) {
-        return built;
+      if (!partitions().isEmpty() && topicBacklogReader().isPresent()) {
+        return autoBuild();
       }
-      int partition_count = PartitionLookupUtils.numPartitions(built.subscriptionPath());
-      SubscriberOptions.Builder builder = built.toBuilder();
-      ImmutableSet.Builder<Partition> partitions = ImmutableSet.builder();
-      for (int i = 0; i < partition_count; i++) {
-        partitions.add(Partition.of(i));
+      AdminClient adminClient =
+          AdminClient.create(
+              AdminClientSettings.newBuilder()
+                  .setRegion(SubscriptionPaths.getZone(subscriptionPath()).region())
+                  .build());
+      TopicPath path;
+      try {
+        path = TopicPath.of(adminClient.getSubscription(subscriptionPath()).get().getTopic());
+      } catch (ExecutionException e) {
+        throw ExtractStatus.toCanonical(e.getCause());
+      } catch (Throwable t) {
+        throw ExtractStatus.toCanonical(t);
       }
-      return builder.setPartitions(partitions.build()).autoBuild();
+
+      if (partitions().isEmpty()) {
+        int partition_count = PartitionLookupUtils.numPartitions(path);
+        ImmutableSet.Builder<Partition> partitions = ImmutableSet.builder();
+        for (int i = 0; i < partition_count; i++) {
+          partitions.add(Partition.of(i));
+        }
+        setPartitions(partitions.build());
+      }
+      if (!topicBacklogReader().isPresent()) {
+        setTopicBacklogReader(
+            new TopicBacklogReaderImpl(
+                TopicStatsClient.create(TopicStatsClientSettings.newBuilder().build()), path));
+      }
+
+      return autoBuild();
     }
   }
 }

--- a/pubsublite-beam-io/src/test/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReaderTest.java
+++ b/pubsublite-beam-io/src/test/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReaderTest.java
@@ -247,8 +247,7 @@ public class PubsubLiteUnboundedReaderTest {
 
   @Test
   public void splitBacklogBytes_returnsUnknownBacklogOnError() throws Exception {
-    when(backlogReader.computeMessageStats(
-            ImmutableMap.of(Partition.of(5), Offset.of(0), Partition.of(8), Offset.of(0))))
+    when(backlogReader.computeMessageStats(ImmutableMap.of()))
         .thenReturn(ApiFutures.immediateFailedFuture(new StatusException(Status.UNAVAILABLE)));
     Assert.assertEquals(PubsubLiteUnboundedReader.BACKLOG_UNKNOWN, reader.getSplitBacklogBytes());
   }
@@ -257,8 +256,7 @@ public class PubsubLiteUnboundedReaderTest {
   public void splitBacklogBytes_computesBacklog() throws Exception {
     ComputeMessageStatsResponse response =
         ComputeMessageStatsResponse.newBuilder().setMessageBytes(40).build();
-    when(backlogReader.computeMessageStats(
-            ImmutableMap.of(Partition.of(5), Offset.of(0), Partition.of(8), Offset.of(0))))
+    when(backlogReader.computeMessageStats(ImmutableMap.of()))
         .thenReturn(ApiFutures.immediateFuture(response));
     Assert.assertEquals(response.getMessageBytes(), reader.getSplitBacklogBytes());
   }
@@ -270,8 +268,7 @@ public class PubsubLiteUnboundedReaderTest {
     ComputeMessageStatsResponse response2 =
         ComputeMessageStatsResponse.newBuilder().setMessageBytes(50).build();
 
-    when(backlogReader.computeMessageStats(
-            ImmutableMap.of(Partition.of(5), Offset.of(0), Partition.of(8), Offset.of(0))))
+    when(backlogReader.computeMessageStats(ImmutableMap.of()))
         .thenReturn(ApiFutures.immediateFuture(response1), ApiFutures.immediateFuture(response2));
 
     Assert.assertEquals(response1.getMessageBytes(), reader.getSplitBacklogBytes());
@@ -286,8 +283,7 @@ public class PubsubLiteUnboundedReaderTest {
     ComputeMessageStatsResponse response =
         ComputeMessageStatsResponse.newBuilder().setMessageBytes(40).build();
 
-    when(backlogReader.computeMessageStats(
-            ImmutableMap.of(Partition.of(5), Offset.of(0), Partition.of(8), Offset.of(0))))
+    when(backlogReader.computeMessageStats(ImmutableMap.of()))
         .thenReturn(
             ApiFutures.immediateFuture(response),
             ApiFutures.immediateFailedFuture(new StatusException(Status.UNAVAILABLE)));

--- a/pubsublite-beam-io/src/test/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReaderTest.java
+++ b/pubsublite-beam-io/src/test/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReaderTest.java
@@ -32,10 +32,15 @@ import com.google.cloud.pubsublite.SequencedMessage;
 import com.google.cloud.pubsublite.beam.PubsubLiteUnboundedReader.SubscriberState;
 import com.google.cloud.pubsublite.internal.FakeApiService;
 import com.google.cloud.pubsublite.internal.wire.Committer;
+import com.google.cloud.pubsublite.proto.ComputeMessageStatsResponse;
+import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Durations;
 import com.google.protobuf.util.Timestamps;
+import io.grpc.Status;
 import io.grpc.StatusException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,6 +51,7 @@ import org.apache.beam.sdk.io.UnboundedSource;
 import org.apache.beam.sdk.io.UnboundedSource.CheckpointMark;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.joda.time.Instant;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -62,11 +68,31 @@ public class PubsubLiteUnboundedReaderTest {
 
   abstract static class CommitterFakeService extends FakeApiService implements Committer {}
 
+  private static class FakeTicker extends Ticker {
+    private Timestamp time;
+
+    FakeTicker(Timestamp start) {
+      time = start;
+    }
+
+    @Override
+    public long read() {
+      return Timestamps.toNanos(time);
+    }
+
+    public void advance(Duration duration) {
+      time = Timestamps.add(time, duration);
+    }
+  }
+
   @Spy private CommitterFakeService committer5;
   @Spy private CommitterFakeService committer8;
 
   @SuppressWarnings("unchecked")
   private final UnboundedSource<SequencedMessage, ?> source = mock(UnboundedSource.class);
+
+  private final TopicBacklogReader backlogReader = mock(TopicBacklogReader.class);
+  private final FakeTicker ticker = new FakeTicker(Timestamps.fromSeconds(450));
 
   private final PubsubLiteUnboundedReader reader;
 
@@ -92,7 +118,10 @@ public class PubsubLiteUnboundedReaderTest {
     state8.committer = committer8;
     reader =
         new PubsubLiteUnboundedReader(
-            source, ImmutableMap.of(Partition.of(5), state5, Partition.of(8), state8));
+            source,
+            ImmutableMap.of(Partition.of(5), state5, Partition.of(8), state8),
+            backlogReader,
+            ticker);
   }
 
   @Test
@@ -214,5 +243,77 @@ public class PubsubLiteUnboundedReaderTest {
     when(committer5.commitOffset(Offset.of(10))).thenReturn(ApiFutures.immediateFuture(null));
     mark.finalizeCheckpoint();
     verify(committer5).commitOffset(Offset.of(10));
+  }
+
+  @Test
+  public void splitBacklogBytes_returnsUnknownBacklogOnError() throws Exception {
+    when(backlogReader.computeMessageStats(
+            ImmutableMap.of(Partition.of(5), Offset.of(0), Partition.of(8), Offset.of(0))))
+        .thenReturn(ApiFutures.immediateFailedFuture(new StatusException(Status.UNAVAILABLE)));
+    Assert.assertEquals(PubsubLiteUnboundedReader.BACKLOG_UNKNOWN, reader.getSplitBacklogBytes());
+  }
+
+  @Test
+  public void splitBacklogBytes_computesBacklog() throws Exception {
+    ComputeMessageStatsResponse response =
+        ComputeMessageStatsResponse.newBuilder().setMessageBytes(40).build();
+    when(backlogReader.computeMessageStats(
+            ImmutableMap.of(Partition.of(5), Offset.of(0), Partition.of(8), Offset.of(0))))
+        .thenReturn(ApiFutures.immediateFuture(response));
+    Assert.assertEquals(response.getMessageBytes(), reader.getSplitBacklogBytes());
+  }
+
+  @Test
+  public void splitBacklogBytes_computesBacklogOncePerTenSeconds() throws Exception {
+    ComputeMessageStatsResponse response1 =
+        ComputeMessageStatsResponse.newBuilder().setMessageBytes(40).build();
+    ComputeMessageStatsResponse response2 =
+        ComputeMessageStatsResponse.newBuilder().setMessageBytes(50).build();
+
+    when(backlogReader.computeMessageStats(
+            ImmutableMap.of(Partition.of(5), Offset.of(0), Partition.of(8), Offset.of(0))))
+        .thenReturn(ApiFutures.immediateFuture(response1), ApiFutures.immediateFuture(response2));
+
+    Assert.assertEquals(response1.getMessageBytes(), reader.getSplitBacklogBytes());
+    ticker.advance(Durations.fromSeconds(10));
+    Assert.assertEquals(response1.getMessageBytes(), reader.getSplitBacklogBytes());
+    ticker.advance(Durations.fromSeconds(1));
+    Assert.assertEquals(response2.getMessageBytes(), reader.getSplitBacklogBytes());
+  }
+
+  @Test
+  public void splitBacklogBytes_oldValueExpiresAfterOneMinute() throws Exception {
+    ComputeMessageStatsResponse response =
+        ComputeMessageStatsResponse.newBuilder().setMessageBytes(40).build();
+
+    when(backlogReader.computeMessageStats(
+            ImmutableMap.of(Partition.of(5), Offset.of(0), Partition.of(8), Offset.of(0))))
+        .thenReturn(
+            ApiFutures.immediateFuture(response),
+            ApiFutures.immediateFailedFuture(new StatusException(Status.UNAVAILABLE)));
+
+    Assert.assertEquals(response.getMessageBytes(), reader.getSplitBacklogBytes());
+    ticker.advance(Durations.fromSeconds(30));
+    Assert.assertEquals(response.getMessageBytes(), reader.getSplitBacklogBytes());
+    ticker.advance(Durations.fromSeconds(31));
+    Assert.assertEquals(PubsubLiteUnboundedReader.BACKLOG_UNKNOWN, reader.getSplitBacklogBytes());
+  }
+
+  @Test
+  public void splitBacklogBytes_usesCorrectCursorValues() throws Exception {
+    SequencedMessage message1 = exampleMessage(Offset.of(10), randomMilliAllignedTimestamp());
+    SequencedMessage message2 = exampleMessage(Offset.of(888), randomMilliAllignedTimestamp());
+    ComputeMessageStatsResponse response =
+        ComputeMessageStatsResponse.newBuilder().setMessageBytes(40).build();
+
+    when(subscriber5.pull()).thenReturn(ImmutableList.of(message1));
+    when(subscriber8.pull()).thenReturn(ImmutableList.of(message2));
+    when(backlogReader.computeMessageStats(
+            ImmutableMap.of(Partition.of(5), Offset.of(10), Partition.of(8), Offset.of(888))))
+        .thenReturn(ApiFutures.immediateFuture(response));
+
+    assertThat(reader.start()).isTrue();
+    assertThat(reader.advance()).isTrue();
+    Assert.assertEquals(response.getMessageBytes(), reader.getSplitBacklogBytes());
   }
 }


### PR DESCRIPTION
We use the TopicStatsService to compute the backlog size for the
assigned splits in the PubsubLiteUnbounded Reader.

We will refresh backlog information every ten seconds, and will use
stale information for up to a minute if the topic stats serivce is
unavailable.

Constructing the TopicBacklogReader in SubscriberOptions is a bit
awkward, but I wanted to make sure we don't need to re-resolve the
subscription -> topic mapping when we split or merge the source.
Otherwise we end up with a hard dependency on the admin service.