### PR TITLE
chore: Move BufferingPullSubscriber into google-cloud-pubsublite

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/BufferingPullSubscriber.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/BufferingPullSubscriber.java
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package com.google.cloud.pubsublite.beam;
+package com.google.cloud.pubsublite.internal;
 
 import com.google.api.core.ApiService.Listener;
 import com.google.api.core.ApiService.State;
 import com.google.cloud.pubsublite.Offset;
 import com.google.cloud.pubsublite.SequencedMessage;
 import com.google.cloud.pubsublite.cloudpubsub.FlowControlSettings;
-import com.google.cloud.pubsublite.internal.ExtractStatus;
 import com.google.cloud.pubsublite.internal.wire.Subscriber;
 import com.google.cloud.pubsublite.internal.wire.SubscriberFactory;
 import com.google.cloud.pubsublite.proto.Cursor;
@@ -36,12 +35,12 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
-class BufferingPullSubscriber implements PullSubscriber<SequencedMessage> {
+public class BufferingPullSubscriber implements PullSubscriber<SequencedMessage> {
   private final Subscriber underlying;
   private final AtomicReference<StatusException> error = new AtomicReference<>();
   private final LinkedBlockingQueue<SequencedMessage> messages = new LinkedBlockingQueue<>();
 
-  BufferingPullSubscriber(SubscriberFactory factory, FlowControlSettings settings)
+  public BufferingPullSubscriber(SubscriberFactory factory, FlowControlSettings settings)
       throws StatusException {
     underlying = factory.New(messages::addAll);
     underlying.addListener(
@@ -60,7 +59,7 @@ class BufferingPullSubscriber implements PullSubscriber<SequencedMessage> {
             .build());
   }
 
-  BufferingPullSubscriber(
+  public BufferingPullSubscriber(
       SubscriberFactory factory, FlowControlSettings settings, Offset initialLocation)
       throws StatusException {
     this(factory, settings);

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/PullSubscriber.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/PullSubscriber.java
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package com.google.cloud.pubsublite.beam;
+package com.google.cloud.pubsublite.internal;
 
 import com.google.common.collect.ImmutableList;
 import io.grpc.StatusException;
 
 // A PullSubscriber exposes a "pull" mechanism for retrieving messages.
-interface PullSubscriber<T> extends AutoCloseable {
+public interface PullSubscriber<T> extends AutoCloseable {
   // Pull currently available messages from this subscriber. Does not block.
   ImmutableList<T> pull() throws StatusException;
 }

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/BufferingPullSubscriberTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/BufferingPullSubscriberTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.pubsublite.beam;
+package com.google.cloud.pubsublite.internal;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReader.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReader.java
@@ -24,6 +24,7 @@ import com.google.cloud.pubsublite.SequencedMessage;
 import com.google.cloud.pubsublite.internal.CloseableMonitor;
 import com.google.cloud.pubsublite.internal.ExtractStatus;
 import com.google.cloud.pubsublite.internal.ProxyService;
+import com.google.cloud.pubsublite.internal.PullSubscriber;
 import com.google.cloud.pubsublite.internal.wire.Committer;
 import com.google.cloud.pubsublite.proto.ComputeMessageStatsResponse;
 import com.google.common.base.Ticker;

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedSource.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedSource.java
@@ -21,6 +21,7 @@ import static com.google.cloud.pubsublite.internal.Preconditions.checkState;
 import com.google.cloud.pubsublite.Offset;
 import com.google.cloud.pubsublite.Partition;
 import com.google.cloud.pubsublite.SequencedMessage;
+import com.google.cloud.pubsublite.internal.BufferingPullSubscriber;
 import com.google.cloud.pubsublite.internal.wire.Committer;
 import com.google.cloud.pubsublite.internal.wire.SubscriberFactory;
 import com.google.common.base.Ticker;

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/SubscriberOptions.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/SubscriberOptions.java
@@ -167,7 +167,7 @@ public abstract class SubscriberOptions implements Serializable {
       try (AdminClient adminClient =
           AdminClient.create(
               AdminClientSettings.newBuilder()
-                  .setRegion(subscriptionPath().location().location().region())
+                  .setRegion(subscriptionPath().location().region())
                   .build())) {
         path = TopicPath.parse(adminClient.getSubscription(subscriptionPath()).get().getTopic());
       } catch (ExecutionException e) {

--- a/pubsublite-beam-io/src/test/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReaderTest.java
+++ b/pubsublite-beam-io/src/test/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReaderTest.java
@@ -31,6 +31,7 @@ import com.google.cloud.pubsublite.Partition;
 import com.google.cloud.pubsublite.SequencedMessage;
 import com.google.cloud.pubsublite.beam.PubsubLiteUnboundedReader.SubscriberState;
 import com.google.cloud.pubsublite.internal.FakeApiService;
+import com.google.cloud.pubsublite.internal.PullSubscriber;
 import com.google.cloud.pubsublite.internal.wire.Committer;
 import com.google.cloud.pubsublite.proto.ComputeMessageStatsResponse;
 import com.google.common.base.Ticker;


### PR DESCRIPTION
This enables it to be reused outside of the beam library.
