### PR TITLE
fix: Fix BufferingPullSubscriber to not seek after sending flow control tokens.

### DIFF
--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/BufferingPullSubscriberTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/BufferingPullSubscriberTest.java
@@ -56,6 +56,10 @@ public class BufferingPullSubscriberTest {
   private final SubscriberFactory underlyingFactory = mock(SubscriberFactory.class);
   private final Subscriber underlying = mock(Subscriber.class);
   private final Offset initialOffset = Offset.of(5);
+  private final SeekRequest initialSeek =
+      SeekRequest.newBuilder()
+          .setCursor(Cursor.newBuilder().setOffset(initialOffset.value()))
+          .build();
   private final FlowControlSettings flowControlSettings =
       ((Supplier<FlowControlSettings>)
               () -> {
@@ -102,15 +106,15 @@ public class BufferingPullSubscriberTest {
         .when(underlying)
         .addListener(any(), any());
 
-    subscriber = new BufferingPullSubscriber(underlyingFactory, flowControlSettings, initialOffset);
+    subscriber = new BufferingPullSubscriber(underlyingFactory, flowControlSettings, initialSeek);
 
     InOrder inOrder = inOrder(underlyingFactory, underlying);
     inOrder.verify(underlyingFactory).New(any());
     inOrder.verify(underlying).addListener(any(), any());
     inOrder.verify(underlying).startAsync();
     inOrder.verify(underlying).awaitRunning();
-    inOrder.verify(underlying).allowFlow(flow);
     inOrder.verify(underlying).seek(seek);
+    inOrder.verify(underlying).allowFlow(flow);
 
     assertThat(messageConsumer).isNotNull();
     assertThat(errorListener).isNotNull();

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedSource.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedSource.java
@@ -24,6 +24,8 @@ import com.google.cloud.pubsublite.SequencedMessage;
 import com.google.cloud.pubsublite.internal.BufferingPullSubscriber;
 import com.google.cloud.pubsublite.internal.wire.Committer;
 import com.google.cloud.pubsublite.internal.wire.SubscriberFactory;
+import com.google.cloud.pubsublite.proto.Cursor;
+import com.google.cloud.pubsublite.proto.SeekRequest;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -87,7 +89,9 @@ class PubsubLiteUnboundedSource extends UnboundedSource<SequencedMessage, Offset
               new BufferingPullSubscriber(
                   subscriberFactories.get(partition),
                   subscriberOptions.flowControlSettings(),
-                  checkpointed);
+                  SeekRequest.newBuilder()
+                      .setCursor(Cursor.newBuilder().setOffset(checkpointed.value()))
+                      .build());
         } else {
           state.subscriber =
               new BufferingPullSubscriber(


### PR DESCRIPTION
Seeking after sending tokens will discard any flow control tokens sent to the server. Also, update BufferingPullSubscriber to accept arbitrary initial seek requests.