### PR TITLE
fix: Make connections start up asynchronously

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/PublisherSettings.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/PublisherSettings.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.pubsublite.cloudpubsub;
 
+import static com.google.cloud.pubsublite.ProjectLookupUtils.toCanonical;
+
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.pubsublite.Constants;
@@ -124,7 +126,7 @@ public abstract class PublisherSettings {
 
     RoutingPublisherBuilder.Builder wireBuilder =
         RoutingPublisherBuilder.newBuilder()
-            .setTopic(topicPath())
+            .setTopic(toCanonical(topicPath()))
             .setPublisherBuilder(singlePartitionPublisherBuilder);
 
     numPartitions().ifPresent(wireBuilder::setNumPartitions);

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/SubscriberSettings.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/SubscriberSettings.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.pubsublite.cloudpubsub;
 
+import static com.google.cloud.pubsublite.ProjectLookupUtils.toCanonical;
+
 import com.google.auto.value.AutoValue;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsublite.MessageTransformer;
@@ -142,13 +144,15 @@ public abstract class SubscriberSettings {
 
   @SuppressWarnings("CheckReturnValue")
   Subscriber instantiate() throws StatusException {
+    SubscriptionPath canonicalPath = toCanonical(subscriptionPath());
+
     SubscriberBuilder.Builder wireSubscriberBuilder = SubscriberBuilder.newBuilder();
-    wireSubscriberBuilder.setSubscriptionPath(subscriptionPath());
+    wireSubscriberBuilder.setSubscriptionPath(canonicalPath);
     subscriberServiceStub().ifPresent(wireSubscriberBuilder::setSubscriberServiceStub);
     wireSubscriberBuilder.setContext(PubsubContext.of(FRAMEWORK));
 
     CommitterBuilder.Builder wireCommitterBuilder = CommitterBuilder.newBuilder();
-    wireCommitterBuilder.setSubscriptionPath(subscriptionPath());
+    wireCommitterBuilder.setSubscriptionPath(canonicalPath);
     cursorServiceStub().ifPresent(wireCommitterBuilder::setCursorStub);
 
     PartitionSubscriberFactory partitionSubscriberFactory =
@@ -166,7 +170,7 @@ public abstract class SubscriberSettings {
 
     if (!partitions().isPresent()) {
       AssignerBuilder.Builder assignerBuilder = AssignerBuilder.newBuilder();
-      assignerBuilder.setSubscriptionPath(subscriptionPath());
+      assignerBuilder.setSubscriptionPath(canonicalPath);
       assignmentServiceStub().ifPresent(assignerBuilder::setAssignmentStub);
       AssignerFactory assignerFactory =
           receiver -> {

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/RetryingConnectionImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/RetryingConnectionImpl.java
@@ -85,8 +85,11 @@ class RetryingConnectionImpl<
 
   @Override
   protected void doStart() {
-    reinitialize();
-    notifyStarted();
+    this.systemExecutor.execute(
+        () -> {
+          reinitialize();
+          notifyStarted();
+        });
   }
 
   // Reinitialize the stream. Must be called in a downcall to prevent deadlock.

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/AssignerImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/AssignerImplTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.pubsublite.internal.wire;
 
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -132,6 +133,7 @@ public class AssignerImplTest {
   @Test
   public void responseObserverFailure_Fails() {
     leakedResponseObserver.onError(Status.INVALID_ARGUMENT.asException());
+    assertThrows(IllegalStateException.class, () -> assigner.awaitTerminated());
     verify(permanentErrorHandler)
         .failed(any(), argThat(new StatusExceptionMatcher(Code.INVALID_ARGUMENT)));
   }

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/AssignerImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/AssignerImplTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.pubsublite.internal.wire;
 
+import static com.google.cloud.pubsublite.internal.wire.RetryingConnectionHelpers.whenFailed;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -46,7 +47,7 @@ import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -132,16 +133,9 @@ public class AssignerImplTest {
 
   @Test
   public void responseObserverFailure_Fails() throws Exception {
-    CountDownLatch failed = new CountDownLatch(1);
-    doAnswer(
-            args -> {
-              failed.countDown();
-              return null;
-            })
-        .when(permanentErrorHandler)
-        .failed(any(), any());
+    Future<Void> failed = whenFailed(permanentErrorHandler);
     leakedResponseObserver.onError(Status.INVALID_ARGUMENT.asException());
-    failed.await();
+    failed.get();
     verify(permanentErrorHandler)
         .failed(any(), argThat(new StatusExceptionMatcher(Code.INVALID_ARGUMENT)));
   }

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/CommitterImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/CommitterImplTest.java
@@ -187,16 +187,10 @@ public class CommitterImplTest {
   @Test
   public void stopInCommitCallback() throws Exception {
     ApiFuture<Void> future = committer.commitOffset(Offset.of(10));
-    CountDownLatch latch = new CountDownLatch(1);
-    ExtractStatus.addFailureHandler(
-        future,
-        (error) -> {
-          committer.stopAsync();
-          latch.countDown();
-        });
+    Future<Void> failed = whenFailed(permanentErrorHandler);
     leakedResponseObserver.onError(Status.FAILED_PRECONDITION.asException());
-    latch.await();
     assertFutureThrowsCode(future, Code.FAILED_PRECONDITION);
+    failed.get();
     verify(permanentErrorHandler)
         .failed(any(), argThat(new StatusExceptionMatcher(Code.FAILED_PRECONDITION)));
   }

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/CommitterImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/CommitterImplTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.pubsublite.internal.wire;
 
 import static com.google.cloud.pubsublite.internal.StatusExceptionMatcher.assertFutureThrowsCode;
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -152,6 +153,7 @@ public class CommitterImplTest {
   public void responseMoreThanSentError() {
     ApiFuture<Void> future = committer.commitOffset(Offset.of(10));
     leakedResponseObserver.onNext(ResponseWithCount(2));
+    assertThrows(IllegalStateException.class, () -> committer.awaitTerminated());
     verify(permanentErrorHandler)
         .failed(any(), argThat(new StatusExceptionMatcher(Code.FAILED_PRECONDITION)));
     assertFutureThrowsCode(future, Code.FAILED_PRECONDITION);

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/RetryingConnectionHelpers.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/RetryingConnectionHelpers.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.pubsublite.internal.wire;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/RetryingConnectionHelpers.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/RetryingConnectionHelpers.java
@@ -1,0 +1,22 @@
+package com.google.cloud.pubsublite.internal.wire;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+import com.google.api.core.ApiService.Listener;
+import com.google.api.core.SettableApiFuture;
+import java.util.concurrent.Future;
+
+class RetryingConnectionHelpers {
+  static Future<Void> whenFailed(Listener mockListener) {
+    SettableApiFuture<Void> future = SettableApiFuture.create();
+    doAnswer(
+            args -> {
+              future.set(null);
+              return null;
+            })
+        .when(mockListener)
+        .failed(any(), any());
+    return future;
+  }
+}


### PR DESCRIPTION
This lets publishers initialize many connections at once for lower startup times with many partitions.

