### PR TITLE
samples: update create topic sample and comments

### DIFF
--- a/samples/snippets/src/main/java/pubsublite/CreateSubscriptionExample.java
+++ b/samples/snippets/src/main/java/pubsublite/CreateSubscriptionExample.java
@@ -64,11 +64,12 @@ public class CreateSubscriptionExample {
     Subscription subscription =
         Subscription.newBuilder()
             .setDeliveryConfig(
-                // The server does not wait for a published message to be successfully
-                // written to storage before delivering it to subscribers. As such, a
-                // subscriber may receive a message for which the write to storage failed.
-                // If the subscriber re-reads the offset of that message later on, there
-                // may be a gap at that offset.
+                // Possible values for delivery_requirement:
+                // - `DELIVER_IMMEDIATELY`
+                // - `DELIVER_AFTER_STORED`
+                // You may choose whether to wait for a published message to be successfully written
+                // to storage before the server delivers it to subscribers. `DELIVER_IMMEDIATELY` is
+                // suitable for applications that need higher throughput.
                 DeliveryConfig.newBuilder()
                     .setDeliveryRequirement(DeliveryRequirement.DELIVER_IMMEDIATELY))
             .setName(subscriptionPath.toString())

--- a/samples/snippets/src/main/java/pubsublite/CreateSubscriptionExample.java
+++ b/samples/snippets/src/main/java/pubsublite/CreateSubscriptionExample.java
@@ -64,7 +64,7 @@ public class CreateSubscriptionExample {
     Subscription subscription =
         Subscription.newBuilder()
             .setDeliveryConfig(
-                // Possible values for delivery_requirement:
+                // Possible values for DeliveryRequirement:
                 // - `DELIVER_IMMEDIATELY`
                 // - `DELIVER_AFTER_STORED`
                 // You may choose whether to wait for a published message to be successfully written

--- a/samples/snippets/src/main/java/pubsublite/CreateTopicExample.java
+++ b/samples/snippets/src/main/java/pubsublite/CreateTopicExample.java
@@ -57,10 +57,14 @@ public class CreateTopicExample {
         Topic.newBuilder()
             .setPartitionConfig(
                 PartitionConfig.newBuilder()
-                    // Set publishing throughput to 1 times the standard partition
-                    // throughput of 4 MiB per sec. This must be in the range [1,4]. A
-                    // topic with `scale` of 2 and count of 10 is charged for 20 partitions.
-                    .setScale(1)
+                    // Set throughput capacity per partition in MiB/s.
+                    .setCapacity(
+                        PartitionConfig.Capacity.newBuilder()
+                            // Must be 4-16 MiB/s.
+                            .setPublishMibPerSec(4)
+                            // Must be 4-32 MiB/s.
+                            .setSubscribeMibPerSec(8)
+                            .build())
                     .setCount(partitions))
             .setRetentionConfig(
                 RetentionConfig.newBuilder()

--- a/samples/snippets/src/main/java/pubsublite/UpdateSubscriptionExample.java
+++ b/samples/snippets/src/main/java/pubsublite/UpdateSubscriptionExample.java
@@ -57,8 +57,11 @@ public class UpdateSubscriptionExample {
     Subscription subscription =
         Subscription.newBuilder()
             .setDeliveryConfig(
-                // DELIVER_AFTER_STORED ensures that the server won't deliver a published message
-                // to subscribers until the message has been successfully written to storage.
+                // Possible values for delivery_requirement:
+                // - `DELIVER_IMMEDIATELY`
+                // - `DELIVER_AFTER_STORED`
+                // `DELIVER_AFTER_STORED` requires a published message to be successfully written
+                // to storage before the server delivers it to subscribers.
                 DeliveryConfig.newBuilder()
                     .setDeliveryRequirement(DeliveryRequirement.DELIVER_AFTER_STORED))
             .setName(subscriptionPath.toString())

--- a/samples/snippets/src/main/java/pubsublite/UpdateSubscriptionExample.java
+++ b/samples/snippets/src/main/java/pubsublite/UpdateSubscriptionExample.java
@@ -57,7 +57,7 @@ public class UpdateSubscriptionExample {
     Subscription subscription =
         Subscription.newBuilder()
             .setDeliveryConfig(
-                // Possible values for delivery_requirement:
+                // Possible values for DeliveryRequirement:
                 // - `DELIVER_IMMEDIATELY`
                 // - `DELIVER_AFTER_STORED`
                 // `DELIVER_AFTER_STORED` requires a published message to be successfully written


### PR DESCRIPTION
1. Update create topic sample to use `capacity` in place of `scale` because it's deprecated. 
https://github.com/googleapis/java-pubsublite/blob/d26cbcf29262bb3123cc5afe360f48a63a80aa42/proto-google-cloud-pubsublite-v1/src/main/proto/google/cloud/pubsublite/v1/common.proto#L100-L108

1. Update comments for delivery requirement.