### PR TITLE
feat: Implement per-server memory limiter for PubsubLiteIO

### DIFF
--- a/google-cloud-pubsublite/pom.xml
+++ b/google-cloud-pubsublite/pom.xml
@@ -40,6 +40,10 @@
       <artifactId>google-cloud-pubsub</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-pubsub-v1</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-resourcemanager</artifactId>
       <version>0.118.4-alpha</version>

--- a/google-cloud-pubsublite/pom.xml
+++ b/google-cloud-pubsublite/pom.xml
@@ -46,10 +46,6 @@
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
-      <artifactId>proto-google-cloud-pubsub-v1</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-pubsublite-v1</artifactId>
       <version>0.6.6-SNAPSHOT</version><!-- {x-version-update:google-cloud-pubsublite:current} -->
     </dependency>

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/FlowControlSettings.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/FlowControlSettings.java
@@ -35,6 +35,8 @@ public abstract class FlowControlSettings implements Serializable {
     return new AutoValue_FlowControlSettings.Builder();
   }
 
+  public abstract Builder toBuilder();
+
   @AutoValue.Builder
   public abstract static class Builder {
     /** The number of quota bytes that may be outstanding to the client. */

--- a/pubsublite-beam-io/README.md
+++ b/pubsublite-beam-io/README.md
@@ -65,5 +65,5 @@
     ```
 
 1. If operating in a memory-constrained environment, making your pipeline
-options inherit from `PubsubLitePipelineOptions` will put a 1GiB per
-machine limit on the accounted memory size of messages.
+options inherit from `PubsubLitePipelineOptions` will put a customizable (1GiB
+per machine by default) limit on the accounted memory size of messages.

--- a/pubsublite-beam-io/README.md
+++ b/pubsublite-beam-io/README.md
@@ -58,8 +58,12 @@
                 .setName(SubscriptionName.of("my-sub"))
                 .build())
             .setFlowControlSettings(FlowControlSettings.builder()
-                .setBytesOutstanding(100_000_000)  // 100 MB
+                .setBytesOutstanding(50_000_000)  // 50 MB
                 .setMessagesOutstanding(Long.MAX_VALUE)
                 .build())
             .build()));
     ```
+
+1. If operating in a memory-constrained environment, making your pipeline
+options inherit from `PubsubLitePipelineOptions` will put a 1GiB per
+machine limit on the accounted memory size of messages.

--- a/pubsublite-beam-io/pom.xml
+++ b/pubsublite-beam-io/pom.xml
@@ -73,11 +73,6 @@
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
-      <artifactId>proto-google-cloud-pubsublite-v1</artifactId>
-      <version>0.6.5-SNAPSHOT</version><!-- {x-version-update:google-cloud-pubsublite:current} -->
-    </dependency>
-    <dependency>
-      <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-pubsub-v1</artifactId>
     </dependency>
     <dependency>

--- a/pubsublite-beam-io/pom.xml
+++ b/pubsublite-beam-io/pom.xml
@@ -26,6 +26,10 @@
       <version>0.6.6-SNAPSHOT</version><!-- {x-version-update:google-cloud-pubsublite:current} -->
     </dependency>
     <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-pubsub-v1</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-core</artifactId>
       <version>2.25.0</version>

--- a/pubsublite-beam-io/pom.xml
+++ b/pubsublite-beam-io/pom.xml
@@ -16,6 +16,11 @@
   <description>Beam IO for Google Cloud Pub/Sub Lite</description>
   <dependencies>
     <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-pubsublite-v1</artifactId>
+      <version>0.6.6-SNAPSHOT</version><!-- {x-version-update:google-cloud-pubsublite:current} -->
+    </dependency>
+    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsublite</artifactId>
       <version>0.6.6-SNAPSHOT</version><!-- {x-version-update:google-cloud-pubsublite:current} -->
@@ -65,7 +70,7 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-pubsublite-v1</artifactId>
-      <version>0.6.6-SNAPSHOT</version><!-- {x-version-update:google-cloud-pubsublite:current} -->
+      <version>0.6.5-SNAPSHOT</version><!-- {x-version-update:google-cloud-pubsublite:current} -->
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/AlarmFactory.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/AlarmFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.beam;
+
+import java.time.Duration;
+
+interface AlarmFactory {
+  interface Alarm extends AutoCloseable {
+    // When this method completes, guarantees that the alarm is not currently running
+    // and will never run again.
+    void close();
+  };
+
+  Alarm newAlarm(Duration alarmPeriod, Runnable alarm);
+}

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/MemoryLease.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/MemoryLease.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.beam;
+
+interface MemoryLease extends AutoCloseable {
+  // The amount of memory associated with this lease.
+  long byteCount();
+  // Releases the claim on memory associated with this lease.
+  void close();
+}

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/MemoryLimiter.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/MemoryLimiter.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.beam;
+
+interface MemoryLimiter {
+  /** Acquires however much memory is currently allowed for a single task, up to `desired`. */
+  MemoryLease acquireMemory(long desired);
+}

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/MemoryLimiterImpl.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/MemoryLimiterImpl.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.beam;
+
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+
+class MemoryLimiterImpl implements MemoryLimiter {
+  private final long totalMemory;
+
+  @GuardedBy("this")
+  private int tasks = 0;
+
+  @GuardedBy("this")
+  private long currentMemory;
+
+  MemoryLimiterImpl(long totalMemory) {
+    this.totalMemory = totalMemory;
+    this.currentMemory = totalMemory;
+  }
+
+  private class LimiterLease implements MemoryLease {
+    long amount;
+
+    LimiterLease(long amount) {
+      this.amount = amount;
+    }
+
+    @Override
+    public long byteCount() {
+      return amount;
+    }
+
+    @Override
+    public void close() {
+      release(amount);
+    }
+  }
+
+  /**
+   * Acquires however much memory is currently allowed for a single task, up to `desired`. Currently
+   * acquires the minimum of (totalMemory/(tasks+1)), currentMemory*3/4 and `desired`.
+   *
+   * <p>This is a trade off between usage of the total capacity and availability of resources for
+   * future tasks. Assuming that readers are recreated with some frequency (say, every 5 minutes as
+   * a strawman) This should eventually trend towards an even distribution with each worker having
+   * 1/21 of the total memory capacity assuming that the number of workers per job stabilizes, as
+   * 1/(n+1) is smaller than (2/(n+1)) * (3/4) = 3/(2(n+1)) and we take the minimum of the two
+   * values.
+   */
+  @Override
+  public synchronized MemoryLease acquireMemory(long desired) {
+    ++tasks;
+    long acquired = Math.min(desired, Math.min(totalMemory / (tasks + 1), currentMemory * 3 / 4));
+    currentMemory -= acquired;
+    return new LimiterLease(acquired);
+  }
+
+  private synchronized void release(long amount) {
+    currentMemory += amount;
+    tasks -= 1;
+  }
+}

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/MemoryLimitingPullSubscriber.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/MemoryLimitingPullSubscriber.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.beam;
+
+import com.google.cloud.pubsublite.Offset;
+import com.google.cloud.pubsublite.SequencedMessage;
+import com.google.cloud.pubsublite.cloudpubsub.FlowControlSettings;
+import com.google.cloud.pubsublite.internal.CheckedApiException;
+import com.google.cloud.pubsublite.internal.ExtractStatus;
+import com.google.cloud.pubsublite.internal.PullSubscriber;
+import com.google.cloud.pubsublite.proto.Cursor;
+import com.google.cloud.pubsublite.proto.SeekRequest;
+import com.google.common.collect.Iterables;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+public class MemoryLimitingPullSubscriber implements PullSubscriber<SequencedMessage> {
+  private final PullSubscriberFactory factory;
+  private final MemoryLimiter limiter;
+  private final FlowControlSettings baseSettings;
+
+  private final AlarmFactory.Alarm alarm;
+
+  @GuardedBy("this")
+  private @Nullable MemoryLease lease;
+
+  @GuardedBy("this")
+  private @Nullable PullSubscriber<SequencedMessage> subscriber;
+
+  @GuardedBy("this")
+  private SeekRequest seekForRestart;
+
+  @GuardedBy("this")
+  private Optional<CheckedApiException> permanentError = Optional.empty();
+
+  MemoryLimitingPullSubscriber(
+      PullSubscriberFactory factory,
+      MemoryLimiter limiter,
+      FlowControlSettings baseSettings,
+      SeekRequest initialSeek,
+      AlarmFactory alarmFactory) {
+    this.factory = factory;
+    this.limiter = limiter;
+    this.baseSettings = baseSettings;
+    this.seekForRestart = initialSeek;
+    refresh();
+    this.alarm = alarmFactory.newAlarm(Duration.ofMinutes(5), this::refresh);
+  }
+
+  private synchronized FlowControlSettings getSettings() {
+    // Must allow at least 1 MiB to allow all potential messages.
+    long bytesAllowed =
+        Math.max(1 << 20, Math.min(this.lease.byteCount(), baseSettings.bytesOutstanding()));
+    return FlowControlSettings.builder()
+        .setMessagesOutstanding(baseSettings.messagesOutstanding())
+        .setBytesOutstanding(bytesAllowed)
+        .build();
+  }
+
+  @Override
+  public synchronized List<SequencedMessage> pull() throws CheckedApiException {
+    if (permanentError.isPresent()) throw permanentError.get();
+    try {
+      List<SequencedMessage> messages = subscriber.pull();
+      if (!messages.isEmpty()) {
+        long next = Iterables.getLast(messages).offset().value() + 1;
+        seekForRestart =
+            SeekRequest.newBuilder().setCursor(Cursor.newBuilder().setOffset(next)).build();
+      }
+      return messages;
+    } catch (CheckedApiException e) {
+      permanentError = Optional.of(e);
+      throw e;
+    }
+  }
+
+  @Override
+  public synchronized Optional<Offset> nextOffset() {
+    if (permanentError.isPresent()) throw permanentError.get().underlying;
+    return subscriber.nextOffset();
+  }
+
+  @Override
+  public void close() throws CheckedApiException {
+    this.alarm.close();
+    tryClose();
+    if (permanentError.isPresent()) throw permanentError.get();
+  }
+
+  private synchronized void tryClose() {
+    try {
+      if (this.subscriber != null) {
+        this.subscriber.close();
+      }
+    } catch (Throwable t) {
+      this.permanentError = Optional.of(ExtractStatus.toCanonical(t));
+    } finally {
+      this.subscriber = null;
+      if (this.lease != null) {
+        this.lease.close();
+        this.lease = null;
+      }
+    }
+  }
+
+  private synchronized void refresh() {
+    tryClose();
+    if (this.permanentError.isPresent()) return;
+    this.lease = limiter.acquireMemory(baseSettings.bytesOutstanding());
+    try {
+      this.subscriber = factory.newPullSubscriber(seekForRestart, getSettings());
+    } catch (CheckedApiException e) {
+      this.permanentError = Optional.of(e);
+    }
+  }
+}

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/NoOpMemoryLimiter.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/NoOpMemoryLimiter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.beam;
+
+class NoOpMemoryLimiter implements MemoryLimiter {
+  @Override
+  public MemoryLease acquireMemory(long desired) {
+    return new MemoryLease() {
+      @Override
+      public long byteCount() {
+        return Long.MAX_VALUE;
+      }
+
+      @Override
+      public void close() {}
+    };
+  }
+}

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PerServerAlarmFactory.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PerServerAlarmFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.beam;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+final class PerServerAlarmFactory implements AlarmFactory {
+  static PerServerAlarmFactory instance;
+
+  private final ScheduledExecutorService exec;
+
+  private PerServerAlarmFactory() {
+    exec = Executors.newSingleThreadScheduledExecutor();
+  }
+
+  @Override
+  public Alarm newAlarm(Duration alarmPeriod, Runnable alarm) {
+    ScheduledFuture<?> future =
+        exec.scheduleAtFixedRate(
+            alarm, alarmPeriod.toMillis(), alarmPeriod.toMillis(), TimeUnit.MILLISECONDS);
+    return () -> {
+      try {
+        future.cancel(false);
+        future.get();
+      } catch (Throwable t) {
+      }
+    };
+  }
+
+  static synchronized AlarmFactory getInstance() {
+    if (instance == null) {
+      instance = new PerServerAlarmFactory();
+    }
+    return instance;
+  }
+}

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PerServerMemoryLimiter.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PerServerMemoryLimiter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.beam;
+
+import com.google.common.base.Preconditions;
+import java.util.Optional;
+
+final class PerServerMemoryLimiter {
+  private PerServerMemoryLimiter() {}
+
+  private static MemoryLimiter limiter;
+  private static Optional<Long> totalBytes = Optional.empty();
+
+  private static synchronized void init() {
+    if (totalBytes.isPresent()) {
+      limiter = new MemoryLimiterImpl(totalBytes.get());
+    } else {
+      limiter = new NoOpMemoryLimiter();
+    }
+  }
+
+  static synchronized MemoryLimiter getLimiter(Optional<Long> totalBytesSetting) {
+    if (totalBytesSetting.isPresent()) {
+      Preconditions.checkArgument(totalBytesSetting.get() > 0);
+    }
+    if (limiter != null) {
+      totalBytes = totalBytesSetting;
+      init();
+    }
+    Preconditions.checkArgument(
+        totalBytes == totalBytesSetting,
+        "getLimiter can only be called with one setting per-server for the total byte count.");
+    return limiter;
+  }
+}

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLitePipelineOptions.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLitePipelineOptions.java
@@ -21,6 +21,12 @@ import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
 
 public interface PubsubLitePipelineOptions extends PipelineOptions {
+  @Description("Whether per-worker memory limiting is enabled.")
+  @Default.Boolean(true)
+  Boolean getPubsubLiteSubscriberWorkerMemoryLimiterEnabled();
+
+  void setPubsubLiteSubscriberWorkerMemoryLimiterEnabled(Boolean val);
+
   @Description("A soft memory limit on messages outstanding to all subscribers on a given worker.")
   @Default.Long(1L << 30) // Default limit is 1GiB.
   Long getPubsubLiteSubscribeWorkerMemoryLimit();

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLitePipelineOptions.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLitePipelineOptions.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.beam;
+
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+public interface PubsubLitePipelineOptions extends PipelineOptions {
+  @Description("A soft memory limit on messages outstanding to all subscribers on a given worker.")
+  @Default.Long(1L << 30) // Default limit is 1GiB.
+  Long getPubsubLiteSubscribeWorkerMemoryLimit();
+
+  void setPubsubLiteSubscribeWorkerMemoryLimit(Long val);
+}

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReader.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReader.java
@@ -179,7 +179,6 @@ class PubsubLiteUnboundedReader extends UnboundedReader<SequencedMessage>
     Optional<Offset> lastDelivered = Optional.empty();
     PullSubscriber<SequencedMessage> subscriber;
     Committer committer;
-    MemoryLease lease;
   }
 
   @AutoValue
@@ -267,7 +266,6 @@ class PubsubLiteUnboundedReader extends UnboundedReader<SequencedMessage>
     Optional<ApiException> error = Optional.empty();
     try (CloseableMonitor.Hold h = monitor.enter()) {
       for (SubscriberState state : subscriberMap.values()) {
-        state.lease.close();
         try {
           state.subscriber.close();
         } catch (Throwable t) {

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedSource.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedSource.java
@@ -69,9 +69,10 @@ class PubsubLiteUnboundedSource extends UnboundedSource<SequencedMessage, Offset
   private MemoryLimiter getMemoryLimiter(PipelineOptions options) {
     Optional<Long> limit = Optional.empty();
     if (options instanceof PubsubLitePipelineOptions) {
-      limit =
-          Optional.of(
-              ((PubsubLitePipelineOptions) options).getPubsubLiteSubscribeWorkerMemoryLimit());
+      PubsubLitePipelineOptions psOptions = (PubsubLitePipelineOptions) options;
+      if (psOptions.getPubsubLiteSubscriberWorkerMemoryLimiterEnabled()) {
+        limit = Optional.of(psOptions.getPubsubLiteSubscribeWorkerMemoryLimit());
+      }
     }
     return PerServerMemoryLimiter.getLimiter(limit);
   }

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PullSubscriberFactory.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PullSubscriberFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.beam;
+
+import com.google.cloud.pubsublite.SequencedMessage;
+import com.google.cloud.pubsublite.cloudpubsub.FlowControlSettings;
+import com.google.cloud.pubsublite.internal.CheckedApiException;
+import com.google.cloud.pubsublite.internal.PullSubscriber;
+import com.google.cloud.pubsublite.proto.SeekRequest;
+
+public interface PullSubscriberFactory {
+  PullSubscriber<SequencedMessage> newPullSubscriber(
+      SeekRequest initialSeek, FlowControlSettings settings) throws CheckedApiException;
+}

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/SubscriberOptions.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/SubscriberOptions.java
@@ -42,8 +42,10 @@ public abstract class SubscriberOptions implements Serializable {
   private static final Framework FRAMEWORK = Framework.of("BEAM");
 
   // Required parameters.
+  /** The full subscription path to subscribe to. */
   public abstract SubscriptionPath subscriptionPath();
 
+  /** Per-partition flow control settings for the subscriber. */
   public abstract FlowControlSettings flowControlSettings();
 
   // Optional parameters.
@@ -124,13 +126,15 @@ public abstract class SubscriberOptions implements Serializable {
   @AutoValue.Builder
   public abstract static class Builder {
     // Required parameters.
+    /** The full subscription path to subscribe to. */
     public abstract Builder setSubscriptionPath(SubscriptionPath path);
 
-    public abstract Builder setPartitions(ImmutableSet<Partition> partitions);
-
+    /** Per-partition flow control settings for the subscriber. */
     public abstract Builder setFlowControlSettings(FlowControlSettings flowControlSettings);
 
     // Optional parameters.
+    public abstract Builder setPartitions(ImmutableSet<Partition> partitions);
+
     public abstract Builder setSubscriberClientSupplier(
         SerializableSupplier<SubscriberServiceClient> supplier);
 

--- a/pubsublite-beam-io/src/test/java/com/google/cloud/pubsublite/beam/MemoryLimiterImplTest.java
+++ b/pubsublite-beam-io/src/test/java/com/google/cloud/pubsublite/beam/MemoryLimiterImplTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.pubsublite.beam;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class MemoryLimiterImplTest {
+  @Test
+  public void memoryDeducted() {
+    long total = 1 << 20;
+    MemoryLimiter limiter = new MemoryLimiterImpl(total);
+    MemoryLease lease1 = limiter.acquireMemory(Long.MAX_VALUE);
+    long bytes1 = total / 2;
+    assertThat(lease1.byteCount()).isEqualTo(bytes1);
+    MemoryLease lease2 = limiter.acquireMemory(Long.MAX_VALUE);
+    long bytes2 = total / 3;
+    assertThat(lease2.byteCount()).isEqualTo(bytes2);
+    MemoryLease limitedByOutstanding = limiter.acquireMemory(Long.MAX_VALUE);
+    long currentAvailable = total - bytes1 - bytes2;
+    assertThat(limitedByOutstanding.byteCount()).isEqualTo(currentAvailable * 3 / 4);
+    limitedByOutstanding.close();
+    lease2.close();
+    MemoryLease lease3 = limiter.acquireMemory(Long.MAX_VALUE);
+    assertThat(lease3.byteCount()).isEqualTo(bytes2);
+    MemoryLease lease4 = limiter.acquireMemory(1024);
+    assertThat(lease4.byteCount()).isEqualTo(1024);
+  }
+}

--- a/pubsublite-beam-io/src/test/java/com/google/cloud/pubsublite/beam/MemoryLimitingPullSubscriberTest.java
+++ b/pubsublite-beam-io/src/test/java/com/google/cloud/pubsublite/beam/MemoryLimitingPullSubscriberTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.beam;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.cloud.pubsublite.Message;
+import com.google.cloud.pubsublite.Offset;
+import com.google.cloud.pubsublite.SequencedMessage;
+import com.google.cloud.pubsublite.cloudpubsub.FlowControlSettings;
+import com.google.cloud.pubsublite.internal.CheckedApiException;
+import com.google.cloud.pubsublite.internal.PullSubscriber;
+import com.google.cloud.pubsublite.proto.Cursor;
+import com.google.cloud.pubsublite.proto.SeekRequest;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.util.Timestamps;
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+
+@RunWith(JUnit4.class)
+public class MemoryLimitingPullSubscriberTest {
+  @Mock PullSubscriberFactory subscriberFactory;
+  @Mock PullSubscriber<SequencedMessage> underlying;
+  @Mock MemoryLimiter limiter;
+  @Mock MemoryLease lease;
+  private static final FlowControlSettings BASE_FLOW_CONTROL =
+      FlowControlSettings.builder()
+          .setBytesOutstanding(1 << 25)
+          .setMessagesOutstanding(1000)
+          .build();
+  private static final FlowControlSettings SMALLER_FLOW_CONTROL =
+      BASE_FLOW_CONTROL
+          .toBuilder()
+          .setBytesOutstanding(BASE_FLOW_CONTROL.bytesOutstanding() - 1)
+          .build();
+  private static final SeekRequest INITIAL =
+      SeekRequest.newBuilder().setNamedTarget(SeekRequest.NamedTarget.COMMITTED_CURSOR).build();
+  @Mock AlarmFactory alarmFactory;
+  @Mock AlarmFactory.Alarm alarm;
+  Runnable alarmRunnable;
+  PullSubscriber<SequencedMessage> subscriber;
+
+  @Before
+  public void setUp() throws Exception {
+    initMocks(this);
+    when(limiter.acquireMemory(BASE_FLOW_CONTROL.bytesOutstanding())).thenReturn(lease);
+    when(lease.byteCount()).thenReturn(SMALLER_FLOW_CONTROL.bytesOutstanding());
+    when(subscriberFactory.newPullSubscriber(INITIAL, SMALLER_FLOW_CONTROL)).thenReturn(underlying);
+    when(alarmFactory.newAlarm(eq(Duration.ofMinutes(5)), any()))
+        .then(
+            args -> {
+              alarmRunnable = args.getArgument(1, Runnable.class);
+              return alarm;
+            });
+    subscriber =
+        new MemoryLimitingPullSubscriber(
+            subscriberFactory, limiter, BASE_FLOW_CONTROL, INITIAL, alarmFactory);
+    verify(limiter).acquireMemory(BASE_FLOW_CONTROL.bytesOutstanding());
+    verify(subscriberFactory).newPullSubscriber(INITIAL, SMALLER_FLOW_CONTROL);
+    assertThat(alarmRunnable).isNotNull();
+  }
+
+  @Test
+  public void createDestroy() {}
+
+  @Test
+  public void exceptionInPullFails() throws Exception {
+    when(underlying.pull()).thenThrow(new CheckedApiException(Code.INTERNAL));
+    assertThrows(CheckedApiException.class, () -> subscriber.pull());
+    verify(underlying).pull();
+    assertThrows(ApiException.class, () -> subscriber.nextOffset());
+    verify(underlying, times(0)).nextOffset();
+    assertThrows(CheckedApiException.class, () -> subscriber.close());
+    verify(lease).close();
+    verify(underlying).close();
+  }
+
+  @Test
+  public void exceptionInCloseFails() throws Exception {
+    doThrow(new CheckedApiException(Code.INTERNAL)).when(underlying).close();
+    alarmRunnable.run();
+    assertThrows(CheckedApiException.class, () -> subscriber.pull());
+    verify(underlying, times(0)).pull();
+    assertThrows(ApiException.class, () -> subscriber.nextOffset());
+    verify(underlying, times(0)).nextOffset();
+    assertThrows(CheckedApiException.class, () -> subscriber.close());
+    verify(lease, times(1)).close();
+    verify(underlying, times(1)).close();
+  }
+
+  @Test
+  public void alarmRecreates() throws Exception {
+    when(lease.byteCount()).thenReturn(BASE_FLOW_CONTROL.bytesOutstanding());
+    alarmRunnable.run();
+    verify(lease).close();
+    verify(underlying).close();
+    verify(limiter, times(2)).acquireMemory(BASE_FLOW_CONTROL.bytesOutstanding());
+    verify(subscriberFactory).newPullSubscriber(INITIAL, BASE_FLOW_CONTROL);
+  }
+
+  @Test
+  public void lowLimitAtLeast1MiB() throws Exception {
+    when(lease.byteCount()).thenReturn(7L);
+    alarmRunnable.run();
+    verify(lease, times(1)).close();
+    verify(underlying, times(1)).close();
+    verify(limiter, times(2)).acquireMemory(BASE_FLOW_CONTROL.bytesOutstanding());
+    verify(subscriberFactory, times(1))
+        .newPullSubscriber(
+            INITIAL, BASE_FLOW_CONTROL.toBuilder().setBytesOutstanding(1 << 20).build());
+  }
+
+  @Test
+  public void seekModifiedAfterReceivingMessages() throws Exception {
+    SequencedMessage m1 =
+        SequencedMessage.of(Message.builder().build(), Timestamps.EPOCH, Offset.of(3), 1);
+    SequencedMessage m2 =
+        SequencedMessage.of(Message.builder().build(), Timestamps.EPOCH, Offset.of(8), 1);
+    when(underlying.pull()).thenReturn(ImmutableList.of(m1, m2));
+    assertThat(subscriber.pull()).containsExactly(m1, m2);
+    alarmRunnable.run();
+    verify(lease, times(1)).close();
+    verify(underlying, times(1)).close();
+    verify(limiter, times(2)).acquireMemory(BASE_FLOW_CONTROL.bytesOutstanding());
+    verify(subscriberFactory, times(1))
+        .newPullSubscriber(
+            SeekRequest.newBuilder().setCursor(Cursor.newBuilder().setOffset(9)).build(),
+            SMALLER_FLOW_CONTROL);
+  }
+}

--- a/pubsublite-beam-io/src/test/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReaderTest.java
+++ b/pubsublite-beam-io/src/test/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReaderTest.java
@@ -65,9 +65,6 @@ public class PubsubLiteUnboundedReaderTest {
   @Mock private PullSubscriber<SequencedMessage> subscriber5;
   @Mock private PullSubscriber<SequencedMessage> subscriber8;
 
-  @Mock private MemoryLease lease5;
-  @Mock private MemoryLease lease8;
-
   abstract static class CommitterFakeService extends FakeApiService implements Committer {}
 
   private static class FakeTicker extends Ticker {
@@ -113,11 +110,9 @@ public class PubsubLiteUnboundedReaderTest {
   public PubsubLiteUnboundedReaderTest() throws CheckedApiException {
     MockitoAnnotations.initMocks(this);
     SubscriberState state5 = new SubscriberState();
-    state5.lease = lease5;
     state5.subscriber = subscriber5;
     state5.committer = committer5;
     SubscriberState state8 = new SubscriberState();
-    state8.lease = lease8;
     state8.subscriber = subscriber8;
     state8.committer = committer8;
     reader =

--- a/pubsublite-beam-io/src/test/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReaderTest.java
+++ b/pubsublite-beam-io/src/test/java/com/google/cloud/pubsublite/beam/PubsubLiteUnboundedReaderTest.java
@@ -56,16 +56,17 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
 @RunWith(JUnit4.class)
 public class PubsubLiteUnboundedReaderTest {
-  @SuppressWarnings("unchecked")
-  private final PullSubscriber<SequencedMessage> subscriber5 = mock(PullSubscriber.class);
+  @Mock private PullSubscriber<SequencedMessage> subscriber5;
+  @Mock private PullSubscriber<SequencedMessage> subscriber8;
 
-  @SuppressWarnings("unchecked")
-  private final PullSubscriber<SequencedMessage> subscriber8 = mock(PullSubscriber.class);
+  @Mock private MemoryLease lease5;
+  @Mock private MemoryLease lease8;
 
   abstract static class CommitterFakeService extends FakeApiService implements Committer {}
 
@@ -112,9 +113,11 @@ public class PubsubLiteUnboundedReaderTest {
   public PubsubLiteUnboundedReaderTest() throws CheckedApiException {
     MockitoAnnotations.initMocks(this);
     SubscriberState state5 = new SubscriberState();
+    state5.lease = lease5;
     state5.subscriber = subscriber5;
     state5.committer = committer5;
     SubscriberState state8 = new SubscriberState();
+    state8.lease = lease8;
     state8.subscriber = subscriber8;
     state8.committer = committer8;
     reader =


### PR DESCRIPTION
This limiter is predicated on the assumptions that:
1) UnboundedSources have split() called at least once in their lifetime
2) UnboundedSources.split may return any amount of splits, even more than requested.
3) The per-partition memory requirements are high (multiple seconds of buffering) but splits will eventually be assigned to new machines if they are artificially restricted due to increasing backlog

It refreshes each individual reader on a machine every 5 minutes, as the memory limiter approaches an even distribution after multiple rounds of all leases being created and destroyed, and splits the IO into one source per partition to ensure that these refreshes are independent.
