### PR TITLE
feat: adds functions to BufferingPullSubscriber

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/PullSubscriber.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/PullSubscriber.java
@@ -25,6 +25,12 @@ public interface PullSubscriber<T> extends AutoCloseable {
   // Pull currently available messages from this subscriber. Does not block.
   List<T> pull() throws CheckedApiException;
 
+  // Pull one available message from this subscriber. Does not block.
+  Optional<T> pullOne() throws CheckedApiException;
+
+  // If there are available messages to pull.
+  boolean hasNext() throws CheckedApiException;
+
   // The next offset expected to be returned by this PullSubscriber, or empty if unknown.
   // Subsequent messages are guaranteed to have offsets of at least this value.
   Optional<Offset> nextOffset();

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/BufferingPullSubscriberTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/BufferingPullSubscriberTest.java
@@ -119,6 +119,16 @@ public class BufferingPullSubscriberTest {
   @Test
   public void emptyPull() throws CheckedApiException {
     assertThat(subscriber.pull()).isEmpty();
+    assertThat(subscriber.hasNext()).isFalse();
+  }
+
+  @Test
+  public void pullOne() throws CheckedApiException {
+    SequencedMessage message1 =
+        SequencedMessage.of(Message.builder().build(), Timestamps.EPOCH, Offset.of(10), 10);
+    messageConsumer.accept(ImmutableList.of(message1));
+    assertThat(subscriber.pullOne()).hasValue(message1);
+    assertThat(subscriber.pullOne()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
This adds two methods to BufferingPullSubscriber so it would be easier to implement Spark's [ContinuousInputPartitionReader](http://spark.apache.org/docs/2.4.1/api/java/org/apache/spark/sql/sources/v2/reader/streaming/ContinuousInputPartitionReader.html)'s get and next.