### PR TITLE
fix: Deadlock in RetryingConnectionImpl when tearing down a connection

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/Lazy.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/Lazy.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.internal;
+
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+/** A thread-safe, lazily constructed instance of an object. */
+public class Lazy<T> {
+  @GuardedBy("this")
+  private @Nullable T instance = null;
+
+  private final Supplier<T> supplier;
+
+  public Lazy(Supplier<T> supplier) {
+    this.supplier = supplier;
+  }
+
+  public synchronized T get() {
+    if (instance == null) instance = supplier.get();
+    return instance;
+  }
+}

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/ServiceClients.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/ServiceClients.java
@@ -18,20 +18,44 @@ package com.google.cloud.pubsublite.internal;
 
 import static com.google.cloud.pubsublite.internal.ExtractStatus.toCanonical;
 
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.FixedExecutorProvider;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.ClientSettings;
 import com.google.cloud.pubsublite.CloudRegion;
 import com.google.cloud.pubsublite.Endpoints;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 public final class ServiceClients {
   private ServiceClients() {}
+
+  @GuardedBy("this")
+  @Nullable
+  private static ScheduledExecutorService EXECUTOR = null;
+
+  private static synchronized ExecutorProvider executorProvider() {
+    if (EXECUTOR == null) {
+      EXECUTOR =
+          MoreExecutors.getExitingScheduledExecutorService(
+              new ScheduledThreadPoolExecutor(
+                  Math.max(4, Runtime.getRuntime().availableProcessors())));
+    }
+    return FixedExecutorProvider.create(EXECUTOR);
+  }
 
   public static <
           Settings extends ClientSettings<Settings>,
           Builder extends ClientSettings.Builder<Settings, Builder>>
       Settings addDefaultSettings(CloudRegion target, Builder builder) throws ApiException {
     try {
-      return builder.setEndpoint(Endpoints.regionalEndpoint(target)).build();
+      return builder
+          .setEndpoint(Endpoints.regionalEndpoint(target))
+          .setExecutorProvider(executorProvider())
+          .build();
     } catch (Throwable t) {
       throw toCanonical(t).underlying;
     }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/RetryingConnectionImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/RetryingConnectionImpl.java
@@ -107,8 +107,6 @@ class RetryingConnectionImpl<
     try (CloseableMonitor.Hold h = connectionMonitor.enter()) {
       if (completed) return;
       completed = true;
-    }
-    try {
       logger.atFine().log(
           String.format("Terminating connection with initial request %s.", initialRequest));
       currentConnection.close();


### PR DESCRIPTION
Also use a shared executor for all GRPC clients to reduce total threadcount and fix errors when tearing down executors used by GRPC connections.

Also add logging to RetryingConnectionImpl

Also ensure all calls out from RetryingConnectionImpl cannot leak exceptions.

Also ensure all streams have heartbeating enabled.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-pubsublite/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️
