### PR TITLE
fix: Remove per-message byte limit in client

### DIFF
--- a/google-cloud-pubsublite/clirr-ignored-differences.xml
+++ b/google-cloud-pubsublite/clirr-ignored-differences.xml
@@ -6,6 +6,11 @@
     <differenceType>8001</differenceType>
     <className>com/google/cloud/pubsublite/ProjectLookupUtils</className>
   </difference>
+  <difference>
+    <differenceType>6011</differenceType>
+    <className>com/google/cloud/pubsublite/Constants</className>
+    <field>MAX_PUBLISH_MESSAGE_BYTES</field>
+  </difference>
   <!-- Blanket ignored files -->
   <difference>
     <differenceType>4001</differenceType>

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/Constants.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/Constants.java
@@ -31,7 +31,6 @@ public class Constants {
           .build();
 
   public static final long MAX_PUBLISH_BATCH_COUNT = 1_000;
-  public static final long MAX_PUBLISH_MESSAGE_BYTES = 1_000_000;
   public static final long MAX_PUBLISH_BATCH_BYTES = 3_500_000;
 
   private Constants() {}

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/PublisherImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/PublisherImpl.java
@@ -26,7 +26,6 @@ import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.StatusCode.Code;
-import com.google.cloud.pubsublite.Constants;
 import com.google.cloud.pubsublite.Message;
 import com.google.cloud.pubsublite.Offset;
 import com.google.cloud.pubsublite.internal.CheckedApiException;
@@ -203,21 +202,6 @@ public final class PublisherImpl extends ProxyService
   @Override
   public ApiFuture<Offset> publish(Message message) {
     PubSubMessage proto = message.toProto();
-    if (proto.getSerializedSize() > Constants.MAX_PUBLISH_MESSAGE_BYTES) {
-      CheckedApiException error =
-          new CheckedApiException(
-              String.format(
-                  "Tried to send message with serialized size %s larger than limit %s on the"
-                      + " stream.",
-                  proto.getSerializedSize(), Constants.MAX_PUBLISH_MESSAGE_BYTES),
-              Code.FAILED_PRECONDITION);
-      try (CloseableMonitor.Hold h = monitor.enter()) {
-        if (!shutdown) {
-          onPermanentError(error);
-        }
-      }
-      return ApiFutures.immediateFailedFuture(error);
-    }
     try (CloseableMonitor.Hold h = monitor.enter()) {
       ApiService.State currentState = state();
       checkState(


### PR DESCRIPTION
There still exists a 3.5MiB byte limit server side, and a protocol level 4MiB message limit.
