### PR TITLE
feat: Adds examples and fixes bugs in spark connector

### DIFF
--- a/pubsublite-spark-sql-streaming/examples/simple_read.py
+++ b/pubsublite-spark-sql-streaming/examples/simple_read.py
@@ -16,18 +16,18 @@
 from pyspark.sql import SparkSession
 import sys
 
-full_subscription_path = sys.argv[0]
+full_subscription_path = sys.argv[1]
 
 spark = SparkSession.builder.appName('Simple PubSub Lite Read').master('yarn').getOrCreate()
 
 spark \
-    .readStream() \
+    .readStream \
     .format('pubsublite') \
     .option('pubsublite.subscription', full_subscription_path) \
     .load() \
     .writeStream \
     .format('console') \
     .outputMode('append') \
-    .trigger(processingTime='1 second') \
+    .trigger(continuous='1 second') \
     .start() \
     .awaitTermination()

--- a/pubsublite-spark-sql-streaming/examples/simple_read.py
+++ b/pubsublite-spark-sql-streaming/examples/simple_read.py
@@ -31,3 +31,6 @@ spark \
     .trigger(continuous='1 second') \
     .start() \
     .awaitTermination()
+
+# .trigger(processingTime='1 second') \
+# .trigger(continuous='1 second') \

--- a/pubsublite-spark-sql-streaming/examples/simple_read.py
+++ b/pubsublite-spark-sql-streaming/examples/simple_read.py
@@ -28,9 +28,6 @@ spark \
     .writeStream \
     .format('console') \
     .outputMode('append') \
-    .trigger(continuous='1 second') \
+    .trigger(processingTime='1 second') \
     .start() \
     .awaitTermination()
-
-# .trigger(processingTime='1 second') \
-# .trigger(continuous='1 second') \

--- a/pubsublite-spark-sql-streaming/examples/simple_read.py
+++ b/pubsublite-spark-sql-streaming/examples/simple_read.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyspark.sql import SparkSession
+import sys
+
+full_subscription_path = sys.argv[0]
+
+spark = SparkSession.builder.appName('Simple PubSub Lite Read').master('yarn').getOrCreate()
+
+spark \
+    .readStream() \
+    .format('pubsublite') \
+    .option('pubsublite.subscription', full_subscription_path) \
+    .load() \
+    .writeStream \
+    .format('console') \
+    .outputMode('append') \
+    .trigger(processingTime='1 second') \
+    .start() \
+    .awaitTermination()

--- a/pubsublite-spark-sql-streaming/src/main/java/com/google/cloud/pubsublite/spark/PslContinuousReader.java
+++ b/pubsublite-spark-sql-streaming/src/main/java/com/google/cloud/pubsublite/spark/PslContinuousReader.java
@@ -21,10 +21,11 @@ import com.google.cloud.pubsublite.cloudpubsub.FlowControlSettings;
 import com.google.cloud.pubsublite.internal.CursorClient;
 import com.google.cloud.pubsublite.internal.wire.SubscriberFactory;
 import com.google.common.annotations.VisibleForTesting;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.sources.v2.reader.InputPartition;
 import org.apache.spark.sql.sources.v2.reader.streaming.ContinuousReader;
@@ -108,21 +109,20 @@ public class PslContinuousReader implements ContinuousReader {
 
   @Override
   public List<InputPartition<InternalRow>> planInputPartitions() {
-
-    return startOffset.getPartitionOffsetMap().values().stream()
-        .map(
-            v -> {
-              SubscriberFactory subscriberFactory =
-                  (consumer) -> partitionSubscriberFactory.newSubscriber(v.partition(), consumer);
-              return new PslContinuousInputPartition(
-                  subscriberFactory,
-                  SparkPartitionOffset.builder()
-                      .partition(v.partition())
-                      .offset(v.offset())
+    List<InputPartition<InternalRow>> list = new ArrayList<>();
+    for (SparkPartitionOffset offset : startOffset.getPartitionOffsetMap().values()) {
+      PartitionSubscriberFactory partitionSubscriberFactory = this.partitionSubscriberFactory;
+      SubscriberFactory subscriberFactory =
+              (consumer) -> partitionSubscriberFactory.newSubscriber(offset.partition(), consumer);
+      list.add(new PslContinuousInputPartition(
+              subscriberFactory,
+              SparkPartitionOffset.builder()
+                      .partition(offset.partition())
+                      .offset(offset.offset())
                       .build(),
-                  subscriptionPath,
-                  flowControlSettings);
-            })
-        .collect(Collectors.toList());
+              subscriptionPath,
+              flowControlSettings));
+    }
+    return list;
   }
 }

--- a/pubsublite-spark-sql-streaming/src/main/java/com/google/cloud/pubsublite/spark/PslContinuousReader.java
+++ b/pubsublite-spark-sql-streaming/src/main/java/com/google/cloud/pubsublite/spark/PslContinuousReader.java
@@ -21,7 +21,6 @@ import com.google.cloud.pubsublite.cloudpubsub.FlowControlSettings;
 import com.google.cloud.pubsublite.internal.CursorClient;
 import com.google.cloud.pubsublite.internal.wire.SubscriberFactory;
 import com.google.common.annotations.VisibleForTesting;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -113,13 +112,14 @@ public class PslContinuousReader implements ContinuousReader {
     for (SparkPartitionOffset offset : startOffset.getPartitionOffsetMap().values()) {
       PartitionSubscriberFactory partitionSubscriberFactory = this.partitionSubscriberFactory;
       SubscriberFactory subscriberFactory =
-              (consumer) -> partitionSubscriberFactory.newSubscriber(offset.partition(), consumer);
-      list.add(new PslContinuousInputPartition(
+          (consumer) -> partitionSubscriberFactory.newSubscriber(offset.partition(), consumer);
+      list.add(
+          new PslContinuousInputPartition(
               subscriberFactory,
               SparkPartitionOffset.builder()
-                      .partition(offset.partition())
-                      .offset(offset.offset())
-                      .build(),
+                  .partition(offset.partition())
+                  .offset(offset.offset())
+                  .build(),
               subscriptionPath,
               flowControlSettings));
     }

--- a/pubsublite-spark-sql-streaming/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchInputPartition.java
+++ b/pubsublite-spark-sql-streaming/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchInputPartition.java
@@ -58,8 +58,11 @@ public class PslMicroBatchInputPartition implements InputPartition<InternalRow> 
               subscriberFactory,
               flowControlSettings,
               SeekRequest.newBuilder()
-                  .setCursor(Cursor.newBuilder().setOffset(
-                          PslSparkUtils.toPslPartitionOffset(startOffset).offset().value()).build())
+                  .setCursor(
+                      Cursor.newBuilder()
+                          .setOffset(
+                              PslSparkUtils.toPslPartitionOffset(startOffset).offset().value())
+                          .build())
                   .build());
     } catch (CheckedApiException e) {
       throw new IllegalStateException(

--- a/pubsublite-spark-sql-streaming/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchInputPartition.java
+++ b/pubsublite-spark-sql-streaming/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchInputPartition.java
@@ -31,6 +31,7 @@ import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
 public class PslMicroBatchInputPartition implements InputPartition<InternalRow> {
 
   private final SubscriberFactory subscriberFactory;
+  private final SparkPartitionOffset startOffset;
   private final SparkPartitionOffset endOffset;
   private final SubscriptionPath subscriptionPath;
   private final FlowControlSettings flowControlSettings;
@@ -38,8 +39,10 @@ public class PslMicroBatchInputPartition implements InputPartition<InternalRow> 
   public PslMicroBatchInputPartition(
       SubscriptionPath subscriptionPath,
       FlowControlSettings flowControlSettings,
+      SparkPartitionOffset startOffset,
       SparkPartitionOffset endOffset,
       SubscriberFactory subscriberFactory) {
+    this.startOffset = startOffset;
     this.endOffset = endOffset;
     this.subscriptionPath = subscriptionPath;
     this.flowControlSettings = flowControlSettings;
@@ -55,7 +58,8 @@ public class PslMicroBatchInputPartition implements InputPartition<InternalRow> 
               subscriberFactory,
               flowControlSettings,
               SeekRequest.newBuilder()
-                  .setCursor(Cursor.newBuilder().setOffset(endOffset.offset()).build())
+                  .setCursor(Cursor.newBuilder().setOffset(
+                          PslSparkUtils.toPslPartitionOffset(startOffset).offset().value()).build())
                   .build());
     } catch (CheckedApiException e) {
       throw new IllegalStateException(

--- a/pubsublite-spark-sql-streaming/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchReader.java
+++ b/pubsublite-spark-sql-streaming/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchReader.java
@@ -20,12 +20,10 @@ import com.google.cloud.pubsublite.SubscriptionPath;
 import com.google.cloud.pubsublite.cloudpubsub.FlowControlSettings;
 import com.google.cloud.pubsublite.internal.CursorClient;
 import com.google.cloud.pubsublite.internal.wire.SubscriberFactory;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.sources.v2.reader.InputPartition;
@@ -117,7 +115,8 @@ public class PslMicroBatchReader implements MicroBatchReader {
   public List<InputPartition<InternalRow>> planInputPartitions() {
     List<InputPartition<InternalRow>> list = new ArrayList<>();
 
-    for (SparkPartitionOffset offset : Objects.requireNonNull(startOffset).getPartitionOffsetMap().values()) {
+    for (SparkPartitionOffset offset :
+        Objects.requireNonNull(startOffset).getPartitionOffsetMap().values()) {
       SparkPartitionOffset endPartitionOffset =
           endOffset.getPartitionOffsetMap().get(offset.partition());
       if (offset.equals(endPartitionOffset)) {
@@ -129,7 +128,11 @@ public class PslMicroBatchReader implements MicroBatchReader {
           (consumer) -> partitionSubscriberFactory.newSubscriber(offset.partition(), consumer);
       list.add(
           new PslMicroBatchInputPartition(
-              subscriptionPath, flowControlSettings, offset, endPartitionOffset, subscriberFactory));
+              subscriptionPath,
+              flowControlSettings,
+              offset,
+              endPartitionOffset,
+              subscriberFactory));
     }
     return list;
   }

--- a/pubsublite-spark-sql-streaming/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchReader.java
+++ b/pubsublite-spark-sql-streaming/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchReader.java
@@ -20,6 +20,8 @@ import com.google.cloud.pubsublite.SubscriptionPath;
 import com.google.cloud.pubsublite.cloudpubsub.FlowControlSettings;
 import com.google.cloud.pubsublite.internal.CursorClient;
 import com.google.cloud.pubsublite.internal.wire.SubscriberFactory;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -113,22 +115,22 @@ public class PslMicroBatchReader implements MicroBatchReader {
 
   @Override
   public List<InputPartition<InternalRow>> planInputPartitions() {
-    assert startOffset != null;
-    return startOffset.getPartitionOffsetMap().values().stream()
-        .map(
-            v -> {
-              SparkPartitionOffset endPartitionOffset =
-                  endOffset.getPartitionOffsetMap().get(v.partition());
-              if (v.equals(endPartitionOffset)) {
-                // There is no message to pull for this partition.
-                return null;
-              }
-              SubscriberFactory subscriberFactory =
-                  (consumer) -> partitionSubscriberFactory.newSubscriber(v.partition(), consumer);
-              return new PslMicroBatchInputPartition(
-                  subscriptionPath, flowControlSettings, endPartitionOffset, subscriberFactory);
-            })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+    List<InputPartition<InternalRow>> list = new ArrayList<>();
+
+    for (SparkPartitionOffset offset : Objects.requireNonNull(startOffset).getPartitionOffsetMap().values()) {
+      SparkPartitionOffset endPartitionOffset =
+          endOffset.getPartitionOffsetMap().get(offset.partition());
+      if (offset.equals(endPartitionOffset)) {
+        // There is no message to pull for this partition.
+        continue;
+      }
+      PartitionSubscriberFactory partitionSubscriberFactory = this.partitionSubscriberFactory;
+      SubscriberFactory subscriberFactory =
+          (consumer) -> partitionSubscriberFactory.newSubscriber(offset.partition(), consumer);
+      list.add(
+          new PslMicroBatchInputPartition(
+              subscriptionPath, flowControlSettings, offset, endPartitionOffset, subscriberFactory));
+    }
+    return list;
   }
 }

--- a/pubsublite-spark-sql-streaming/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchReader.java
+++ b/pubsublite-spark-sql-streaming/src/main/java/com/google/cloud/pubsublite/spark/PslMicroBatchReader.java
@@ -19,6 +19,7 @@ package com.google.cloud.pubsublite.spark;
 import com.google.cloud.pubsublite.SubscriptionPath;
 import com.google.cloud.pubsublite.cloudpubsub.FlowControlSettings;
 import com.google.cloud.pubsublite.internal.CursorClient;
+import com.google.cloud.pubsublite.internal.wire.SubscriberFactory;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -122,11 +123,10 @@ public class PslMicroBatchReader implements MicroBatchReader {
                 // There is no message to pull for this partition.
                 return null;
               }
+              SubscriberFactory subscriberFactory =
+                  (consumer) -> partitionSubscriberFactory.newSubscriber(v.partition(), consumer);
               return new PslMicroBatchInputPartition(
-                  subscriptionPath,
-                  flowControlSettings,
-                  endPartitionOffset,
-                  (consumer) -> partitionSubscriberFactory.newSubscriber(v.partition(), consumer));
+                  subscriptionPath, flowControlSettings, endPartitionOffset, subscriberFactory);
             })
         .filter(Objects::nonNull)
         .collect(Collectors.toList());


### PR DESCRIPTION
This adds a simple read example and fixes the following bugs:
1. microbatchinputpartition subscriber should initially seek to startoffset instead of endoffset
2. lambda introduced in previous PRs brings `this`(PslXXXReader) as part of serialization, this PR detached `this` in lambda.