### PR TITLE
fix: Rebatch messages when restarting a publish stream

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/Constants.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/Constants.java
@@ -31,7 +31,7 @@ public class Constants {
           .build();
 
   public static final long MAX_PUBLISH_BATCH_COUNT = 1_000;
-  public static final long MAX_PUBLISH_BATCH_BYTES = 3_500_000;
+  public static final long MAX_PUBLISH_BATCH_BYTES = 1024 * 1024 * 7 / 4;  // 3.5 MiB
 
   private Constants() {}
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/Constants.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/Constants.java
@@ -31,7 +31,7 @@ public class Constants {
           .build();
 
   public static final long MAX_PUBLISH_BATCH_COUNT = 1_000;
-  public static final long MAX_PUBLISH_BATCH_BYTES = 1024 * 1024 * 7 / 4;  // 3.5 MiB
+  public static final long MAX_PUBLISH_BATCH_BYTES = 1024 * 1024 * 7 / 2;  // 3.5 MiB
 
   private Constants() {}
 }


### PR DESCRIPTION
This prevents publishers which are network isolated for a while from appearing disconnected when the server attempts to acknowledge messages.