### PR TITLE
build: fix version replacement in pubsublite-beam-io

### DIFF
--- a/pubsublite-beam-io/pom.xml
+++ b/pubsublite-beam-io/pom.xml
@@ -9,7 +9,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>pubsublite-beam-io</artifactId>
-  <version>0.10.1-SNAPSHOT</version>
+  <version>0.11.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-pubsublite:current} -->
   <packaging>jar</packaging>
   <name>Pub/Sub Lite IO</name>
   <url>https://github.com/googleapis/java-pubsublite</url>


### PR DESCRIPTION
Fixes the releases for pubsublite-beam-io artifact moving forward.

The artifact's pom.xml was missing the version replace tag so when we tried to release 0.11.0, this artifact still had 0.10.1-SNAPSHOT and couldn't be released.