### PR TITLE
chore: remove Constants.java from the list of generated files in synth.metadata

### DIFF
--- a/synth.metadata
+++ b/synth.metadata
@@ -99,7 +99,6 @@
     "CONTRIBUTING.md",
     "LICENSE",
     "codecov.yaml",
-    "google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/Constants.java",
     "google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/v1/AdminServiceClient.java",
     "google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/v1/AdminServiceSettings.java",
     "google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/v1/CursorServiceClient.java",


### PR DESCRIPTION
Remove handwritten file Constants.java from the list of generated files in synth.metadata to stop autosynth from suggesting PRs which delete Constants.java file
