### PR TITLE
fix: Centralize alarm executor creation for Pub/Sub Lite

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/PartitionCountWatcherImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/PartitionCountWatcherImpl.java
@@ -30,7 +30,6 @@ public class PartitionCountWatcherImpl extends AbstractApiService implements Par
   private final Duration period;
   private final TopicPath topicPath;
   private final AdminClient adminClient;
-  private final ScheduledExecutorService executorService;
   private final Consumer<Long> partitionCountReceiver;
 
   private ScheduledFuture<?> partitionCountPoll;
@@ -59,7 +58,6 @@ public class PartitionCountWatcherImpl extends AbstractApiService implements Par
     this.topicPath = topicPath;
     this.adminClient = adminClient;
     this.partitionCountReceiver = receiver;
-    this.executorService = Executors.newSingleThreadScheduledExecutor();
   }
 
   private void pollTopicConfig() {
@@ -96,8 +94,9 @@ public class PartitionCountWatcherImpl extends AbstractApiService implements Par
   @Override
   protected void doStart() {
     partitionCountPoll =
-        executorService.scheduleAtFixedRate(
-            this::pollTopicConfig, 0, period.toMillis(), TimeUnit.MILLISECONDS);
+        SystemExecutors.getAlarmExecutor()
+            .scheduleAtFixedRate(
+                this::pollTopicConfig, 0, period.toMillis(), TimeUnit.MILLISECONDS);
   }
 
   @Override

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ServiceClients.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ServiceClients.java
@@ -27,8 +27,6 @@ import com.google.cloud.pubsublite.CloudRegion;
 import com.google.cloud.pubsublite.Endpoints;
 import com.google.cloud.pubsublite.internal.Lazy;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.MoreExecutors;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.threeten.bp.Duration;
 
 public final class ServiceClients {
@@ -38,9 +36,7 @@ public final class ServiceClients {
       new Lazy<>(
           () ->
               FixedExecutorProvider.create(
-                  MoreExecutors.getExitingScheduledExecutorService(
-                      new ScheduledThreadPoolExecutor(
-                          Math.max(4, Runtime.getRuntime().availableProcessors())))));
+                  SystemExecutors.newDaemonExecutor("pubsub-lite-service-clients")));
 
   public static <
           Settings extends ClientSettings<Settings>,

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SystemExecutors.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SystemExecutors.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.internal.wire;
+
+import com.google.cloud.pubsublite.internal.Lazy;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class SystemExecutors {
+  private SystemExecutors() {}
+
+  public static ScheduledExecutorService newDaemonExecutor(String prefix) {
+    return Executors.newScheduledThreadPool(
+        Math.max(4, Runtime.getRuntime().availableProcessors()),
+        new ThreadFactoryBuilder().setDaemon(true).setNameFormat(prefix + "-%d").build());
+  }
+
+  private static final Lazy<ScheduledExecutorService> ALARM_EXECUTOR =
+      new Lazy<>(() -> newDaemonExecutor("pubsub-lite-alarms"));
+  // An executor for alarms.
+  public static ScheduledExecutorService getAlarmExecutor() {
+    return ALARM_EXECUTOR.get();
+  }
+}

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PerServerPublisherCache.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PerServerPublisherCache.java
@@ -26,4 +26,8 @@ final class PerServerPublisherCache {
   private PerServerPublisherCache() {}
 
   static final PublisherCache PUBLISHER_CACHE = new PublisherCache();
+
+  static {
+    Runtime.getRuntime().addShutdownHook(new Thread(PUBLISHER_CACHE::close));
+  }
 }

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PublisherCache.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PublisherCache.java
@@ -22,52 +22,50 @@ import com.google.api.core.ApiService.Listener;
 import com.google.api.core.ApiService.State;
 import com.google.api.gax.rpc.ApiException;
 import com.google.cloud.pubsublite.MessageMetadata;
-import com.google.cloud.pubsublite.internal.CloseableMonitor;
 import com.google.cloud.pubsublite.internal.Publisher;
+import com.google.cloud.pubsublite.internal.wire.SystemExecutors;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.util.HashMap;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 
 /** A map of working publishers by PublisherOptions. */
-class PublisherCache {
-  private final CloseableMonitor monitor = new CloseableMonitor();
-
-  private final Executor listenerExecutor = Executors.newSingleThreadExecutor();
-
-  @GuardedBy("monitor.monitor")
+class PublisherCache implements AutoCloseable {
+  @GuardedBy("this")
   private final HashMap<PublisherOptions, Publisher<MessageMetadata>> livePublishers =
       new HashMap<>();
 
-  Publisher<MessageMetadata> get(PublisherOptions options) throws ApiException {
+  private synchronized void evict(PublisherOptions options) {
+    livePublishers.remove(options);
+  }
+
+  synchronized Publisher<MessageMetadata> get(PublisherOptions options) throws ApiException {
     checkArgument(options.usesCache());
-    try (CloseableMonitor.Hold h = monitor.enter()) {
-      Publisher<MessageMetadata> publisher = livePublishers.get(options);
-      if (publisher != null) {
-        return publisher;
-      }
-      publisher = Publishers.newPublisher(options);
-      livePublishers.put(options, publisher);
-      publisher.addListener(
-          new Listener() {
-            @Override
-            public void failed(State s, Throwable t) {
-              try (CloseableMonitor.Hold h = monitor.enter()) {
-                livePublishers.remove(options);
-              }
-            }
-          },
-          listenerExecutor);
-      publisher.startAsync().awaitRunning();
+    Publisher<MessageMetadata> publisher = livePublishers.get(options);
+    if (publisher != null) {
       return publisher;
     }
+    publisher = Publishers.newPublisher(options);
+    livePublishers.put(options, publisher);
+    publisher.addListener(
+        new Listener() {
+          @Override
+          public void failed(State s, Throwable t) {
+            evict(options);
+          }
+        },
+        SystemExecutors.getAlarmExecutor());
+    publisher.startAsync().awaitRunning();
+    return publisher;
   }
 
   @VisibleForTesting
-  void set(PublisherOptions options, Publisher<MessageMetadata> toCache) {
-    try (CloseableMonitor.Hold h = monitor.enter()) {
-      livePublishers.put(options, toCache);
-    }
+  synchronized void set(PublisherOptions options, Publisher<MessageMetadata> toCache) {
+    livePublishers.put(options, toCache);
+  }
+
+  @Override
+  public synchronized void close() {
+    livePublishers.forEach(((options, publisher) -> publisher.stopAsync()));
+    livePublishers.clear();
   }
 }

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/Publishers.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/Publishers.java
@@ -26,6 +26,7 @@ import com.google.cloud.pubsublite.AdminClient;
 import com.google.cloud.pubsublite.AdminClientSettings;
 import com.google.cloud.pubsublite.MessageMetadata;
 import com.google.cloud.pubsublite.Partition;
+import com.google.cloud.pubsublite.cloudpubsub.PublisherSettings;
 import com.google.cloud.pubsublite.internal.Publisher;
 import com.google.cloud.pubsublite.internal.wire.PartitionCountWatchingPublisherSettings;
 import com.google.cloud.pubsublite.internal.wire.PubsubContext;
@@ -92,6 +93,7 @@ class Publishers {
                     .setTopic(options.topicPath())
                     .setPartition(partition)
                     .setServiceClient(newServiceClient(options, partition))
+                    .setBatchingSettings(PublisherSettings.DEFAULT_BATCHING_SETTINGS)
                     .build())
         .setAdminClient(newAdminClient(options))
         .build()

--- a/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteSink.java
+++ b/pubsublite-beam-io/src/main/java/com/google/cloud/pubsublite/beam/PubsubLiteSink.java
@@ -28,13 +28,12 @@ import com.google.cloud.pubsublite.beam.PublisherOrError.Kind;
 import com.google.cloud.pubsublite.internal.CheckedApiException;
 import com.google.cloud.pubsublite.internal.ExtractStatus;
 import com.google.cloud.pubsublite.internal.Publisher;
+import com.google.cloud.pubsublite.internal.wire.SystemExecutors;
 import com.google.cloud.pubsublite.proto.PubSubMessage;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import org.apache.beam.sdk.transforms.DoFn;
 
@@ -54,8 +53,6 @@ class PubsubLiteSink extends DoFn<PubSubMessage, Void> {
 
   @GuardedBy("this")
   private transient Deque<CheckedApiException> errorsSinceLastFinish;
-
-  private static final Executor executor = Executors.newCachedThreadPool();
 
   PubsubLiteSink(PublisherOptions options) {
     this.options = options;
@@ -129,7 +126,7 @@ class PubsubLiteSink extends DoFn<PubSubMessage, Void> {
             onFailure.accept(t);
           }
         },
-        executor);
+        SystemExecutors.getAlarmExecutor());
   }
 
   // Intentionally don't flush on bundle finish to allow multi-sink client reuse.


### PR DESCRIPTION
Also prevent creation of per-object thread pools which are largely unused and may prevent shutdown if not using daemon threads.