### PR TITLE
feat: Ability to reset subscriber upon out of band seek

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/SubscriberSettings.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/SubscriberSettings.java
@@ -260,7 +260,11 @@ public abstract class SubscriberSettings {
               partition, transformer().orElse(MessageTransforms.toCpsSubscribeTransformer())),
           new AckSetTrackerImpl(wireCommitter),
           nackHandler().orElse(new NackHandler() {}),
-          messageConsumer -> wireSubscriberBuilder.setMessageConsumer(messageConsumer).build(),
+          (messageConsumer, resetHandler) ->
+              wireSubscriberBuilder
+                  .setMessageConsumer(messageConsumer)
+                  .setResetHandler(resetHandler)
+                  .build(),
           perPartitionFlowControlSettings());
     } catch (Throwable t) {
       throw toCanonical(t);

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/AckSetTracker.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/AckSetTracker.java
@@ -25,7 +25,7 @@ interface AckSetTracker extends ApiService {
   // to add to the ack set. Must be called with strictly increasing offset messages.
   Runnable track(SequencedMessage message) throws CheckedApiException;
 
-  // Wait until all messages have been acked and the commit offset has been acknowledged by the
+  // Discard all outstanding acks and wait for any pending commit offset to be acknowledged by the
   // server. Throws an exception if the committer has shut down.
-  void waitUntilEmpty() throws CheckedApiException;
+  void waitUntilCommitted() throws CheckedApiException;
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/AckSetTracker.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/AckSetTracker.java
@@ -26,6 +26,6 @@ interface AckSetTracker extends ApiService {
   Runnable track(SequencedMessage message) throws CheckedApiException;
 
   // Discard all outstanding acks and wait for any pending commit offset to be acknowledged by the
-  // server. Throws an exception if the committer has shut down.
+  // server. Throws an exception if the committer shut down due to a permanent error.
   void waitUntilCommitted() throws CheckedApiException;
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/AckSetTrackerImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/AckSetTrackerImpl.java
@@ -113,6 +113,7 @@ public class AckSetTrackerImpl extends TrivialProxyService implements AckSetTrac
     try (CloseableMonitor.Hold h = monitor.enter()) {
       receiptsCopy = ImmutableList.copyOf(receipts);
     }
+    // Clearing receipts here avoids deadlocks due to locks acquired in different order.
     receiptsCopy.forEach(Receipt::clear);
     try (CloseableMonitor.Hold h = monitor.enter()) {
       receipts.clear();

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/AckSetTrackerImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/AckSetTrackerImpl.java
@@ -109,8 +109,8 @@ public class AckSetTrackerImpl extends TrivialProxyService implements AckSetTrac
       receipts.forEach(Receipt::clear);
       receipts.clear();
       acks.clear();
+      committer.waitUntilEmpty();
     }
-    committer.waitUntilEmpty();
   }
 
   private void onAck(Offset offset) {

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/AckSetTrackerImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/AckSetTrackerImpl.java
@@ -28,7 +28,6 @@ import com.google.cloud.pubsublite.internal.CloseableMonitor;
 import com.google.cloud.pubsublite.internal.ExtractStatus;
 import com.google.cloud.pubsublite.internal.TrivialProxyService;
 import com.google.cloud.pubsublite.internal.wire.Committer;
-import com.google.common.util.concurrent.Monitor.Guard;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -37,20 +36,51 @@ import java.util.PriorityQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class AckSetTrackerImpl extends TrivialProxyService implements AckSetTracker {
-  private final CloseableMonitor monitor = new CloseableMonitor();
+  // Receipt represents an unacked message. It can be cleared, which will cause the ack to be
+  // ignored.
+  private static class Receipt implements Runnable {
+    private final CloseableMonitor m = new CloseableMonitor();
+    private final AtomicBoolean wasAcked = new AtomicBoolean(false);
+    final Offset offset;
 
-  private final Guard isEmptyOrShutdown =
-      new Guard(monitor.monitor) {
-        public boolean isSatisfied() {
-          return (receipts.isEmpty() && acks.isEmpty()) || !isRunning();
+    @GuardedBy("m.monitor")
+    private Optional<AckSetTrackerImpl> tracker;
+
+    Receipt(Offset offset, AckSetTrackerImpl tracker) {
+      this.offset = offset;
+      this.tracker = Optional.of(tracker);
+    }
+
+    void clear() {
+      try (CloseableMonitor.Hold h = m.enter()) {
+        tracker = Optional.empty();
+      }
+    }
+
+    @Override
+    public void run() {
+      try (CloseableMonitor.Hold h = m.enter()) {
+        if (!tracker.isPresent()) {
+          return;
         }
-      };
+      }
+      if (wasAcked.getAndSet(true)) {
+        CheckedApiException e =
+            new CheckedApiException("Duplicate acks are not allowed.", Code.FAILED_PRECONDITION);
+        tracker.get().onPermanentError(e);
+        throw e.underlying;
+      }
+      tracker.get().onAck(offset);
+    }
+  }
+
+  private final CloseableMonitor monitor = new CloseableMonitor();
 
   @GuardedBy("monitor.monitor")
   private final Committer committer;
 
   @GuardedBy("monitor.monitor")
-  private final Deque<Offset> receipts = new ArrayDeque<>();
+  private final Deque<Receipt> receipts = new ArrayDeque<>();
 
   @GuardedBy("monitor.monitor")
   private final PriorityQueue<Offset> acks = new PriorityQueue<>();
@@ -65,28 +95,21 @@ public class AckSetTrackerImpl extends TrivialProxyService implements AckSetTrac
   public Runnable track(SequencedMessage message) throws CheckedApiException {
     final Offset messageOffset = message.offset();
     try (CloseableMonitor.Hold h = monitor.enter()) {
-      checkArgument(receipts.isEmpty() || receipts.peekLast().value() < messageOffset.value());
-      receipts.addLast(messageOffset);
+      checkArgument(
+          receipts.isEmpty() || receipts.peekLast().offset.value() < messageOffset.value());
+      Receipt receipt = new Receipt(messageOffset, this);
+      receipts.addLast(receipt);
+      return receipt;
     }
-    return new Runnable() {
-      private final AtomicBoolean wasAcked = new AtomicBoolean(false);
-
-      @Override
-      public void run() {
-        if (wasAcked.getAndSet(true)) {
-          CheckedApiException e =
-              new CheckedApiException("Duplicate acks are not allowed.", Code.FAILED_PRECONDITION);
-          onPermanentError(e);
-          throw e.underlying;
-        }
-        onAck(messageOffset);
-      }
-    };
   }
 
   @Override
-  public void waitUntilEmpty() throws CheckedApiException {
-    try (CloseableMonitor.Hold h = monitor.enterWhenUninterruptibly(isEmptyOrShutdown)) {}
+  public void waitUntilCommitted() throws CheckedApiException {
+    try (CloseableMonitor.Hold h = monitor.enter()) {
+      receipts.forEach(Receipt::clear);
+      receipts.clear();
+      acks.clear();
+    }
     committer.waitUntilEmpty();
   }
 
@@ -96,7 +119,7 @@ public class AckSetTrackerImpl extends TrivialProxyService implements AckSetTrac
       Optional<Offset> prefixAckedOffset = Optional.empty();
       while (!receipts.isEmpty()
           && !acks.isEmpty()
-          && receipts.peekFirst().value() == acks.peek().value()) {
+          && receipts.peekFirst().offset.value() == acks.peek().value()) {
         prefixAckedOffset = Optional.of(acks.remove());
         receipts.removeFirst();
       }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/AckSetTrackerImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/AckSetTrackerImpl.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class AckSetTrackerImpl extends TrivialProxyService implements AckSetTracker {
   // Receipt represents an unacked message. It can be cleared, which will cause the ack to be
   // ignored.
-  private static class Receipt implements Runnable {
+  private static class Receipt {
     private final CloseableMonitor m = new CloseableMonitor();
     private final AtomicBoolean wasAcked = new AtomicBoolean(false);
     final Offset offset;
@@ -57,8 +57,7 @@ public class AckSetTrackerImpl extends TrivialProxyService implements AckSetTrac
       }
     }
 
-    @Override
-    public void run() {
+    void onAck() {
       try (CloseableMonitor.Hold h = m.enter()) {
         if (!tracker.isPresent()) {
           return;
@@ -99,7 +98,7 @@ public class AckSetTrackerImpl extends TrivialProxyService implements AckSetTrac
           receipts.isEmpty() || receipts.peekLast().offset.value() < messageOffset.value());
       Receipt receipt = new Receipt(messageOffset, this);
       receipts.addLast(receipt);
-      return receipt;
+      return receipt::onAck;
     }
   }
 

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/ResettableSubscriberFactory.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/ResettableSubscriberFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,17 @@
 
 package com.google.cloud.pubsublite.cloudpubsub.internal;
 
-import com.google.api.core.ApiService;
+import com.google.api.gax.rpc.ApiException;
 import com.google.cloud.pubsublite.SequencedMessage;
-import com.google.cloud.pubsublite.internal.CheckedApiException;
+import com.google.cloud.pubsublite.internal.wire.Subscriber;
+import com.google.cloud.pubsublite.internal.wire.SubscriberResetHandler;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.util.function.Consumer;
 
-interface AckSetTracker extends ApiService {
-  // Track the given message. Returns a Runnable to ack this message if the message is a valid one
-  // to add to the ack set. Must be called with strictly increasing offset messages.
-  Runnable track(SequencedMessage message) throws CheckedApiException;
-
-  // Wait until all messages have been acked and the commit offset has been acknowledged by the
-  // server. Throws an exception if the committer has shut down.
-  void waitUntilEmpty() throws CheckedApiException;
+public interface ResettableSubscriberFactory extends Serializable {
+  Subscriber newSubscriber(
+      Consumer<ImmutableList<SequencedMessage>> messageConsumer,
+      SubscriberResetHandler resetHandler)
+      throws ApiException;
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/SinglePartitionSubscriber.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/SinglePartitionSubscriber.java
@@ -129,7 +129,7 @@ public class SinglePartitionSubscriber extends ProxyService implements Subscribe
 
   @VisibleForTesting
   boolean onSubscriberReset() throws CheckedApiException {
-    ackSetTracker.waitUntilEmpty();
+    ackSetTracker.waitUntilCommitted();
     return true;
   }
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/SinglePartitionSubscriber.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/SinglePartitionSubscriber.java
@@ -129,7 +129,7 @@ public class SinglePartitionSubscriber extends ProxyService implements Subscribe
 
   @VisibleForTesting
   boolean onSubscriberReset() throws CheckedApiException {
-    ackSetTracker.waitUntilCommitted();
-    return true;
+    // TODO: handle reset.
+    return false;
   }
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/SinglePartitionSubscriber.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/SinglePartitionSubscriber.java
@@ -30,7 +30,6 @@ import com.google.cloud.pubsublite.cloudpubsub.Subscriber;
 import com.google.cloud.pubsublite.internal.CheckedApiException;
 import com.google.cloud.pubsublite.internal.ExtractStatus;
 import com.google.cloud.pubsublite.internal.ProxyService;
-import com.google.cloud.pubsublite.internal.wire.SubscriberFactory;
 import com.google.cloud.pubsublite.proto.FlowControlRequest;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -50,7 +49,7 @@ public class SinglePartitionSubscriber extends ProxyService implements Subscribe
       MessageTransformer<SequencedMessage, PubsubMessage> transformer,
       AckSetTracker ackSetTracker,
       NackHandler nackHandler,
-      SubscriberFactory wireSubscriberFactory,
+      ResettableSubscriberFactory wireSubscriberFactory,
       FlowControlSettings flowControlSettings)
       throws ApiException {
     this.receiver = receiver;
@@ -58,7 +57,8 @@ public class SinglePartitionSubscriber extends ProxyService implements Subscribe
     this.ackSetTracker = ackSetTracker;
     this.nackHandler = nackHandler;
     this.flowControlSettings = flowControlSettings;
-    this.wireSubscriber = wireSubscriberFactory.newSubscriber(this::onMessages);
+    this.wireSubscriber =
+        wireSubscriberFactory.newSubscriber(this::onMessages, this::onSubscriberReset);
     addServices(ackSetTracker, wireSubscriber);
   }
 
@@ -125,5 +125,11 @@ public class SinglePartitionSubscriber extends ProxyService implements Subscribe
     } catch (Throwable t) {
       onPermanentError(ExtractStatus.toCanonical(t));
     }
+  }
+
+  @VisibleForTesting
+  boolean onSubscriberReset() throws CheckedApiException {
+    ackSetTracker.waitUntilEmpty();
+    return true;
   }
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ApiExceptionCommitter.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ApiExceptionCommitter.java
@@ -21,6 +21,7 @@ import static com.google.cloud.pubsublite.internal.ExtractStatus.toClientFuture;
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.rpc.ApiException;
 import com.google.cloud.pubsublite.Offset;
+import com.google.cloud.pubsublite.internal.CheckedApiException;
 import com.google.cloud.pubsublite.internal.TrivialProxyService;
 
 class ApiExceptionCommitter extends TrivialProxyService implements Committer {
@@ -34,5 +35,10 @@ class ApiExceptionCommitter extends TrivialProxyService implements Committer {
   @Override
   public ApiFuture<Void> commitOffset(Offset offset) {
     return toClientFuture(committer.commitOffset(offset));
+  }
+
+  @Override
+  public void waitUntilEmpty() throws CheckedApiException {
+    committer.waitUntilEmpty();
   }
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/CommitState.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/CommitState.java
@@ -59,15 +59,13 @@ class CommitState {
 
   void complete(long numComplete) throws CheckedApiException {
     if (numComplete > currentConnectionFutures.size()) {
-      CheckedApiException error =
-          new CheckedApiException(
-              String.format(
-                  "Received %s completions, which is more than the commits outstanding for this"
-                      + " stream.",
-                  numComplete),
-              Code.FAILED_PRECONDITION);
-      abort(error);
-      throw error;
+      // Note: Throw here to permanently shut down CommitterImpl, which will later call abort().
+      throw new CheckedApiException(
+          String.format(
+              "Received %s completions, which is more than the commits outstanding for this"
+                  + " stream.",
+              numComplete),
+          Code.FAILED_PRECONDITION);
     }
     while (!pastConnectionFutures.isEmpty()) {
       // Past futures refer to commits sent chronologically before the current stream, and thus they

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/Committer.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/Committer.java
@@ -26,6 +26,6 @@ public interface Committer extends ApiService {
   ApiFuture<Void> commitOffset(Offset offset);
 
   // Waits until all commits have been sent and acknowledged by the server. Throws an exception if
-  // the committer has shut down.
+  // the committer shut down due to a permanent error.
   void waitUntilEmpty() throws CheckedApiException;
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/NextOffsetTracker.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/NextOffsetTracker.java
@@ -59,4 +59,9 @@ public class NextOffsetTracker {
                 .setCursor(Cursor.newBuilder().setOffset(offset.value()))
                 .build());
   }
+
+  // Resets the offset tracker to its initial state.
+  void reset() {
+    nextOffset = Optional.empty();
+  }
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberBuilder.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberBuilder.java
@@ -37,8 +37,12 @@ public abstract class SubscriberBuilder {
 
   abstract SubscriberServiceClient serviceClient();
 
+  // Optional parameters.
+  abstract SubscriberResetHandler resetHandler();
+
   public static Builder newBuilder() {
-    return new AutoValue_SubscriberBuilder.Builder();
+    return new AutoValue_SubscriberBuilder.Builder()
+        .setResetHandler(SubscriberResetHandler::unhandled);
   }
 
   @AutoValue.Builder
@@ -53,6 +57,9 @@ public abstract class SubscriberBuilder {
 
     public abstract Builder setServiceClient(SubscriberServiceClient serviceClient);
 
+    // Optional parameters.
+    public abstract Builder setResetHandler(SubscriberResetHandler resetHandler);
+
     abstract SubscriberBuilder autoBuild();
 
     @SuppressWarnings("CheckReturnValue")
@@ -66,7 +73,10 @@ public abstract class SubscriberBuilder {
               .build();
       return new ApiExceptionSubscriber(
           new SubscriberImpl(
-              autoBuilt.serviceClient(), initialSubscribeRequest, autoBuilt.messageConsumer()));
+              autoBuilt.serviceClient(),
+              initialSubscribeRequest,
+              autoBuilt.messageConsumer(),
+              autoBuilt.resetHandler()));
     }
   }
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberResetHandler.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberResetHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,16 @@
 
 package com.google.cloud.pubsublite.internal.wire;
 
-import com.google.api.core.ApiFuture;
-import com.google.api.core.ApiService;
-import com.google.cloud.pubsublite.Offset;
 import com.google.cloud.pubsublite.internal.CheckedApiException;
 
-public interface Committer extends ApiService {
-  // Commit a given offset. Clean shutdown waits for all outstanding commits to complete.
-  ApiFuture<Void> commitOffset(Offset offset);
+public interface SubscriberResetHandler {
+  // Called when the server instructs the subscriber to reset its state in order to handle an out of
+  // band seek. The implementation should return false if reset is not handled by this type of
+  // subscriber client. If an exception is thrown, the subscriber is shut down.
+  boolean handleReset() throws CheckedApiException;
 
-  // Waits until all commits have been sent and acknowledged by the server. Throws an exception if
-  // the committer has shut down.
-  void waitUntilEmpty() throws CheckedApiException;
+  // Use SubscriberResetHandler::unhandled to disable reset handling.
+  static boolean unhandled() {
+    return false;
+  }
 }

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/cloudpubsub/internal/AckSetTrackerImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/cloudpubsub/internal/AckSetTrackerImplTest.java
@@ -39,8 +39,6 @@ import com.google.cloud.pubsublite.internal.testing.FakeApiService;
 import com.google.cloud.pubsublite.internal.wire.Committer;
 import com.google.cloud.pubsublite.proto.Cursor;
 import com.google.common.util.concurrent.MoreExecutors;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,8 +54,6 @@ public class AckSetTrackerImplTest {
   @Spy private FakeCommitter committer;
 
   @Mock private Listener permanentErrorHandler;
-
-  private final ExecutorService executorService = Executors.newCachedThreadPool();
 
   AckSetTracker tracker;
 

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/cloudpubsub/internal/SinglePartitionSubscriberTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/cloudpubsub/internal/SinglePartitionSubscriberTest.java
@@ -225,6 +225,6 @@ public class SinglePartitionSubscriberTest {
   @Test
   public void onSubscriberResetWaitsForAckSetTracker() throws CheckedApiException {
     assertThat(subscriber.onSubscriberReset()).isTrue();
-    verify(ackSetTracker).waitUntilEmpty();
+    verify(ackSetTracker).waitUntilCommitted();
   }
 }

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/cloudpubsub/internal/SinglePartitionSubscriberTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/cloudpubsub/internal/SinglePartitionSubscriberTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.pubsublite.cloudpubsub.internal;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -39,7 +40,6 @@ import com.google.cloud.pubsublite.internal.ApiExceptionMatcher;
 import com.google.cloud.pubsublite.internal.CheckedApiException;
 import com.google.cloud.pubsublite.internal.testing.FakeApiService;
 import com.google.cloud.pubsublite.internal.wire.Subscriber;
-import com.google.cloud.pubsublite.internal.wire.SubscriberFactory;
 import com.google.cloud.pubsublite.proto.Cursor;
 import com.google.cloud.pubsublite.proto.FlowControlRequest;
 import com.google.common.collect.ImmutableList;
@@ -68,7 +68,7 @@ public class SinglePartitionSubscriberTest {
 
   @Spy private AckSetTrackerFakeService ackSetTracker;
   @Mock private NackHandler nackHandler;
-  @Mock private SubscriberFactory subscriberFactory;
+  @Mock private ResettableSubscriberFactory subscriberFactory;
 
   abstract static class SubscriberFakeService extends FakeApiService implements Subscriber {}
 
@@ -88,7 +88,7 @@ public class SinglePartitionSubscriberTest {
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
-    when(subscriberFactory.newSubscriber(any())).thenReturn(wireSubscriber);
+    when(subscriberFactory.newSubscriber(any(), any())).thenReturn(wireSubscriber);
     subscriber =
         new SinglePartitionSubscriber(
             receiver,
@@ -101,7 +101,7 @@ public class SinglePartitionSubscriberTest {
                 .setBytesOutstanding(1000000)
                 .build());
     subscriber.startAsync().awaitRunning();
-    verify(subscriberFactory).newSubscriber(any());
+    verify(subscriberFactory).newSubscriber(any(), any());
     verify(ackSetTracker).startAsync();
     verify(wireSubscriber).startAsync();
     subscriber.addListener(permanentErrorHandler, MoreExecutors.directExecutor());
@@ -220,5 +220,11 @@ public class SinglePartitionSubscriberTest {
     verify(wireSubscriber).stopAsync();
     verify(permanentErrorHandler)
         .failed(any(), argThat(new ApiExceptionMatcher(Code.INVALID_ARGUMENT)));
+  }
+
+  @Test
+  public void onSubscriberResetWaitsForAckSetTracker() throws CheckedApiException {
+    assertThat(subscriber.onSubscriberReset()).isTrue();
+    verify(ackSetTracker).waitUntilEmpty();
   }
 }

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/cloudpubsub/internal/SinglePartitionSubscriberTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/cloudpubsub/internal/SinglePartitionSubscriberTest.java
@@ -223,8 +223,7 @@ public class SinglePartitionSubscriberTest {
   }
 
   @Test
-  public void onSubscriberResetWaitsForAckSetTracker() throws CheckedApiException {
-    assertThat(subscriber.onSubscriberReset()).isTrue();
-    verify(ackSetTracker).waitUntilCommitted();
+  public void onSubscriberResetNotHandled() throws CheckedApiException {
+    assertThat(subscriber.onSubscriberReset()).isFalse();
   }
 }

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/CommitStateTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/CommitStateTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.pubsublite.internal.wire;
 
-import static com.google.cloud.pubsublite.internal.ApiExceptionMatcher.assertFutureThrowsCode;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -63,8 +62,6 @@ public class CommitStateTest {
 
     CheckedApiException e = assertThrows(CheckedApiException.class, () -> state.complete(2));
     assertThat(e.code()).isEqualTo(Code.FAILED_PRECONDITION);
-
-    assertFutureThrowsCode(future, Code.FAILED_PRECONDITION);
   }
 
   @Test
@@ -101,8 +98,5 @@ public class CommitStateTest {
 
     CheckedApiException e = assertThrows(CheckedApiException.class, () -> state.complete(2));
     assertThat(e.code()).isEqualTo(Code.FAILED_PRECONDITION);
-
-    assertFutureThrowsCode(future1, Code.FAILED_PRECONDITION);
-    assertFutureThrowsCode(future2, Code.FAILED_PRECONDITION);
   }
 }

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/SubscriberBuilderTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/SubscriberBuilderTest.java
@@ -29,6 +29,7 @@ import com.google.cloud.pubsublite.SubscriptionPath;
 import com.google.cloud.pubsublite.v1.SubscriberServiceClient;
 import com.google.common.collect.ImmutableList;
 import java.util.function.Consumer;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -38,9 +39,30 @@ import org.mockito.Mock;
 public class SubscriberBuilderTest {
   @Mock public Consumer<ImmutableList<SequencedMessage>> mockConsumer;
 
-  @Test
-  public void testBuilder() {
+  @Before
+  public void setUp() {
     initMocks(this);
+  }
+
+  @Test
+  public void testBuilder_setAll() {
+    Subscriber unusedSubscriber =
+        SubscriberBuilder.newBuilder()
+            .setSubscriptionPath(
+                SubscriptionPath.newBuilder()
+                    .setLocation(CloudZone.of(CloudRegion.of("us-central1"), 'a'))
+                    .setProject(ProjectNumber.of(3))
+                    .setName(SubscriptionName.of("abc"))
+                    .build())
+            .setMessageConsumer(mockConsumer)
+            .setPartition(Partition.of(3))
+            .setServiceClient(mock(SubscriberServiceClient.class))
+            .setResetHandler(SubscriberResetHandler::unhandled)
+            .build();
+  }
+
+  @Test
+  public void testBuilder_omitOptionalFields() {
     Subscriber unusedSubscriber =
         SubscriberBuilder.newBuilder()
             .setSubscriptionPath(


### PR DESCRIPTION
Prepares for handling the `RESET` signal from the server, by:

* Discarding outstanding acks for delivered messages.
* Waiting for the committer to flush pending commits and receive the acknowledgment from the server.
* Then resetting subscriber state, including canceling any in-flight client seeks.

Notes:

* This PR is effectively a no-op as `SinglePartitionSubscriber.onSubscriberReset` returns false for now.
* The next PR will fully handle admin seeks by setting InitialSubscribeRequest.initial_location and implement `SinglePartitionSubscriber.onSubscriberReset`. Omitted to keep the size of the PR down.
* `CommitState.complete` had to be refactored to just throw (and not abort) because `CommitterImpl.waitUntilEmpty` should throw when there are excess commit responses, since the committer will shortly shut down.