### PR TITLE
chore: require sample tests to pass in presubmit

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -36,6 +36,8 @@ branchProtectionRules:
     - "units (8)"
     - "units (11)"
     - "Kokoro - Test: Integration"
+    - "Kokoro - Test: Samples Java 11"
+    - "Kokoro - Test: Samples Java 8"
     - "cla/google"
 # List of explicit permissions to add (additive only)
 permissionRules:


### PR DESCRIPTION
Now that we are adding sample tests (https://github.com/googleapis/java-pubsublite/pull/686) as a way to test the beam module of java-pubsublite. Requiring sample tests to pass in presubmit will help catch any bugs before committing to master.