### PR TITLE
chore: prevent synthtool from changing samples.yaml

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -29,4 +29,6 @@ java.common_templates(excludes=[
   '.kokoro/*/samples.cfg',
   # TODO: allow when pubsublite is available in libraries-bom
   'samples/install-without-bom/*',
+  # TODO: remove when the library is GA   
+  '.github/workflows/samples.yaml',
 ])


### PR DESCRIPTION
Prevent synthtool-proposed changes in checkstyle tests, as in this PR https://github.com/googleapis/java-pubsublite/pull/706/files

```yaml
      - name: Run checkstyle
        run: mvn -P lint --quiet --batch-mode checkstyle:check
        working-directory: samples/snippets
```

The working directory should stay as `samples`. We recently added https://github.com/googleapis/java-pubsublite/blob/master/samples/checkstyle-suppressions.xml in #686 and it requires we run checkstyel from `samples/` instead of `sampels/snippets`.