### PR TITLE
samples: exclude beam deps from pubsublite samples POM

### DIFF
--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -11,4 +11,4 @@ jobs:
           java-version: 8
       - name: Run checkstyle
         run: mvn -P lint --quiet --batch-mode checkstyle:check
-        working-directory: samples/snippets
+        working-directory: samples

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -50,21 +50,22 @@
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
-      <artifactId>pubsublite-beam-io</artifactId>
-      <version>0.16.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
       <version>1.113.3</version>
+    </dependency>
+    <!-- [END pubsublite_java_dependencies] -->
+    <!-- [END pubsublite_install_without_bom] -->
+    
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>pubsublite-beam-io</artifactId>
+      <version>0.16.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-model-pipeline</artifactId>
       <version>2.29.0</version>
     </dependency>
-    <!-- [END pubsublite_java_dependencies] -->
-    <!-- [END pubsublite_install_without_bom] -->
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
This is a region tag misuse. The Beam deps aren't needed for the Lite Java quickstart.

https://cloud.google.com/pubsub/lite/docs/quickstart#pubsublite-client-libraries-java