### PR TITLE
fix: Move BacklogLocation enum to standalone file

### DIFF
--- a/google-cloud-pubsublite/clirr-ignored-differences.xml
+++ b/google-cloud-pubsublite/clirr-ignored-differences.xml
@@ -3,6 +3,16 @@
 <differences>
   <!-- TODO: Remove on next release -->
   <difference>
+    <differenceType>7005</differenceType>
+    <className>com/google/cloud/pubsublite/AdminClient</className>
+    <method>*</method>
+    <to>*</to>
+  </difference>
+  <difference>
+    <differenceType>8001</differenceType>
+    <className>com/google/cloud/pubsublite/AdminClient*</className>
+  </difference>
+  <difference>
     <differenceType>7006</differenceType>
     <className>com/google/cloud/pubsublite/SubscriptionPath</className>
     <method>*</method>

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/AdminClient.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/AdminClient.java
@@ -32,17 +32,6 @@ public interface AdminClient extends ApiBackgroundResource {
     return settings.instantiate();
   }
 
-  /**
-   * BacklogLoction refers to a location with respect to the message backlog.
-   *
-   * <p>BEGINNING refers to the location of the oldest retained message. END refers to the location
-   * past all currently published messages, skipping the entire message backlog.
-   */
-  public enum BacklogLocation {
-    BEGINNING,
-    END
-  }
-
   /** The Google Cloud region this client operates on. */
   CloudRegion region();
 

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/BacklogLocation.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/BacklogLocation.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite;
+
+/** BacklogLocation refers to a location with respect to the message backlog. */
+public enum BacklogLocation {
+  /** BEGINNING refers to the location of the oldest retained message. */
+  BEGINNING,
+  /**
+   * END refers to the location past all currently published messages, skipping the entire message
+   * backlog.
+   */
+  END
+}

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/AdminClientImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/AdminClientImpl.java
@@ -19,7 +19,7 @@ package com.google.cloud.pubsublite.internal;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.pubsublite.AdminClient;
-import com.google.cloud.pubsublite.AdminClient.BacklogLocation;
+import com.google.cloud.pubsublite.BacklogLocation;
 import com.google.cloud.pubsublite.CloudRegion;
 import com.google.cloud.pubsublite.LocationPath;
 import com.google.cloud.pubsublite.ReservationPath;

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/AdminClientImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/AdminClientImplTest.java
@@ -28,7 +28,7 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.cloud.pubsublite.AdminClient.BacklogLocation;
+import com.google.cloud.pubsublite.BacklogLocation;
 import com.google.cloud.pubsublite.CloudRegion;
 import com.google.cloud.pubsublite.CloudZone;
 import com.google.cloud.pubsublite.LocationPath;


### PR DESCRIPTION
Allows `BacklogLocation` to be referenced from an upcoming class containing seek targets.