### PR TITLE
refactor: Add debug logging

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/AssignerImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/AssignerImpl.java
@@ -28,12 +28,15 @@ import com.google.cloud.pubsublite.proto.PartitionAssignment;
 import com.google.cloud.pubsublite.proto.PartitionAssignmentRequest;
 import com.google.cloud.pubsublite.v1.PartitionAssignmentServiceClient;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.flogger.GoogleLogger;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.util.HashSet;
 import java.util.Set;
 
 public class AssignerImpl extends TrivialProxyService
     implements Assigner, RetryingConnectionObserver<PartitionAssignment> {
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
   private final PartitionAssignmentRequest initialRequest;
 
   private final CloseableMonitor monitor = new CloseableMonitor();
@@ -90,7 +93,9 @@ public class AssignerImpl extends TrivialProxyService
   @Override
   public void onClientResponse(PartitionAssignment value) throws CheckedApiException {
     try (CloseableMonitor.Hold h = monitor.enter()) {
-      receiver.handleAssignment(toSet(value));
+      Set<Partition> partitions = toSet(value);
+      receiver.handleAssignment(partitions);
+      logger.atInfo().log("Subscribed to partitions: %s", partitions);
       connection.modifyConnection(connectionOr -> connectionOr.ifPresent(ConnectedAssigner::ack));
     }
   }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/PublisherImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/PublisherImpl.java
@@ -41,6 +41,7 @@ import com.google.cloud.pubsublite.proto.PublishResponse;
 import com.google.cloud.pubsublite.v1.PublisherServiceClient;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.Monitor;
 import java.util.ArrayDeque;
 import java.util.Collection;
@@ -54,6 +55,8 @@ import javax.annotation.concurrent.GuardedBy;
 
 public final class PublisherImpl extends ProxyService
     implements Publisher<Offset>, RetryingConnectionObserver<Offset> {
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
   private final BatchingSettings batchingSettings;
   private final PublishRequest initialRequest;
   private Future<?> alarmFuture;
@@ -135,6 +138,7 @@ public final class PublisherImpl extends ProxyService
         messages.add(UnbatchedMessage.of(batch.messages.get(i), batch.messageFutures.get(i)));
       }
     }
+    logger.atFiner().log("Re-publishing %s messages after reconnection", messages.size());
     long size = 0;
     int count = 0;
     Queue<UnbatchedMessage> currentBatch = new ArrayDeque<>();


### PR DESCRIPTION
* Log the partitions that a subscriber is assigned, at Info.
* Log verbose messages around stream reconnection (for prober debugging).