### PR TITLE
fix: Updates for import

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/CloudRegionOrZone.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/CloudRegionOrZone.java
@@ -22,7 +22,7 @@ import java.io.Serializable;
 
 @AutoOneOf(CloudRegionOrZone.Kind.class)
 public abstract class CloudRegionOrZone implements Serializable {
-  enum Kind {
+  public enum Kind {
     REGION,
     ZONE
   }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ConnectedSubscriberImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ConnectedSubscriberImpl.java
@@ -27,15 +27,12 @@ import com.google.cloud.pubsublite.proto.MessageResponse;
 import com.google.cloud.pubsublite.proto.SubscribeRequest;
 import com.google.cloud.pubsublite.proto.SubscribeResponse;
 import com.google.common.base.Preconditions;
-import com.google.common.flogger.GoogleLogger;
 import java.util.List;
 import java.util.stream.Collectors;
 
 class ConnectedSubscriberImpl
     extends SingleConnection<SubscribeRequest, SubscribeResponse, List<SequencedMessage>>
     implements ConnectedSubscriber {
-
-  private static final GoogleLogger log = GoogleLogger.forEnclosingClass();
 
   private final SubscribeRequest initialRequest;
 

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/PartitionCountWatchingPublisher.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/PartitionCountWatchingPublisher.java
@@ -193,7 +193,6 @@ public class PartitionCountWatchingPublisher extends ProxyService
       current.ifPresent(p -> p.publishers.forEach(mapBuilder::put));
       getNewPartitionPublishers(LongStream.range(currentSize, partitionCount))
           .forEach(mapBuilder::put);
-      ImmutableMap<Partition, Publisher<MessageMetadata>> newMap = mapBuilder.build();
 
       partitionsWithRouting =
           Optional.of(

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberFactory.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberFactory.java
@@ -23,5 +23,5 @@ import java.util.List;
 import java.util.function.Consumer;
 
 public interface SubscriberFactory extends Serializable {
-  Subscriber newSubscriber(Consumer<List<SequencedMessage>> message_consumer) throws ApiException;
+  Subscriber newSubscriber(Consumer<List<SequencedMessage>> messageConsumer) throws ApiException;
 }

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/ConnectedSubscriberImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/ConnectedSubscriberImplTest.java
@@ -102,8 +102,8 @@ public class ConnectedSubscriberImplTest {
         .then(
             args -> {
               Preconditions.checkArgument(!leakedResponseStream.isPresent());
-              ResponseObserver<SubscribeResponse> ResponseObserver = args.getArgument(0);
-              leakedResponseStream = Optional.of(ResponseObserver);
+              ResponseObserver<SubscribeResponse> responseObserver = args.getArgument(0);
+              leakedResponseStream = Optional.of(responseObserver);
               return mockRequestStream;
             });
   }


### PR DESCRIPTION
* Makes `CloudRegionOrZone.Kind` public so that users can check the kind before accessing region() or zone(). Otherwise an exception is thrown when accessing the wrong type.
* Fixed a few lint errors.