### PR TITLE
fix(test): deflake SubscriptionPartitionProcessorImplTest

### DIFF
--- a/pubsublite-beam-io/src/test/java/com/google/cloud/pubsublite/beam/SubscriptionPartitionProcessorImplTest.java
+++ b/pubsublite-beam-io/src/test/java/com/google/cloud/pubsublite/beam/SubscriptionPartitionProcessorImplTest.java
@@ -139,7 +139,7 @@ public class SubscriptionPartitionProcessorImplTest {
     processor.start();
     subscriber.fail(new CheckedApiException(Code.OUT_OF_RANGE));
     ApiException e =
-        assertThrows(ApiException.class, () -> processor.waitForCompletion(Duration.ZERO));
+        assertThrows(ApiException.class, () -> processor.waitForCompletion(Duration.millis(10)));
     assertEquals(Code.OUT_OF_RANGE, e.getStatusCode().getCode());
   }
 


### PR DESCRIPTION
Wait for 10ms for the PartitionProcessor to fail after failing the underlying subscriber.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-pubsublite/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #767 ☕️
