### PR TITLE
Always notifyFailed on ProxyService

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/ProxyService.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/ProxyService.java
@@ -67,12 +67,15 @@ public abstract class ProxyService extends AbstractApiService {
   // Tries to stop all dependent services and sets this service into the FAILED state.
   protected final void onPermanentError(CheckedApiException error) {
     if (stoppedOrFailed.getAndSet(true)) return;
-    for (ApiService service : services) {
-      service.stopAsync();
+    try {
+      for (ApiService service : services) {
+        service.stopAsync();
+      }
+      handlePermanentError(error);
+    } finally {
+      // Failures are sent to the client and should always be ApiExceptions.
+      notifyFailed(error.underlying);
     }
-    handlePermanentError(error);
-    // Failures are sent to the client and should always be ApiExceptions.
-    notifyFailed(error.underlying);
   }
 
   // AbstractApiService implementation.


### PR DESCRIPTION
If a class that extends `ProxyService` throw an exception from `handlePermanentError`, `notifyFailed` is never called. That prevent any user of this service from handling issue from this ApiService.

For context, we are currently facing some race condition in the AssigningSubscriber which cause it to fail without notifying the listener. We sometimes are getting new assignment from the server, which cause the client to close some SinglePartitionSubscriber. For some reason, this sometime an error with offset trying to be committed after the stream being close. This failure bubble up to the AssigningSubscriber that close all the SinglePartitionSubscriber. But since one of them is in failed state, this [line](https://github.com/googleapis/java-pubsublite/blob/master/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/AssigningSubscriber.java#L73) throw an exception. This bubble up to [here](https://github.com/googleapis/java-pubsublite/blob/master/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/ProxyService.java#L73). Since this exception is not handled, notifyFailed is not called and we can’t catch the exception and restart our pod.

I'll create a separate issue for this race condition.

```
com.google.api.gax.rpc.ApiException: 
	at com.google.cloud.pubsublite.internal.CheckedApiException.<init>(CheckedApiException.java:51)
	at com.google.cloud.pubsublite.internal.CheckedApiException.<init>(CheckedApiException.java:55)
	at com.google.cloud.pubsublite.internal.ExtractStatus.toCanonical(ExtractStatus.java:48)
	at com.google.cloud.pubsublite.internal.wire.ApiServiceUtils.blockingShutdown(ApiServiceUtils.java:61)
	at com.google.cloud.pubsublite.cloudpubsub.internal.AssigningSubscriber.stop(AssigningSubscriber.java:73)
	at com.google.cloud.pubsublite.cloudpubsub.internal.AssigningSubscriber.handlePermanentError(AssigningSubscriber.java:79)
	at com.google.cloud.pubsublite.internal.ProxyService.onPermanentError(ProxyService.java:73)
	at com.google.cloud.pubsublite.cloudpubsub.internal.AssigningSubscriber.access$000(AssigningSubscriber.java:41)
	at com.google.cloud.pubsublite.cloudpubsub.internal.AssigningSubscriber$1.failed(AssigningSubscriber.java:109)
	at com.google.api.core.AbstractApiService$1.failed(AbstractApiService.java:69)
	at com.google.common.util.concurrent.AbstractService$5.call(AbstractService.java:562)
	at com.google.common.util.concurrent.AbstractService$5.call(AbstractService.java:559)
	at com.google.common.util.concurrent.ListenerCallQueue$PerListenerQueue.run(ListenerCallQueue.java:205)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
	Caused by: java.lang.IllegalStateException: Expected the service InnerService [FAILED] to be TERMINATED, but the service has FAILED
	at com.google.common.util.concurrent.AbstractService.checkCurrentState(AbstractService.java:379)
	at com.google.common.util.concurrent.AbstractService.awaitTerminated(AbstractService.java:336)
	at com.google.api.core.AbstractApiService.awaitTerminated(AbstractApiService.java:104)
	at com.google.cloud.pubsublite.internal.wire.ApiServiceUtils.blockingShutdown(ApiServiceUtils.java:58)
	... 16 common frames omitted
	Caused by: com.google.api.gax.rpc.ApiException: Committed after the stream shut down.
	at com.google.cloud.pubsublite.internal.CheckedApiException.<init>(CheckedApiException.java:51)
	at com.google.cloud.pubsublite.internal.CheckedApiException.<init>(CheckedApiException.java:59)
	at com.google.cloud.pubsublite.internal.CheckedApiPreconditions.checkState(CheckedApiPreconditions.java:38)
	at com.google.cloud.pubsublite.internal.wire.CommitterImpl.commitOffset(CommitterImpl.java:137)
	at com.google.cloud.pubsublite.internal.wire.ApiExceptionCommitter.commitOffset(ApiExceptionCommitter.java:37)
	at com.google.cloud.pubsublite.cloudpubsub.internal.AckSetTrackerImpl.onAck(AckSetTrackerImpl.java:138)
	at com.google.cloud.pubsublite.cloudpubsub.internal.AckSetTrackerImpl.access$100(AckSetTrackerImpl.java:39)
	at com.google.cloud.pubsublite.cloudpubsub.internal.AckSetTrackerImpl$Receipt.onAck(AckSetTrackerImpl.java:76)
	at com.google.cloud.pubsublite.cloudpubsub.internal.SinglePartitionSubscriber$1.ack(SinglePartitionSubscriber.java:92)
```

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-pubsublite/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️
