### PR TITLE
fix: catch more possible errors in AssigningSubscriber and don't have hard errors on stopping subscribers

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/AssigningSubscriber.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/AssigningSubscriber.java
@@ -93,8 +93,8 @@ public class AssigningSubscriber extends ProxyService implements Subscriber {
           if (!liveSubscriberMap.containsKey(partition)) startSubscriber(partition);
         }
       }
-    } catch (CheckedApiException e) {
-      onPermanentError(e);
+    } catch (Throwable t) {
+      onPermanentError(toCanonical(t));
     }
   }
 
@@ -106,6 +106,7 @@ public class AssigningSubscriber extends ProxyService implements Subscriber {
         new Listener() {
           @Override
           public void failed(State from, Throwable failure) {
+            if (State.STOPPING.equals(from)) return;
             onPermanentError(toCanonical(failure));
           }
 

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/cloudpubsub/internal/AssigningSubscriberTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/cloudpubsub/internal/AssigningSubscriberTest.java
@@ -82,8 +82,8 @@ public class AssigningSubscriberTest {
 
   @Test
   public void failedCreate() throws CheckedApiException {
-    when(subscriberFactory.newSubscriber(Partition.of(1))).thenThrow(
-        new RuntimeException("Arbitrary error."));
+    when(subscriberFactory.newSubscriber(Partition.of(1)))
+        .thenThrow(new RuntimeException("Arbitrary error."));
     leakedReceiver.handleAssignment(ImmutableSet.of(Partition.of(1)));
     verify(subscriberFactory).newSubscriber(Partition.of(1));
     assertThrows(IllegalStateException.class, assigningSubscriber::awaitTerminated);


### PR DESCRIPTION
Possible improvement/fix for #871, unclear as I've been unable to reproduce.