### PR TITLE
chore: Add SubscriberSettings.setPartitionSubscriberClientSupplier

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/PartitionSubscriberClientSupplier.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/PartitionSubscriberClientSupplier.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.cloudpubsub;
+
+import com.google.cloud.pubsublite.Partition;
+import com.google.cloud.pubsublite.SubscriptionPath;
+import com.google.cloud.pubsublite.v1.SubscriberServiceClient;
+
+/** Supplies new SubscriberServiceClient instances. */
+public interface PartitionSubscriberClientSupplier {
+  /** Creates a new SubscriberServiceClient for the specified subscription and partition. */
+  SubscriberServiceClient get(SubscriptionPath subscription, Partition partition);
+}

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/cloudpubsub/SubscriberSettingsTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/cloudpubsub/SubscriberSettingsTest.java
@@ -50,7 +50,8 @@ public class SubscriberSettingsTest {
         .setPerPartitionFlowControlSettings(
             FlowControlSettings.builder().setBytesOutstanding(1).setMessagesOutstanding(1).build())
         .setCursorServiceClientSupplier(() -> mock(CursorServiceClient.class))
-        .setSubscriberServiceClientSupplier(() -> mock(SubscriberServiceClient.class))
+        .setPartitionSubscriberClientSupplier(
+            (subscription, partition) -> mock(SubscriberServiceClient.class))
         .setPartitions(ImmutableList.of(Partition.of(3), Partition.of(1)))
         .build()
         .instantiate();
@@ -65,7 +66,8 @@ public class SubscriberSettingsTest {
             FlowControlSettings.builder().setBytesOutstanding(1).setMessagesOutstanding(1).build())
         .setAssignmentServiceClient(mock(PartitionAssignmentServiceClient.class))
         .setCursorServiceClientSupplier(() -> mock(CursorServiceClient.class))
-        .setSubscriberServiceClientSupplier(() -> mock(SubscriberServiceClient.class))
+        .setPartitionSubscriberClientSupplier(
+            (subscription, partition) -> mock(SubscriberServiceClient.class))
         .build()
         .instantiate();
   }


### PR DESCRIPTION
Passes the subscription path and partition to the supplier.

Replaces SubscriberSettings.setSubscriberServiceClientSupplier, which is deprecated.