### PR TITLE
fix: Partition assignment stream does not require an initial response

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ConnectedAssignerImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ConnectedAssignerImpl.java
@@ -38,7 +38,7 @@ public class ConnectedAssignerImpl
       StreamFactory<PartitionAssignmentRequest, PartitionAssignment> streamFactory,
       ResponseObserver<PartitionAssignment> clientStream,
       PartitionAssignmentRequest initialRequest) {
-    super(streamFactory, clientStream);
+    super(streamFactory, clientStream, /*expectInitialResponse=*/ false);
     initialize(initialRequest);
   }
 

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/ConnectedAssignerImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/ConnectedAssignerImplTest.java
@@ -83,13 +83,13 @@ public class ConnectedAssignerImplTest {
   public void setUp() throws IOException {
     MockitoAnnotations.initMocks(this);
     doAnswer(
-            (Answer<ClientStream<PartitionAssignmentRequest>>)
-                args -> {
-                  Preconditions.checkArgument(!leakedResponseStream.isPresent());
-                  ResponseObserver<PartitionAssignment> ResponseObserver = args.getArgument(0);
-                  leakedResponseStream = Optional.of(ResponseObserver);
-                  return mockRequestStream;
-                })
+        (Answer<ClientStream<PartitionAssignmentRequest>>)
+            args -> {
+              Preconditions.checkArgument(!leakedResponseStream.isPresent());
+              ResponseObserver<PartitionAssignment> responseObserver = args.getArgument(0);
+              leakedResponseStream = Optional.of(responseObserver);
+              return mockRequestStream;
+            })
         .when(streamFactory)
         .New(any());
   }
@@ -137,6 +137,12 @@ public class ConnectedAssignerImplTest {
     doAnswer(AnswerWith(Code.INTERNAL)).when(mockRequestStream).send(initialRequest());
     try (ConnectedAssigner assigner =
         FACTORY.New(streamFactory, mockOutputStream, initialRequest())) {}
+  }
+
+  @Test
+  public void construct_noInitialResponse() throws Exception {
+    assigner = FACTORY.New(streamFactory, mockOutputStream, initialRequest());
+    verify(mockRequestStream).send(initialRequest());
   }
 
   private void initialize() {

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/ConnectedAssignerImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/ConnectedAssignerImplTest.java
@@ -83,13 +83,13 @@ public class ConnectedAssignerImplTest {
   public void setUp() throws IOException {
     MockitoAnnotations.initMocks(this);
     doAnswer(
-        (Answer<ClientStream<PartitionAssignmentRequest>>)
-            args -> {
-              Preconditions.checkArgument(!leakedResponseStream.isPresent());
-              ResponseObserver<PartitionAssignment> responseObserver = args.getArgument(0);
-              leakedResponseStream = Optional.of(responseObserver);
-              return mockRequestStream;
-            })
+            (Answer<ClientStream<PartitionAssignmentRequest>>)
+                args -> {
+                  Preconditions.checkArgument(!leakedResponseStream.isPresent());
+                  ResponseObserver<PartitionAssignment> responseObserver = args.getArgument(0);
+                  leakedResponseStream = Optional.of(responseObserver);
+                  return mockRequestStream;
+                })
         .when(streamFactory)
         .New(any());
   }


### PR DESCRIPTION
If the client reconnects and assignments have not changed, the server does not send an initial assignment set. This can cause subscriber shutdown to hang because the lock is held in SingleConnection while waiting for stream initialization to complete.
