### PR TITLE
fix: Add a timeout to getTopicPartitionCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ If you are using Maven, add this to your pom.xml file:
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-pubsublite:1.4.1'
+implementation 'com.google.cloud:google-cloud-pubsublite:1.4.3'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-pubsublite" % "1.4.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-pubsublite" % "1.4.3"
 ```
 
 ## Authentication


### PR DESCRIPTION
This is a workaround for https://github.com/googleapis/gax-java/issues/1577
