### PR TITLE
fix: Share the transport channel provider for publishers and subscribers in the same region

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ If you are using Maven, add this to your pom.xml file:
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-pubsublite:1.4.4'
+implementation 'com.google.cloud:google-cloud-pubsublite:1.4.5'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-pubsublite" % "1.4.4"
+libraryDependencies += "com.google.cloud" % "google-cloud-pubsublite" % "1.4.5"
 ```
 
 ## Authentication

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ServiceClients.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ServiceClients.java
@@ -40,16 +40,20 @@ public final class ServiceClients {
               FixedExecutorProvider.create(
                   SystemExecutors.newDaemonExecutor("pubsub-lite-service-clients")));
 
-  private static final ConcurrentHashMap<CloudRegion, TransportChannelProvider> CHANNELS = new ConcurrentHashMap<>();
+  private static final ConcurrentHashMap<CloudRegion, TransportChannelProvider> CHANNELS =
+      new ConcurrentHashMap<>();
 
   private static TransportChannelProvider getTransportChannelProvider(CloudRegion region) {
-    return CHANNELS.computeIfAbsent(region, key -> InstantiatingGrpcChannelProvider.newBuilder()
-        .setMaxInboundMessageSize(Integer.MAX_VALUE)
-        .setKeepAliveTime(Duration.ofMinutes(1))
-        .setKeepAliveWithoutCalls(true)
-        .setKeepAliveTimeout(Duration.ofMinutes(1))
-        .setPoolSize(100)
-        .build());
+    return CHANNELS.computeIfAbsent(
+        region,
+        key ->
+            InstantiatingGrpcChannelProvider.newBuilder()
+                .setMaxInboundMessageSize(Integer.MAX_VALUE)
+                .setKeepAliveTime(Duration.ofMinutes(1))
+                .setKeepAliveWithoutCalls(true)
+                .setKeepAliveTimeout(Duration.ofMinutes(1))
+                .setPoolSize(100)
+                .build());
   }
 
   public static <


### PR DESCRIPTION
This prevents GRPC lock ups that can happen when creating new channels all the time for publishers with many partitions.

Use 100 channels in the pool to avoid GRPC limits on streams per channel.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-pubsublite/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
