### PR TITLE
build: add log4j≤2.15 to banned deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,28 @@
           </annotationProcessorPaths>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-banned-deps</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <!-- ban all log4j 2.x deps with CVEs -->
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>org.apache.logging.log4j:*:[2.0-alpha1,2.15.0]</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Hopefully this will not be necessary with the next flogger release containing this change: https://github.com/google/flogger/pull/307