### PR TITLE
fix: Numerous publish path performance issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ If you are using Maven, add this to your pom.xml file:
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-pubsublite:1.4.5'
+implementation 'com.google.cloud:google-cloud-pubsublite:1.4.6'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-pubsublite" % "1.4.5"
+libraryDependencies += "com.google.cloud" % "google-cloud-pubsublite" % "1.4.6"
 ```
 
 ## Authentication

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/WrappingPublisher.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/internal/WrappingPublisher.java
@@ -29,6 +29,7 @@ import com.google.cloud.pubsublite.internal.CheckedApiException;
 import com.google.cloud.pubsublite.internal.ProxyService;
 import com.google.cloud.pubsublite.internal.wire.SystemExecutors;
 import com.google.common.flogger.GoogleLogger;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.pubsub.v1.PubsubMessage;
 
 // A WrappingPublisher wraps the wire protocol client with a Cloud Pub/Sub api compliant
@@ -74,6 +75,6 @@ public class WrappingPublisher extends ProxyService implements Publisher {
     return ApiFutures.transform(
         wirePublisher.publish(wireMessage),
         MessageMetadata::encode,
-        SystemExecutors.getFuturesExecutor());
+        MoreExecutors.directExecutor());
   }
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/CheckedApiPreconditions.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/CheckedApiPreconditions.java
@@ -30,11 +30,24 @@ public class CheckedApiPreconditions {
     if (!test) throw new CheckedApiException(description, Code.INVALID_ARGUMENT);
   }
 
+  public static void checkArgument(boolean test, String descriptionFormat, Object... args)
+      throws CheckedApiException {
+    if (!test)
+      throw new CheckedApiException(String.format(descriptionFormat, args), Code.INVALID_ARGUMENT);
+  }
+
   public static void checkState(boolean test) throws CheckedApiException {
     checkState(test, "");
   }
 
   public static void checkState(boolean test, String description) throws CheckedApiException {
     if (!test) throw new CheckedApiException(description, Code.FAILED_PRECONDITION);
+  }
+
+  public static void checkState(boolean test, String descriptionFormat, Object... args)
+      throws CheckedApiException {
+    if (!test)
+      throw new CheckedApiException(
+          String.format(descriptionFormat, args), Code.FAILED_PRECONDITION);
   }
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/ExtractStatus.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/ExtractStatus.java
@@ -21,6 +21,7 @@ import com.google.api.core.ApiFutures;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.cloud.pubsublite.internal.wire.SystemExecutors;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
@@ -53,7 +54,7 @@ public final class ExtractStatus {
         source,
         Throwable.class,
         t -> ApiFutures.immediateFailedFuture(toCanonical(t).underlying),
-        SystemExecutors.getFuturesExecutor());
+        MoreExecutors.directExecutor());
   }
 
   public static void addFailureHandler(

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ConnectedSubscriberImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ConnectedSubscriberImpl.java
@@ -100,18 +100,16 @@ class ConnectedSubscriberImpl
   private void onMessages(MessageResponse response) throws CheckedApiException {
     checkState(
         response.getMessagesCount() > 0,
-        String.format(
-            "Received an empty MessageResponse on stream with initial request %s.",
-            initialRequest));
+        "Received an empty MessageResponse on stream with initial request %s.",
+        initialRequest);
     List<SequencedMessage> messages =
         response.getMessagesList().stream()
             .map(SequencedMessage::fromProto)
             .collect(Collectors.toList());
     checkState(
         Predicates.isOrdered(messages),
-        String.format(
-            "Received out of order messages on the stream with initial request %s.",
-            initialRequest));
+        "Received out of order messages on the stream with initial request %s.",
+        initialRequest);
     sendToClient(messages);
   }
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/PartitionCountWatchingPublisher.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/PartitionCountWatchingPublisher.java
@@ -63,9 +63,8 @@ public class PartitionCountWatchingPublisher extends ProxyService
                 : routingPolicy.route(message.key());
         checkState(
             publishers.containsKey(routedPartition),
-            String.format(
-                "Routed to partition %s for which there is no publisher available.",
-                routedPartition));
+            "Routed to partition %s for which there is no publisher available.",
+            routedPartition);
         return publishers.get(routedPartition).publish(message);
       } catch (Throwable t) {
         throw toCanonical(t);

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/PublisherImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/PublisherImpl.java
@@ -234,7 +234,8 @@ public final class PublisherImpl extends ProxyService
       ApiService.State currentState = state();
       checkState(
           currentState == ApiService.State.RUNNING,
-          String.format("Cannot publish when Publisher state is %s.", currentState.name()));
+          "Cannot publish when Publisher state is %s.",
+          currentState.name());
       return batcher.add(proto);
     } catch (CheckedApiException e) {
       onPermanentError(e);

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/RoutingPublisher.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/RoutingPublisher.java
@@ -52,9 +52,8 @@ public class RoutingPublisher extends ProxyService implements Publisher<MessageM
           message.key().isEmpty() ? policy.routeWithoutKey() : policy.route(message.key());
       checkState(
           partitionPublishers.containsKey(routedPartition),
-          String.format(
-              "Routed to partition %s for which there is no publisher available.",
-              routedPartition));
+          "Routed to partition %s for which there is no publisher available.",
+          routedPartition);
       return partitionPublishers.get(routedPartition).publish(message);
     } catch (Throwable t) {
       CheckedApiException e = toCanonical(t);

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SinglePartitionPublisher.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SinglePartitionPublisher.java
@@ -25,6 +25,7 @@ import com.google.cloud.pubsublite.Offset;
 import com.google.cloud.pubsublite.Partition;
 import com.google.cloud.pubsublite.internal.ProxyService;
 import com.google.cloud.pubsublite.internal.Publisher;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 
 public class SinglePartitionPublisher extends ProxyService implements Publisher<MessageMetadata> {
@@ -43,7 +44,7 @@ public class SinglePartitionPublisher extends ProxyService implements Publisher<
     return ApiFutures.transform(
         publisher.publish(message),
         offset -> MessageMetadata.of(partition, offset),
-        SystemExecutors.getFuturesExecutor());
+        MoreExecutors.directExecutor());
   }
 
   @Override


### PR DESCRIPTION
All of the uses of DirectExecutor are performing simple data-only transformations and are in the publisher hotpath

