### PR TITLE
fix: Reinitialize streams in an unbounded executor

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/RetryingConnectionImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/RetryingConnectionImpl.java
@@ -199,17 +199,21 @@ class RetryingConnectionImpl<
         backoffTime, streamDescription());
     ScheduledFuture<?> retry =
         SystemExecutors.getAlarmExecutor()
-            .schedule(
-                () -> {
-                  try {
-                    observer.triggerReinitialize(statusOr.get());
-                  } catch (Throwable t2) {
-                    logger.atWarning().withCause(t2).log("Error occurred in triggerReinitialize.");
-                    onError(t2);
-                  }
-                },
-                backoffTime,
-                MILLISECONDS);
+            .schedule(() -> triggerReinitialize(statusOr.get()), backoffTime, MILLISECONDS);
+  }
+
+  private void triggerReinitialize(CheckedApiException streamError) {
+    // Reinitialize in an unbounded executor to avoid starving the bounded alarm executor.
+    SystemExecutors.getFuturesExecutor()
+        .execute(
+            () -> {
+              try {
+                observer.triggerReinitialize(streamError);
+              } catch (Throwable t) {
+                logger.atWarning().withCause(t).log("Error occurred in triggerReinitialize.");
+                onError(t);
+              }
+            });
   }
 
   @Override

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/RetryingConnectionImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/RetryingConnectionImpl.java
@@ -203,7 +203,8 @@ class RetryingConnectionImpl<
   }
 
   private void triggerReinitialize(CheckedApiException streamError) {
-    // Reinitialize in an unbounded executor to avoid starving the bounded alarm executor.
+    // Reinitialize in an unbounded executor to avoid starving tasks using the bounded alarm
+    // executor.
     SystemExecutors.getFuturesExecutor()
         .execute(
             () -> {


### PR DESCRIPTION
Stream initializations can sometimes be stalled, which starves tasks using the alarm executor. This performs reinitialization in an unbounded (futures) executor.
