### PR TITLE
fix: Ensure messages are delivered in order

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/SerialExecutor.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/SerialExecutor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.internal;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.concurrent.GuardedBy;
+
+/** An executor that runs tasks sequentially. */
+public final class SerialExecutor implements AutoCloseable, Executor {
+  private final Executor executor;
+  private final AtomicBoolean isShutdown = new AtomicBoolean(false);
+
+  @GuardedBy("this")
+  private final Queue<Runnable> tasks;
+
+  @GuardedBy("this")
+  private boolean isTaskActive;
+
+  public SerialExecutor(Executor executor) {
+    this.executor = executor;
+    this.tasks = new ArrayDeque<>();
+    this.isTaskActive = false;
+  }
+
+  /**
+   * Shuts down the executor. No subsequent tasks will run, but any running task will be left to
+   * complete.
+   */
+  @Override
+  public void close() {
+    isShutdown.set(true);
+  }
+
+  @Override
+  public synchronized void execute(Runnable r) {
+    if (isShutdown.get()) {
+      return;
+    }
+    tasks.add(
+        () -> {
+          if (isShutdown.get()) {
+            return;
+          }
+          try {
+            r.run();
+          } finally {
+            scheduleNextTask();
+          }
+        });
+    if (!isTaskActive) {
+      scheduleNextTask();
+    }
+  }
+
+  private synchronized void scheduleNextTask() {
+    isTaskActive = !tasks.isEmpty();
+    if (isTaskActive) {
+      executor.execute(tasks.poll());
+    }
+  }
+}

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/SerialExecutorTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/SerialExecutorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import com.google.cloud.pubsublite.internal.wire.SystemExecutors;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class SerialExecutorTest {
+  private final SerialExecutor executor = new SerialExecutor(SystemExecutors.getFuturesExecutor());
+
+  @Test
+  public void serializesTasks() throws Exception {
+    final int numTasks = 100;
+    List<Integer> receivedSequences = new ArrayList<>();
+    CountDownLatch tasksDone = new CountDownLatch(numTasks);
+    for (int i = 0; i < numTasks; i++) {
+      int sequence = i;
+      executor.execute(
+          () -> {
+            synchronized (receivedSequences) {
+              receivedSequences.add(sequence);
+            }
+            tasksDone.countDown();
+          });
+    }
+    assertThat(tasksDone.await(30, SECONDS)).isTrue();
+
+    for (int i = 0; i < receivedSequences.size(); i++) {
+      assertThat(receivedSequences.get(i)).isEqualTo(i);
+    }
+  }
+
+  @Test
+  public void closeDiscardsTasks() throws Exception {
+    List<Integer> receivedSequences = new ArrayList<>();
+    CountDownLatch tasksDone = new CountDownLatch(1);
+    for (int i = 0; i < 10; i++) {
+      int sequence = i;
+      executor.execute(
+          () -> {
+            synchronized (receivedSequences) {
+              receivedSequences.add(sequence);
+            }
+            tasksDone.countDown();
+            executor.close();
+          });
+    }
+    assertThat(tasksDone.await(10, SECONDS)).isTrue();
+
+    assertThat(receivedSequences).containsExactly(0);
+  }
+}


### PR DESCRIPTION
The messages are ordered when they are processed by the wire subscriber. However, if the user message receiver is slow, different message batches may be concurrently processed by the receiver. The wire subscriber now serializes delivery of the message batches.

Internal: cl/423978493.