### PR TITLE
fix: Mitigate gRPC stream connection issues

### DIFF
--- a/google-cloud-pubsublite/clirr-ignored-differences.xml
+++ b/google-cloud-pubsublite/clirr-ignored-differences.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <differenceType>7004</differenceType>
+    <className>com/google/cloud/pubsublite/internal/**</className>
+    <method>*</method>
+  </difference>
+</differences>

--- a/google-cloud-pubsublite/pom.xml
+++ b/google-cloud-pubsublite/pom.xml
@@ -134,6 +134,11 @@
       <artifactId>gson</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- Need testing utility classes for generated gRPC clients tests -->
     <dependency>
       <groupId>com.google.api</groupId>

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ConnectedAssignerImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ConnectedAssignerImpl.java
@@ -25,10 +25,13 @@ import com.google.cloud.pubsublite.proto.PartitionAssignment;
 import com.google.cloud.pubsublite.proto.PartitionAssignmentAck;
 import com.google.cloud.pubsublite.proto.PartitionAssignmentRequest;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
+import java.time.Duration;
 
 public class ConnectedAssignerImpl
     extends SingleConnection<PartitionAssignmentRequest, PartitionAssignment, PartitionAssignment>
     implements ConnectedAssigner {
+  private static final Duration STREAM_IDLE_TIMEOUT = Duration.ofMinutes(10);
+
   private final CloseableMonitor monitor = new CloseableMonitor();
 
   @GuardedBy("monitor.monitor")
@@ -38,7 +41,7 @@ public class ConnectedAssignerImpl
       StreamFactory<PartitionAssignmentRequest, PartitionAssignment> streamFactory,
       ResponseObserver<PartitionAssignment> clientStream,
       PartitionAssignmentRequest initialRequest) {
-    super(streamFactory, clientStream, /*expectInitialResponse=*/ false);
+    super(streamFactory, clientStream, STREAM_IDLE_TIMEOUT, /*expectInitialResponse=*/ false);
     initialize(initialRequest);
   }
 

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ConnectedCommitterImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ConnectedCommitterImpl.java
@@ -26,6 +26,8 @@ import com.google.cloud.pubsublite.proto.SequencedCommitCursorRequest;
 import com.google.cloud.pubsublite.proto.SequencedCommitCursorResponse;
 import com.google.cloud.pubsublite.proto.StreamingCommitCursorRequest;
 import com.google.cloud.pubsublite.proto.StreamingCommitCursorResponse;
+import com.google.common.annotations.VisibleForTesting;
+import java.time.Duration;
 
 public class ConnectedCommitterImpl
     extends SingleConnection<
@@ -33,11 +35,13 @@ public class ConnectedCommitterImpl
     implements ConnectedCommitter {
   private final StreamingCommitCursorRequest initialRequest;
 
-  private ConnectedCommitterImpl(
+  @VisibleForTesting
+  ConnectedCommitterImpl(
       StreamFactory<StreamingCommitCursorRequest, StreamingCommitCursorResponse> streamFactory,
       ResponseObserver<SequencedCommitCursorResponse> clientStream,
-      StreamingCommitCursorRequest initialRequest) {
-    super(streamFactory, clientStream);
+      StreamingCommitCursorRequest initialRequest,
+      Duration streamIdleTimeout) {
+    super(streamFactory, clientStream, streamIdleTimeout, /*expectInitialResponse=*/ true);
     this.initialRequest = initialRequest;
     initialize(initialRequest);
   }
@@ -48,7 +52,8 @@ public class ConnectedCommitterImpl
         StreamFactory<StreamingCommitCursorRequest, StreamingCommitCursorResponse> streamFactory,
         ResponseObserver<SequencedCommitCursorResponse> clientStream,
         StreamingCommitCursorRequest initialRequest) {
-      return new ConnectedCommitterImpl(streamFactory, clientStream, initialRequest);
+      return new ConnectedCommitterImpl(
+          streamFactory, clientStream, initialRequest, DEFAULT_STREAM_IDLE_TIMEOUT);
     }
   }
 

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/StreamIdleTimer.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/StreamIdleTimer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.internal.wire;
+
+import static com.google.common.collect.Comparators.min;
+
+import com.google.cloud.pubsublite.internal.AlarmFactory;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Ticker;
+import java.time.Duration;
+import java.util.concurrent.Future;
+import javax.annotation.concurrent.GuardedBy;
+
+/** An approximate timer used to detect idle streams. */
+class StreamIdleTimer implements AutoCloseable {
+  /** Handles a timeout. */
+  interface Handler {
+    void onTimeout();
+  }
+
+  private static final long POLL_DIVISOR = 4;
+  private static final Duration MAX_POLL_INTERVAL = Duration.ofMinutes(1);
+
+  @VisibleForTesting
+  static Duration getDelay(Duration timeout) {
+    return min(MAX_POLL_INTERVAL, timeout.dividedBy(POLL_DIVISOR));
+  }
+
+  private final Duration timeout;
+  private final Handler handler;
+  private final Future<?> task;
+
+  @GuardedBy("this")
+  private final Stopwatch stopwatch;
+
+  /**
+   * Creates a started timer.
+   *
+   * @param timeout Call the handler after this duration has elapsed. The call may be delayed up to
+   *     (timeout / POLL_DIVISOR) after the timeout duration.
+   * @param handler Called after the timeout has expired and the timer is running.
+   */
+  StreamIdleTimer(Duration timeout, Handler handler) {
+    this(timeout, handler, Ticker.systemTicker(), AlarmFactory.create(getDelay(timeout)));
+  }
+
+  @VisibleForTesting
+  StreamIdleTimer(Duration timeout, Handler handler, Ticker ticker, AlarmFactory alarmFactory) {
+    this.timeout = timeout;
+    this.handler = handler;
+    this.stopwatch = Stopwatch.createStarted(ticker);
+    this.task = alarmFactory.newAlarm(this::onPoll);
+  }
+
+  @Override
+  public void close() throws Exception {
+    task.cancel(false);
+  }
+
+  /** Restart the timer from zero. */
+  public synchronized void restart() {
+    stopwatch.reset().start();
+  }
+
+  private synchronized void onPoll() {
+    if (stopwatch.elapsed().compareTo(timeout) > 0) {
+      SystemExecutors.getFuturesExecutor().execute(handler::onTimeout);
+    }
+  }
+}

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SystemExecutors.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SystemExecutors.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 
 public class SystemExecutors {
@@ -31,8 +32,13 @@ public class SystemExecutors {
   }
 
   public static ScheduledExecutorService newDaemonExecutor(String prefix) {
-    return Executors.newScheduledThreadPool(
-        Math.max(4, Runtime.getRuntime().availableProcessors()), newDaemonThreadFactory(prefix));
+    ScheduledThreadPoolExecutor executor =
+        new ScheduledThreadPoolExecutor(
+            Math.max(4, Runtime.getRuntime().availableProcessors()),
+            newDaemonThreadFactory(prefix));
+    // Remove scheduled tasks from the executor as soon as they are cancelled.
+    executor.setRemoveOnCancelPolicy(true);
+    return executor;
   }
 
   private static final Lazy<ScheduledExecutorService> ALARM_EXECUTOR =

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/StreamIdleTimerTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/StreamIdleTimerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.internal.wire;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.google.api.core.SettableApiFuture;
+import com.google.cloud.pubsublite.internal.AlarmFactory;
+import com.google.common.testing.FakeTicker;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+
+@RunWith(JUnit4.class)
+public class StreamIdleTimerTest {
+  private static final Duration TIMEOUT = Duration.ofSeconds(60);
+
+  @Mock private AlarmFactory mockAlarmFactory;
+
+  private final SettableApiFuture<Void> taskFuture = SettableApiFuture.create();
+  private final FakeTicker fakeTicker = new FakeTicker();
+  private final CountDownLatch handlerCalled = new CountDownLatch(1);
+  private StreamIdleTimer timer;
+  private Runnable leakedPoller;
+
+  @Before
+  public void setUp() {
+    initMocks(this);
+    when(mockAlarmFactory.newAlarm(any()))
+        .thenAnswer(
+            args -> {
+              leakedPoller = args.getArgument(0);
+              return taskFuture;
+            });
+    timer = new StreamIdleTimer(TIMEOUT, handlerCalled::countDown, fakeTicker, mockAlarmFactory);
+    verify(mockAlarmFactory).newAlarm(any());
+    assertThat(leakedPoller).isNotNull();
+  }
+
+  @After
+  public void shutdown() {
+    verifyNoMoreInteractions(mockAlarmFactory);
+  }
+
+  @Test
+  public void delayComputedCorrectly() {
+    assertThat(StreamIdleTimer.getDelay(Duration.ofSeconds(60))).isEqualTo(Duration.ofSeconds(15));
+    assertThat(StreamIdleTimer.getDelay(Duration.ofMinutes(5))).isEqualTo(Duration.ofMinutes(1));
+  }
+
+  @Test
+  public void timeoutHandlerCalledCorrectly() throws Exception {
+    // Timeout has not expired.
+    fakeTicker.advance(TIMEOUT.minusSeconds(1));
+    leakedPoller.run();
+    assertThat(handlerCalled.await(10, MILLISECONDS)).isFalse();
+
+    // Timeout now expired.
+    fakeTicker.advance(Duration.ofSeconds(2));
+    leakedPoller.run();
+    assertThat(handlerCalled.await(30, SECONDS)).isTrue();
+  }
+
+  @Test
+  public void restartResetsTimer() throws Exception {
+    // Timer restarted just before it expires.
+    fakeTicker.advance(TIMEOUT.minusSeconds(1));
+    timer.restart();
+
+    fakeTicker.advance(Duration.ofSeconds(2));
+    leakedPoller.run();
+    assertThat(handlerCalled.await(10, MILLISECONDS)).isFalse();
+
+    // Timeout now expired.
+    fakeTicker.advance(TIMEOUT);
+    leakedPoller.run();
+    assertThat(handlerCalled.await(30, SECONDS)).isTrue();
+  }
+
+  @Test
+  public void closeCancelsTask() throws Exception {
+    fakeTicker.advance(TIMEOUT.minusSeconds(1));
+    leakedPoller.run();
+
+    timer.close();
+
+    assertThat(taskFuture.isCancelled()).isTrue();
+    assertThat(handlerCalled.await(10, MILLISECONDS)).isFalse();
+  }
+}


### PR DESCRIPTION
Mitigates hanging streams by detecting idle streams and reconnecting after a timeout (default 10min for partition assignment streams, 2min for all others).

The StreamIdleTimer is restarted when the client receives a response on the stream. The stream is reinitialized when the timeout expires. For publish and commit streams, the timeout will still expire even if there is no user activity.

Internal: cl/422650400 and subsequent fixes.