### PR TITLE
fix: Committer stuck in retry loop on shutdown

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/SubscriberSettings.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/SubscriberSettings.java
@@ -315,7 +315,6 @@ public abstract class SubscriberSettings {
     }
 
     List<ApiService> services = new ArrayList<>();
-    services.add(autoCloseableAsApiService(partitionSubscriberFactory));
     for (Partition partition : partitions()) {
       try {
         services.add(partitionSubscriberFactory.newSubscriber(partition));
@@ -323,6 +322,7 @@ public abstract class SubscriberSettings {
         throw e.underlying;
       }
     }
+    services.add(autoCloseableAsApiService(partitionSubscriberFactory));
     return MultiPartitionSubscriber.of(services);
   }
 }


### PR DESCRIPTION
Close the partition subscriber factory (which contains the client stubs) last. If the Committer has a pending commit, it will try to send it before shutdown. The commit stream will repeatedly fail to reconnect with error "UNAVAILABLE: Channel shutdown invoked" and cause shutdown to hang.

Internal: b/218984062.