### PR TITLE
fix: Flush messages in serial executor before handling admin seek

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ If you are using Maven, add this to your pom.xml file:
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-pubsublite:1.4.12'
+implementation 'com.google.cloud:google-cloud-pubsublite:1.5.0'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-pubsublite" % "1.4.12"
+libraryDependencies += "com.google.cloud" % "google-cloud-pubsublite" % "1.5.0"
 ```
 
 ## Authentication

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberImpl.java
@@ -174,7 +174,10 @@ public class SubscriberImpl extends ProxyService
   public void triggerReinitialize(CheckedApiException streamError) {
     if (ResetSignal.isResetSignal(streamError)) {
       try {
+        // Flush pre-seek messages.
+        messageDeliveryExecutor.waitUntilInactive();
         if (resetHandler.handleReset()) {
+          // Wait for cursor commit.
           reset();
         }
       } catch (CheckedApiException e) {

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/SubscriberImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/SubscriberImplTest.java
@@ -310,8 +310,6 @@ public class SubscriberImplTest {
             SequencedMessage.of(Message.builder().build(), Timestamps.EPOCH, Offset.of(1), 10));
     CountDownLatch messagesReceived = countdownMessageBatches(1);
     leakedResponseObserver.onResponse(messages);
-    assertThat(messagesReceived.await(10, SECONDS)).isTrue();
-    verify(mockMessageConsumer).accept(messages);
 
     doAnswer(
             args -> {
@@ -325,6 +323,8 @@ public class SubscriberImplTest {
     // from the committed cursor upon reconnect.
     when(mockResetHandler.handleReset()).thenReturn(true);
     subscriber.triggerReinitialize(TestResetSignal.newCheckedException());
+    assertThat(messagesReceived.await(10, SECONDS)).isTrue();
+    verify(mockMessageConsumer).accept(messages); // Pre-seek messages always received.
     verify(mockSubscriberFactory, times(2)).New(any(), any(), eq(initialRequest()));
     verify(mockConnectedSubscriber2)
         .allowFlow(


### PR DESCRIPTION
Messages queued in the serial executor should not be delivered post-seek.
