### PR TITLE
feat: add explicit duplicate subscriber handling to SubscriberImpl for beam

### DIFF
--- a/google-cloud-pubsublite/clirr-ignored-differences.xml
+++ b/google-cloud-pubsublite/clirr-ignored-differences.xml
@@ -6,4 +6,9 @@
     <className>com/google/cloud/pubsublite/internal/**</className>
     <method>*</method>
   </difference>
+  <difference>
+    <differenceType>7013</differenceType>
+    <className>com/google/cloud/pubsublite/internal/**</className>
+    <method>*</method>
+  </difference>
 </differences>

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/RetryingConnectionImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/RetryingConnectionImpl.java
@@ -118,7 +118,7 @@ class RetryingConnectionImpl<
         currentConnection.close();
       }
     } catch (Throwable t) {
-      logger.atWarning().withCause(t).log(
+      logger.atInfo().withCause(t).log(
           "Failed while terminating connection for %s", streamDescription());
       notifyFailed(t);
       return;
@@ -215,7 +215,7 @@ class RetryingConnectionImpl<
               try {
                 observer.triggerReinitialize(streamError);
               } catch (Throwable t) {
-                logger.atWarning().withCause(t).log("Error occurred in triggerReinitialize.");
+                logger.atInfo().withCause(t).log("Error occurred in triggerReinitialize.");
                 onError(t);
               }
             });

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberBuilder.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SubscriberBuilder.java
@@ -43,9 +43,13 @@ public abstract class SubscriberBuilder {
   // Optional parameters.
   abstract SubscriberResetHandler resetHandler();
 
+  // Whether to retry races when streams are created by other clients.
+  abstract boolean retryStreamRaces();
+
   public static Builder newBuilder() {
     return new AutoValue_SubscriberBuilder.Builder()
-        .setResetHandler(SubscriberResetHandler::unhandled);
+        .setResetHandler(SubscriberResetHandler::unhandled)
+        .setRetryStreamRaces(true);
   }
 
   @AutoValue.Builder
@@ -64,6 +68,9 @@ public abstract class SubscriberBuilder {
     // Optional parameters.
     public abstract Builder setResetHandler(SubscriberResetHandler resetHandler);
 
+    // Whether to re
+    public abstract Builder setRetryStreamRaces(boolean retryStreamRaces);
+
     abstract SubscriberBuilder autoBuild();
 
     @SuppressWarnings("CheckReturnValue")
@@ -80,7 +87,8 @@ public abstract class SubscriberBuilder {
           initialSubscribeRequest,
           autoBuilt.initialLocation(),
           autoBuilt.messageConsumer(),
-          autoBuilt.resetHandler());
+          autoBuilt.resetHandler(),
+          autoBuilt.retryStreamRaces());
     }
   }
 }


### PR DESCRIPTION
Beam needs a way to know that a <subscription, partition> has been relocated to another worker, and provides no in-model way to do this. We can reuse the duplicate connection error to detect occurences of this and respect them.
