### PR TITLE
fix: declaring test-scope artifact as runtime

### DIFF
--- a/google-cloud-pubsublite/pom.xml
+++ b/google-cloud-pubsublite/pom.xml
@@ -92,6 +92,12 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <!--
+       Within this repository this dependency is only used in tests. However,
+       making this test scope causes undeclared dependencies after the
+       flatten-maven-plugin.
+       https://github.com/mojohaus/flatten-maven-plugin/issues/185
+      -->
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/google-cloud-pubsublite/pom.xml
+++ b/google-cloud-pubsublite/pom.xml
@@ -90,6 +90,11 @@
       <artifactId>gax-grpc</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
     </dependency>
@@ -127,11 +132,6 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <version>2.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Declaring certain test-scope dependencies that are actually runtime dependencies.

Similar to https://github.com/googleapis/java-pubsub/issues/1239