### PR TITLE
feat: Create subscriptions at a seek target

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ If you are using Maven, add this to your pom.xml file:
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-pubsublite:1.7.0'
+implementation 'com.google.cloud:google-cloud-pubsublite:1.7.1'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-pubsublite" % "1.7.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-pubsublite" % "1.7.1"
 ```
 
 ## Authentication

--- a/google-cloud-pubsublite/clirr-ignored-differences.xml
+++ b/google-cloud-pubsublite/clirr-ignored-differences.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
 <differences>
+  <!-- Added method to AdminClient interface (Always okay) -->
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/pubsublite/AdminClient</className>
+    <method>*</method>
+  </difference>
   <difference>
     <differenceType>7004</differenceType>
     <className>com/google/cloud/pubsublite/internal/**</className>

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/AdminClient.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/AdminClient.java
@@ -129,6 +129,20 @@ public interface AdminClient extends ApiBackgroundResource {
       Subscription subscription, BacklogLocation startingOffset);
 
   /**
+   * Create the provided subscription at the given target location within the message backlog, if it
+   * does not yet exist.
+   *
+   * <p>A seek is initiated if the target location is a publish or event time. If the seek fails,
+   * the created subscription is not deleted.
+   *
+   * @param subscription The subscription to create.
+   * @param target The target location that the subscription should be initialized to.
+   * @return A future that will have either an error {@link com.google.api.gax.rpc.ApiException} or
+   *     the subscription on success.
+   */
+  ApiFuture<Subscription> createSubscription(Subscription subscription, SeekTarget target);
+
+  /**
    * Get the subscription with id {@code id} if it exists.
    *
    * @param path The path of the subscription to retrieve.

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/testing/UnitTestExamples.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/testing/UnitTestExamples.java
@@ -28,6 +28,9 @@ import com.google.cloud.pubsublite.SubscriptionName;
 import com.google.cloud.pubsublite.SubscriptionPath;
 import com.google.cloud.pubsublite.TopicName;
 import com.google.cloud.pubsublite.TopicPath;
+import com.google.cloud.pubsublite.proto.ExportConfig;
+import com.google.cloud.pubsublite.proto.ExportConfig.PubSubConfig;
+import com.google.cloud.pubsublite.proto.ExportConfig.State;
 import com.google.cloud.pubsublite.proto.Reservation;
 import com.google.cloud.pubsublite.proto.Subscription;
 import com.google.cloud.pubsublite.proto.Subscription.DeliveryConfig;
@@ -58,6 +61,7 @@ public final class UnitTestExamples {
           .put(Reservation.class, exampleReservation())
           .put(LocationPath.class, exampleLocationPath())
           .put(Offset.class, exampleOffset())
+          .put(ExportConfig.class, exampleExportConfig())
           .build();
 
   public static <T> T example(Class<T> klass) {
@@ -121,6 +125,13 @@ public final class UnitTestExamples {
                 .setDeliveryRequirement(DeliveryConfig.DeliveryRequirement.DELIVER_AFTER_STORED))
         .setName(exampleSubscriptionPath().toString())
         .setTopic(exampleTopicPath().toString())
+        .build();
+  }
+
+  public static ExportConfig exampleExportConfig() {
+    return ExportConfig.newBuilder()
+        .setDesiredState(State.ACTIVE)
+        .setPubsubConfig(PubSubConfig.newBuilder().setTopic("pubsub_topic"))
         .build();
   }
 


### PR DESCRIPTION
Support creating subscriptions at a nominated target location within the message backlog. A seek is performed for publish and event timestamps.

Export subscriptions (pre-release feature) are also supported.