### PR TITLE
feat: Publish idempotence

### DIFF
--- a/google-cloud-pubsublite/clirr-ignored-differences.xml
+++ b/google-cloud-pubsublite/clirr-ignored-differences.xml
@@ -8,9 +8,25 @@
     <method>*</method>
   </difference>
   <difference>
+    <differenceType>7013</differenceType>
+    <className>com/google/cloud/pubsublite/cloudpubsub/PublisherSettings$Builder</className>
+    <method>*</method>
+  </difference>
+  <difference>
+    <differenceType>4001</differenceType>
+    <className>com/google/cloud/pubsublite/internal/**</className>
+    <to>**</to>
+  </difference>
+  <difference>
     <differenceType>7004</differenceType>
     <className>com/google/cloud/pubsublite/internal/**</className>
     <method>*</method>
+  </difference>
+  <difference>
+    <differenceType>7005</differenceType>
+    <className>com/google/cloud/pubsublite/internal/**</className>
+    <method>*</method>
+    <to>**</to>
   </difference>
   <difference>
     <differenceType>7013</differenceType>

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/MessageMetadata.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/MessageMetadata.java
@@ -33,7 +33,15 @@ public abstract class MessageMetadata {
   /** The partition a message was published to. */
   public abstract Partition partition();
 
-  /** The offset a message was assigned. */
+  /**
+   * The offset a message was assigned.
+   *
+   * <p>If this MessageMetadata was returned for a publish result and publish idempotence was
+   * enabled, the offset may be -1 when the message was identified as a duplicate of an already
+   * successfully published message, but the server did not have sufficient information to return
+   * the message's offset at publish time. Messages received by subscribers will always have the
+   * correct offset.
+   */
   public abstract Offset offset();
 
   /** Construct a MessageMetadata from a Partition and Offset. */

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/PublishSequenceNumber.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/PublishSequenceNumber.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.internal;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+
+/** A sequence number for a published message, for implementing publish idempotency. */
+@AutoValue
+public abstract class PublishSequenceNumber implements Serializable {
+
+  /** Create a publish sequence number from its long value. */
+  public static PublishSequenceNumber of(long sequenceNumber) {
+    return new AutoValue_PublishSequenceNumber(sequenceNumber);
+  }
+
+  /** The sequence number that should be set for the first message in a publisher session. */
+  public static final PublishSequenceNumber FIRST = PublishSequenceNumber.of(0);
+
+  /** Returns the next sequence number that follows the current. */
+  public PublishSequenceNumber next() {
+    return PublishSequenceNumber.of(value() + 1);
+  }
+
+  /** The long value of this publish sequence number. */
+  public abstract long value();
+}

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/SequencedPublisher.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/SequencedPublisher.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.internal;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiService;
+import com.google.cloud.pubsublite.Message;
+import java.io.Flushable;
+
+/**
+ * A PubSub Lite publisher that requires a sequence number assigned to every message, for publish
+ * idempotency. Errors are handled out of band. Thread safe.
+ */
+public interface SequencedPublisher<ResponseT> extends ApiService, Flushable {
+  /**
+   * Publish a new message with an assigned sequence number.
+   *
+   * <p>Behavior is undefined if a call to flush() is outstanding or close() has already been
+   * called. This method never blocks.
+   *
+   * <p>Guarantees that if a single publish future has an exception set, all publish calls made
+   * after that will also have an exception set.
+   */
+  ApiFuture<ResponseT> publish(Message message, PublishSequenceNumber sequenceNumber);
+
+  /** Attempts to cancel all outstanding publishes. */
+  void cancelOutstandingPublishes();
+}

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/AssignerSettings.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/AssignerSettings.java
@@ -21,8 +21,6 @@ import com.google.cloud.pubsublite.SubscriptionPath;
 import com.google.cloud.pubsublite.proto.InitialPartitionAssignmentRequest;
 import com.google.cloud.pubsublite.v1.PartitionAssignmentServiceClient;
 import com.google.common.flogger.GoogleLogger;
-import com.google.protobuf.ByteString;
-import java.nio.ByteBuffer;
 import java.util.UUID;
 
 @AutoValue
@@ -39,7 +37,7 @@ public abstract class AssignerSettings {
   abstract UUID uuid();
 
   public static Builder newBuilder() {
-    return new AutoValue_AssignerSettings.Builder().setUuid(UUID.randomUUID());
+    return new AutoValue_AssignerSettings.Builder().setUuid(UuidBuilder.generate());
   }
 
   @AutoValue.Builder
@@ -58,16 +56,13 @@ public abstract class AssignerSettings {
   }
 
   public Assigner instantiate() {
-    ByteBuffer uuidBuffer = ByteBuffer.allocate(16);
-    uuidBuffer.putLong(uuid().getMostSignificantBits());
-    uuidBuffer.putLong(uuid().getLeastSignificantBits());
     logger.atInfo().log(
         "Subscription %s using UUID %s for assignment.", subscriptionPath(), uuid());
 
     InitialPartitionAssignmentRequest initial =
         InitialPartitionAssignmentRequest.newBuilder()
             .setSubscription(subscriptionPath().toString())
-            .setClientId(ByteString.copyFrom(uuidBuffer.array()))
+            .setClientId(UuidBuilder.toByteString(uuid()))
             .build();
     return new AssignerImpl(serviceClient(), initial, receiver());
   }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/BatchPublisher.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/BatchPublisher.java
@@ -16,10 +16,14 @@
 
 package com.google.cloud.pubsublite.internal.wire;
 
+import com.google.cloud.pubsublite.internal.PublishSequenceNumber;
 import com.google.cloud.pubsublite.proto.PubSubMessage;
 import java.util.Collection;
 
 interface BatchPublisher extends AutoCloseable {
-  /** Publish the batch of messages. Failures are communicated out of band. */
-  void publish(Collection<PubSubMessage> messages);
+  /**
+   * Publish the batch of messages, with the given sequence number of the first message in the
+   * batch. Failures are communicated out of band.
+   */
+  void publish(Collection<PubSubMessage> messages, PublishSequenceNumber firstSequenceNumber);
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/BatchPublisherFactory.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/BatchPublisherFactory.java
@@ -16,9 +16,10 @@
 
 package com.google.cloud.pubsublite.internal.wire;
 
-import com.google.cloud.pubsublite.Offset;
+import com.google.cloud.pubsublite.proto.MessagePublishResponse;
 import com.google.cloud.pubsublite.proto.PublishRequest;
 import com.google.cloud.pubsublite.proto.PublishResponse;
 
 interface BatchPublisherFactory
-    extends SingleConnectionFactory<PublishRequest, PublishResponse, Offset, BatchPublisher> {}
+    extends SingleConnectionFactory<
+        PublishRequest, PublishResponse, MessagePublishResponse, BatchPublisher> {}

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SequenceAssigningPublisher.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SequenceAssigningPublisher.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.internal.wire;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.pubsublite.Message;
+import com.google.cloud.pubsublite.Offset;
+import com.google.cloud.pubsublite.internal.ProxyService;
+import com.google.cloud.pubsublite.internal.PublishSequenceNumber;
+import com.google.cloud.pubsublite.internal.Publisher;
+import com.google.cloud.pubsublite.internal.SequencedPublisher;
+import java.io.IOException;
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * A publisher that assigns sequence numbers to messages and delegates to an underlying
+ * SequencedPublisher.
+ */
+public class SequenceAssigningPublisher extends ProxyService implements Publisher<Offset> {
+  private final SequencedPublisher<Offset> publisher;
+
+  @GuardedBy("this")
+  private PublishSequenceNumber nextSequence = PublishSequenceNumber.FIRST;
+
+  SequenceAssigningPublisher(SequencedPublisher<Offset> publisher) throws ApiException {
+    super(publisher);
+    this.publisher = publisher;
+  }
+
+  // Publisher implementation.
+  @Override
+  public synchronized ApiFuture<Offset> publish(Message message) {
+    ApiFuture<Offset> future = publisher.publish(message, nextSequence);
+    nextSequence = nextSequence.next();
+    return future;
+  }
+
+  @Override
+  public void cancelOutstandingPublishes() {
+    publisher.cancelOutstandingPublishes();
+  }
+
+  @Override
+  public void flush() throws IOException {
+    publisher.flush();
+  }
+}

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SinglePartitionPublisherBuilder.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/SinglePartitionPublisherBuilder.java
@@ -25,6 +25,8 @@ import com.google.cloud.pubsublite.TopicPath;
 import com.google.cloud.pubsublite.internal.Publisher;
 import com.google.cloud.pubsublite.internal.wire.StreamFactories.PublishStreamFactory;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.ByteString;
+import java.util.Optional;
 
 @AutoValue
 public abstract class SinglePartitionPublisherBuilder {
@@ -36,6 +38,9 @@ public abstract class SinglePartitionPublisherBuilder {
   abstract PublishStreamFactory streamFactory();
 
   abstract BatchingSettings batchingSettings();
+
+  // Optional parameters.
+  abstract Optional<ByteString> clientId();
 
   // For testing.
   abstract PublisherBuilder.Builder underlyingBuilder();
@@ -57,6 +62,9 @@ public abstract class SinglePartitionPublisherBuilder {
 
     public abstract Builder setBatchingSettings(BatchingSettings batchingSettings);
 
+    // Optional parameters.
+    public abstract Builder setClientId(ByteString clientId);
+
     // For testing.
     @VisibleForTesting
     abstract Builder setUnderlyingBuilder(PublisherBuilder.Builder underlyingBuilder);
@@ -72,6 +80,9 @@ public abstract class SinglePartitionPublisherBuilder {
               .setPartition(builder.partition())
               .setStreamFactory(builder.streamFactory())
               .setBatching(builder.batchingSettings());
+      if (builder.clientId().isPresent()) {
+        publisherBuilder.setClientId(builder.clientId().get());
+      }
       return new SinglePartitionPublisher(publisherBuilder.build(), builder.partition());
     }
   }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/UuidBuilder.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/UuidBuilder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.internal.wire;
+
+import com.google.protobuf.ByteString;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+/** Utilities for generating and converting 128-bit UUIDs. */
+public final class UuidBuilder {
+
+  /** Generates a random UUID. */
+  public static UUID generate() {
+    return UUID.randomUUID();
+  }
+
+  /** Converts a UUID to a ByteString. */
+  public static ByteString toByteString(UUID uuid) {
+    ByteBuffer uuidBuffer = ByteBuffer.allocate(16);
+    uuidBuffer.putLong(uuid.getMostSignificantBits());
+    uuidBuffer.putLong(uuid.getLeastSignificantBits());
+    return ByteString.copyFrom(uuidBuffer.array());
+  }
+
+  private UuidBuilder() {}
+}

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/PublisherBuilderTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/PublisherBuilderTest.java
@@ -27,7 +27,9 @@ import com.google.cloud.pubsublite.TopicName;
 import com.google.cloud.pubsublite.TopicPath;
 import com.google.cloud.pubsublite.cloudpubsub.PublisherSettings;
 import com.google.cloud.pubsublite.internal.Publisher;
+import com.google.cloud.pubsublite.internal.SequencedPublisher;
 import com.google.cloud.pubsublite.internal.wire.StreamFactories.PublishStreamFactory;
+import com.google.protobuf.ByteString;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -36,7 +38,7 @@ import org.junit.runners.JUnit4;
 public class PublisherBuilderTest {
   @Test
   public void testBuilder() {
-    Publisher<Offset> unusedPublisher =
+    PublisherBuilder.Builder builder =
         PublisherBuilder.builder()
             .setBatching(PublisherSettings.DEFAULT_BATCHING_SETTINGS)
             .setTopic(
@@ -46,7 +48,13 @@ public class PublisherBuilderTest {
                     .setName(TopicName.of("abc"))
                     .build())
             .setPartition(Partition.of(85))
-            .setStreamFactory(mock(PublishStreamFactory.class))
-            .build();
+            .setStreamFactory(mock(PublishStreamFactory.class));
+    Publisher<Offset> unusedPublisher = builder.build();
+    SequencedPublisher<Offset> unusedSequencedPublisher = builder.buildSequenced();
+
+    // Optional parameters.
+    builder.setClientId(ByteString.copyFromUtf8("publisher"));
+    unusedPublisher = builder.build();
+    unusedSequencedPublisher = builder.buildSequenced();
   }
 }

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/SequenceAssigningPublisherTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/SequenceAssigningPublisherTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.internal.wire;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.google.api.core.ApiFutures;
+import com.google.cloud.pubsublite.Message;
+import com.google.cloud.pubsublite.Offset;
+import com.google.cloud.pubsublite.internal.PublishSequenceNumber;
+import com.google.cloud.pubsublite.internal.SequencedPublisher;
+import com.google.cloud.pubsublite.internal.testing.FakeApiService;
+import com.google.protobuf.ByteString;
+import java.util.concurrent.Future;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Spy;
+
+@RunWith(JUnit4.class)
+public final class SequenceAssigningPublisherTest {
+
+  private static Message makeMessage(String data) {
+    return Message.builder().setData(ByteString.copyFromUtf8(data)).build();
+  }
+
+  abstract static class FakeSequencedPublisher extends FakeApiService
+      implements SequencedPublisher<Offset> {}
+
+  @Spy private FakeSequencedPublisher underlyingPublisher;
+
+  private SequenceAssigningPublisher publisher;
+
+  @Before
+  public void setUp() {
+    initMocks(this);
+    publisher = new SequenceAssigningPublisher(underlyingPublisher);
+  }
+
+  @Test
+  public void publishAssignsSequenceNumbers() throws Exception {
+    Message message1 = makeMessage("msg1");
+    Message message2 = makeMessage("msg2");
+    Message message3 = makeMessage("msg3");
+
+    when(underlyingPublisher.publish(eq(message1), eq(PublishSequenceNumber.of(0))))
+        .thenReturn(ApiFutures.immediateFuture(Offset.of(100)));
+    when(underlyingPublisher.publish(eq(message2), eq(PublishSequenceNumber.of(1))))
+        .thenReturn(ApiFutures.immediateFuture(Offset.of(200)));
+    when(underlyingPublisher.publish(eq(message3), eq(PublishSequenceNumber.of(2))))
+        .thenReturn(ApiFutures.immediateFuture(Offset.of(300)));
+
+    Future<Offset> future1 = publisher.publish(message1);
+    verify(underlyingPublisher).publish(eq(message1), eq(PublishSequenceNumber.of(0)));
+    Future<Offset> future2 = publisher.publish(message2);
+    verify(underlyingPublisher).publish(eq(message2), eq(PublishSequenceNumber.of(1)));
+    Future<Offset> future3 = publisher.publish(message3);
+    verify(underlyingPublisher).publish(eq(message3), eq(PublishSequenceNumber.of(2)));
+
+    assertThat(future1.isDone()).isTrue();
+    assertThat(future1.get()).isEqualTo(Offset.of(100));
+    assertThat(future2.isDone()).isTrue();
+    assertThat(future2.get()).isEqualTo(Offset.of(200));
+    assertThat(future3.isDone()).isTrue();
+    assertThat(future3.get()).isEqualTo(Offset.of(300));
+  }
+
+  @Test
+  public void cancelOutstandingPublishesDelegatesToUnderlying() throws Exception {
+    publisher.cancelOutstandingPublishes();
+    verify(underlyingPublisher).cancelOutstandingPublishes();
+  }
+
+  @Test
+  public void flushDelegatesToUnderlying() throws Exception {
+    publisher.flush();
+    verify(underlyingPublisher).flush();
+  }
+}


### PR DESCRIPTION
Implements publish idempotence (default enabled), where the server will ensure that unique messages within a single publisher session are only stored once.
