### PR TITLE
fix: Change RoutingPolicy to accept the whole message, not just the `key` field

### DIFF
--- a/google-cloud-pubsublite/clirr-ignored-differences.xml
+++ b/google-cloud-pubsublite/clirr-ignored-differences.xml
@@ -29,6 +29,18 @@
     <to>**</to>
   </difference>
   <difference>
+    <differenceType>7009</differenceType>
+    <className>com/google/cloud/pubsublite/internal/**</className>
+    <method>*</method>
+    <to>**</to>
+  </difference>
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/pubsublite/internal/**</className>
+    <method>*</method>
+    <to>**</to>
+  </difference>
+  <difference>
     <differenceType>7013</differenceType>
     <className>com/google/cloud/pubsublite/internal/**</className>
     <method>*</method>

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/RoutingPolicy.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/RoutingPolicy.java
@@ -17,15 +17,13 @@
 package com.google.cloud.pubsublite.internal;
 
 import com.google.cloud.pubsublite.Partition;
-import com.google.protobuf.ByteString;
+import com.google.cloud.pubsublite.proto.PubSubMessage;
 
 // Route the user message key to a given partition.
 public interface RoutingPolicy {
   interface Factory {
     RoutingPolicy newPolicy(long numPartitions);
   }
-  // Route a message without a key to a partition.
-  Partition routeWithoutKey() throws CheckedApiException;
-  // Route a message with a key to a partition.
-  Partition route(ByteString messageKey) throws CheckedApiException;
+  // Route a message to a partition.
+  Partition route(PubSubMessage messageKey) throws CheckedApiException;
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/PartitionCountWatchingPublisher.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/PartitionCountWatchingPublisher.java
@@ -58,10 +58,7 @@ public class PartitionCountWatchingPublisher extends ProxyService
 
     public ApiFuture<MessageMetadata> publish(PubSubMessage message) throws CheckedApiException {
       try {
-        Partition routedPartition =
-            message.getKey().isEmpty()
-                ? routingPolicy.routeWithoutKey()
-                : routingPolicy.route(message.getKey());
+        Partition routedPartition = routingPolicy.route(message);
         checkState(
             publishers.containsKey(routedPartition),
             "Routed to partition %s for which there is no publisher available.",

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/RoutingPublisher.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/RoutingPublisher.java
@@ -48,8 +48,7 @@ public class RoutingPublisher extends ProxyService implements Publisher<MessageM
   @Override
   public ApiFuture<MessageMetadata> publish(PubSubMessage message) {
     try {
-      Partition routedPartition =
-          message.getKey().isEmpty() ? policy.routeWithoutKey() : policy.route(message.getKey());
+      Partition routedPartition = policy.route(message);
       checkState(
           partitionPublishers.containsKey(routedPartition),
           "Routed to partition %s for which there is no publisher available.",

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/DefaultRoutingPolicyTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/DefaultRoutingPolicyTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.pubsublite.internal;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.cloud.pubsublite.Partition;
+import com.google.cloud.pubsublite.proto.PubSubMessage;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.protobuf.ByteString;
@@ -54,7 +55,7 @@ public class DefaultRoutingPolicyTest {
     Map<ByteString, Partition> map = loadTestCases();
     ImmutableMap.Builder<ByteString, Partition> results = ImmutableMap.builder();
     for (ByteString key : map.keySet()) {
-      results.put(key, policy.route(key));
+      results.put(key, policy.route(PubSubMessage.newBuilder().setKey(key).build()));
     }
     assertThat(results.build()).containsExactlyEntriesIn(map);
   }

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/PartitionCountWatchingPublisherTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/PartitionCountWatchingPublisherTest.java
@@ -111,8 +111,8 @@ public class PartitionCountWatchingPublisherTest {
         PubSubMessage.newBuilder().setKey(ByteString.copyFromUtf8("0")).build();
     PubSubMessage message1 =
         PubSubMessage.newBuilder().setKey(ByteString.copyFromUtf8("1")).build();
-    when(mockRoutingPolicy.route(message0.getKey())).thenReturn(Partition.of(0));
-    when(mockRoutingPolicy.route(message1.getKey())).thenReturn(Partition.of(1));
+    when(mockRoutingPolicy.route(message0)).thenReturn(Partition.of(0));
+    when(mockRoutingPolicy.route(message1)).thenReturn(Partition.of(1));
 
     Future<?> unusedFuture0 = publisher.publish(message0);
     Future<?> unusedFuture1 = publisher.publish(message1);
@@ -128,9 +128,8 @@ public class PartitionCountWatchingPublisherTest {
     PubSubMessage messageB =
         PubSubMessage.newBuilder().setData(ByteString.copyFromUtf8("b")).build();
 
-    when(mockRoutingPolicy.routeWithoutKey())
-        .thenReturn(Partition.of(0))
-        .thenReturn(Partition.of(1));
+    when(mockRoutingPolicy.route(messageA)).thenReturn(Partition.of(0));
+    when(mockRoutingPolicy.route(messageB)).thenReturn(Partition.of(1));
 
     Future<?> unusedFutureA = publisher.publish(messageA);
     Future<?> unusedFutureB = publisher.publish(messageB);
@@ -143,7 +142,7 @@ public class PartitionCountWatchingPublisherTest {
   public void testPublishWithBadRouting() throws Exception {
     PubSubMessage message = PubSubMessage.newBuilder().build();
 
-    when(mockRoutingPolicy.routeWithoutKey()).thenReturn(Partition.of(4));
+    when(mockRoutingPolicy.route(message)).thenReturn(Partition.of(4));
     Future<?> unusedFuture = publisher.publish(message);
 
     ApiExceptionMatcher.assertThrowableMatches(
@@ -191,9 +190,9 @@ public class PartitionCountWatchingPublisherTest {
         PubSubMessage.newBuilder().setKey(ByteString.copyFromUtf8("1")).build();
     PubSubMessage message2 =
         PubSubMessage.newBuilder().setKey(ByteString.copyFromUtf8("2")).build();
-    when(mockRoutingPolicy.route(message0.getKey())).thenReturn(Partition.of(0));
-    when(mockRoutingPolicy.route(message1.getKey())).thenReturn(Partition.of(1));
-    when(mockRoutingPolicy.route(message2.getKey())).thenReturn(Partition.of(2));
+    when(mockRoutingPolicy.route(message0)).thenReturn(Partition.of(0));
+    when(mockRoutingPolicy.route(message1)).thenReturn(Partition.of(1));
+    when(mockRoutingPolicy.route(message2)).thenReturn(Partition.of(2));
 
     Future<?> unusedFuture0 = publisher.publish(message0);
     Future<?> unusedFuture1 = publisher.publish(message1);
@@ -212,8 +211,8 @@ public class PartitionCountWatchingPublisherTest {
         PubSubMessage.newBuilder().setKey(ByteString.copyFromUtf8("0")).build();
     PubSubMessage message1 =
         PubSubMessage.newBuilder().setKey(ByteString.copyFromUtf8("1")).build();
-    when(mockRoutingPolicy.route(message0.getKey())).thenReturn(Partition.of(0));
-    when(mockRoutingPolicy.route(message1.getKey())).thenReturn(Partition.of(1));
+    when(mockRoutingPolicy.route(message0)).thenReturn(Partition.of(0));
+    when(mockRoutingPolicy.route(message1)).thenReturn(Partition.of(1));
 
     Future<?> unusedFuture0 = publisher.publish(message0);
     Future<?> unusedFuture1 = publisher.publish(message1);
@@ -231,8 +230,8 @@ public class PartitionCountWatchingPublisherTest {
         PubSubMessage.newBuilder().setKey(ByteString.copyFromUtf8("0")).build();
     PubSubMessage message1 =
         PubSubMessage.newBuilder().setKey(ByteString.copyFromUtf8("1")).build();
-    when(mockRoutingPolicy.route(message0.getKey())).thenReturn(Partition.of(0));
-    when(mockRoutingPolicy.route(message1.getKey())).thenReturn(Partition.of(1));
+    when(mockRoutingPolicy.route(message0)).thenReturn(Partition.of(0));
+    when(mockRoutingPolicy.route(message1)).thenReturn(Partition.of(1));
 
     Future<?> unusedFuture0 = publisher.publish(message0);
     Future<?> unusedFuture1 = publisher.publish(message1);

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/RoutingPublisherTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/RoutingPublisherTest.java
@@ -84,7 +84,7 @@ public class RoutingPublisherTest {
   public void publishValidRoute() throws Exception {
     PubSubMessage message =
         PubSubMessage.newBuilder().setKey(ByteString.copyFromUtf8("abc")).build();
-    when(routingPolicy.route(message.getKey())).thenReturn(Partition.of(1));
+    when(routingPolicy.route(message)).thenReturn(Partition.of(1));
     MessageMetadata meta = MessageMetadata.of(Partition.of(1), Offset.of(3));
     when(publisher1.publish(message)).thenReturn(ApiFutures.immediateFuture(meta));
     ApiFuture<MessageMetadata> fut = routing.publish(message);
@@ -97,7 +97,7 @@ public class RoutingPublisherTest {
   public void publishInvalidRoute() throws Exception {
     PubSubMessage message =
         PubSubMessage.newBuilder().setKey(ByteString.copyFromUtf8("abc")).build();
-    when(routingPolicy.route(message.getKey())).thenReturn(Partition.of(77));
+    when(routingPolicy.route(message)).thenReturn(Partition.of(77));
     ApiFuture<MessageMetadata> fut = routing.publish(message);
     ApiExceptionMatcher.assertFutureThrowsCode(fut, Code.FAILED_PRECONDITION);
   }


### PR DESCRIPTION
This is intended for use in the kafka connector, to send messages to the same pubsublite partition as they were published to in kafka