### PR TITLE
deps: update dependency com.google.cloud:google-cloud-pubsub to v1.13.17. with temp fix.

### DIFF
--- a/google-cloud-pubsublite/pom.xml
+++ b/google-cloud-pubsublite/pom.xml
@@ -18,6 +18,14 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
+      <!--   Temp exclusion. Remove next protobuf upgrade (to 3.23.3 or higher)
+   context: https://github.com/googleapis/sdk-platform-java/pull/1791#issuecomment-1601587713-->
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.j2objc</groupId>
+          <artifactId>j2objc-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
@@ -38,6 +46,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
+      <version>1.123.17</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>


### PR DESCRIPTION
This intends to fix issue in https://github.com/googleapis/java-cloud-bom/pull/6050#issuecomment-1610404487
dependency tree for `j2objc-annotations` without this fix:
```
[INFO] --------------< com.google.cloud:google-cloud-pubsublite >--------------
[INFO] Building Google Cloud Pub/Sub Lite 1.12.10-SNAPSHOT                [4/5]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.5.0:tree (default-cli) @ google-cloud-pubsublite ---
[INFO] com.google.cloud:google-cloud-pubsublite:jar:1.12.10-SNAPSHOT
[INFO] \- com.google.cloud:google-cloud-pubsub:jar:1.123.14:compile
[INFO]    \- com.google.j2objc:j2objc-annotations:jar:1.3:compile

```
- With out declaring version for `google-cloud-pubsub` here, it's getting `1.123.14` (new `shared-dependencies` included in [v1.123.15](https://github.com/googleapis/java-pubsub/releases/tag/v1.123.15)).  I think this should be updated as part of #1444. (pubsub is a blocker for pubsublit release) Is this sufficient to be picked up by bot in future upgrades?
- Then the temp fix is needed because `j2objc-annotations:jar:1.3` in protobuf 3.23.2 and we could not upgrade to 3.23.3 due to missing protoc prebuilds in maven central (https://github.com/protocolbuffers/protobuf/issues/13070). Similar fix implemented in https://github.com/googleapis/java-spanner/pull/2512 and will be removed on next protobuf upgrade. (will add this to internal bug as reminder when we decide to merge this in.)

After this fix: 
```
[INFO] --------------< com.google.cloud:google-cloud-pubsublite >--------------
[INFO] Building Google Cloud Pub/Sub Lite 1.12.10-SNAPSHOT                [4/5]
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from central: https://repo.maven.apache.org/maven2/com/google/cloud/google-cloud-pubsub/1.123.17/google-cloud-pubsub-1.123.17.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/google/cloud/google-cloud-pubsub/1.123.17/google-cloud-pubsub-1.123.17.pom (36 kB at 102 kB/s)
[INFO] 
[INFO] --- maven-dependency-plugin:3.5.0:tree (default-cli) @ google-cloud-pubsublite ---
[INFO] com.google.cloud:google-cloud-pubsublite:jar:1.12.10-SNAPSHOT
[INFO] \- com.google.cloud:google-cloud-pubsub:jar:1.123.17:compile
[INFO]    \- com.google.j2objc:j2objc-annotations:jar:2.8:compile
[INFO] 

```