### PR TITLE
fix: Change SingleConnection to batch before initial response instead of blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ If you are using Maven, add this to your pom.xml file:
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-pubsublite:1.12.10'
+implementation 'com.google.cloud:google-cloud-pubsublite:1.12.11'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-pubsublite" % "1.12.10"
+libraryDependencies += "com.google.cloud" % "google-cloud-pubsublite" % "1.12.11"
 ```
 <!-- {x-version-update-end} -->
 
@@ -483,7 +483,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-pubsublite/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-pubsublite.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-pubsublite/1.12.10
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-pubsublite/1.12.11
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/BatchPublisherImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/BatchPublisherImpl.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.pubsublite.internal.wire;
 
-
 import com.google.api.gax.rpc.ResponseObserver;
 import com.google.cloud.pubsublite.internal.PublishSequenceNumber;
 import com.google.cloud.pubsublite.internal.wire.StreamFactories.PublishStreamFactory;

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/BatchPublisherImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/BatchPublisherImpl.java
@@ -16,10 +16,8 @@
 
 package com.google.cloud.pubsublite.internal.wire;
 
-import static com.google.cloud.pubsublite.internal.CheckedApiPreconditions.checkState;
 
 import com.google.api.gax.rpc.ResponseObserver;
-import com.google.cloud.pubsublite.internal.CheckedApiException;
 import com.google.cloud.pubsublite.internal.PublishSequenceNumber;
 import com.google.cloud.pubsublite.internal.wire.StreamFactories.PublishStreamFactory;
 import com.google.cloud.pubsublite.proto.MessagePublishRequest;

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/BatchPublisherImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/BatchPublisherImpl.java
@@ -69,18 +69,10 @@ class BatchPublisherImpl
   }
 
   @Override
-  protected void handleInitialResponse(PublishResponse response) throws CheckedApiException {
-    checkState(
-        response.hasInitialResponse(),
-        "First stream response is not an initial response: " + response);
-  }
-
-  @Override
-  protected void handleStreamResponse(PublishResponse response) throws CheckedApiException {
-    checkState(!response.hasInitialResponse(), "Received duplicate initial response.");
-    checkState(
-        response.hasMessageResponse(),
-        "Received response on stream which was neither a message or initial response.");
+  protected void handleStreamResponse(PublishResponse response) {
+    if (!response.hasMessageResponse()) {
+      return;
+    }
     sendToClient(response.getMessageResponse());
   }
 }

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ConnectedAssignerImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ConnectedAssignerImpl.java
@@ -41,7 +41,7 @@ public class ConnectedAssignerImpl
       StreamFactory<PartitionAssignmentRequest, PartitionAssignment> streamFactory,
       ResponseObserver<PartitionAssignment> clientStream,
       PartitionAssignmentRequest initialRequest) {
-    super(streamFactory, clientStream, STREAM_IDLE_TIMEOUT, /*expectInitialResponse=*/ false);
+    super(streamFactory, clientStream, STREAM_IDLE_TIMEOUT);
     initialize(initialRequest);
   }
 
@@ -56,13 +56,6 @@ public class ConnectedAssignerImpl
   }
 
   // SingleConnection implementation.
-  @Override
-  protected void handleInitialResponse(PartitionAssignment response) throws CheckedApiException {
-    // The assignment stream is server-initiated by sending a PartitionAssignment. The
-    // initial response from the server is handled identically to other responses.
-    handleStreamResponse(response);
-  }
-
   @Override
   protected void handleStreamResponse(PartitionAssignment response) throws CheckedApiException {
     try (CloseableMonitor.Hold h = monitor.enter()) {

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ConnectedCommitterImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ConnectedCommitterImpl.java
@@ -41,7 +41,7 @@ public class ConnectedCommitterImpl
       ResponseObserver<SequencedCommitCursorResponse> clientStream,
       StreamingCommitCursorRequest initialRequest,
       Duration streamIdleTimeout) {
-    super(streamFactory, clientStream, streamIdleTimeout, /*expectInitialResponse=*/ true);
+    super(streamFactory, clientStream, streamIdleTimeout);
     this.initialRequest = initialRequest;
     initialize(initialRequest);
   }
@@ -57,20 +57,12 @@ public class ConnectedCommitterImpl
     }
   }
 
-  // SingleConnection implementation.
-  @Override
-  protected void handleInitialResponse(StreamingCommitCursorResponse response)
-      throws CheckedApiException {
-    checkState(
-        response.hasInitial(),
-        String.format(
-            "Received non-initial first response %s on stream with initial request %s.",
-            response, initialRequest));
-  }
-
   @Override
   protected void handleStreamResponse(StreamingCommitCursorResponse response)
       throws CheckedApiException {
+    if (response.hasInitial()) {
+      return;
+    }
     checkState(
         response.hasCommit(),
         String.format(

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ConnectedSubscriberImpl.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ConnectedSubscriberImpl.java
@@ -65,23 +65,10 @@ class ConnectedSubscriberImpl
   }
 
   @Override
-  protected void handleInitialResponse(SubscribeResponse response) throws CheckedApiException {
-    checkState(
-        response.hasInitial(),
-        String.format(
-            "Received non-initial first response %s on stream with initial request %s.",
-            response, initialRequest));
-  }
-
-  @Override
   protected void handleStreamResponse(SubscribeResponse response) throws CheckedApiException {
     switch (response.getResponseCase()) {
       case INITIAL:
-        throw new CheckedApiException(
-            String.format(
-                "Received duplicate initial response on stream with initial request %s.",
-                initialRequest),
-            Code.FAILED_PRECONDITION);
+        return;
       case MESSAGES:
         onMessages(response.getMessages());
         return;

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/BatchPublisherImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/BatchPublisherImplTest.java
@@ -245,16 +245,6 @@ public class BatchPublisherImplTest {
   }
 
   @Test
-  public void duplicateInitial_Abort() {
-    BatchPublisher unusedPublisher = initialize(ByteString.EMPTY);
-    PublishResponse.Builder builder = PublishResponse.newBuilder();
-    builder.getInitialResponseBuilder();
-    leakedResponseStream.get().onResponse(builder.build());
-    verify(mockOutputStream).onError(argThat(new ApiExceptionMatcher(Code.FAILED_PRECONDITION)));
-    leakedResponseStream = Optional.empty();
-  }
-
-  @Test
   public void setsSequenceNumbersWhenClientIdPresent() {
     BatchPublisher publisher = initialize(CLIENT_ID);
     doAnswer(new MessageResponseAnswer(CLIENT_ID, messageResponse(Offset.of(10))))

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/BatchPublisherImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/BatchPublisherImplTest.java
@@ -203,19 +203,6 @@ public class BatchPublisherImplTest {
     }
   }
 
-  @Test
-  public void construct_SendsMessagePublishResponseError() {
-    doAnswer(new MessageResponseAnswer(ByteString.EMPTY, messageResponse(Offset.of(10))))
-        .when(mockRequestStream)
-        .send(initialRequest(ByteString.EMPTY));
-    try (BatchPublisherImpl publisher =
-        FACTORY.New(streamFactory, mockOutputStream, initialRequest(ByteString.EMPTY))) {
-      verify(mockOutputStream).onError(argThat(new ApiExceptionMatcher(Code.FAILED_PRECONDITION)));
-      verifyNoMoreInteractions(mockOutputStream);
-    }
-    leakedResponseStream = Optional.empty();
-  }
-
   private BatchPublisherImpl initialize(ByteString clientId) {
     doAnswer(
             (Answer<Void>)

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/ConnectedCommitterImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/ConnectedCommitterImplTest.java
@@ -191,16 +191,6 @@ public class ConnectedCommitterImplTest {
   }
 
   @Test
-  public void duplicateInitial_Abort() {
-    initialize();
-    StreamingCommitCursorResponse.Builder builder = StreamingCommitCursorResponse.newBuilder();
-    builder.getInitialBuilder();
-    leakedResponseStream.get().onResponse(builder.build());
-    verify(mockOutputStream).onError(argThat(new ApiExceptionMatcher(Code.FAILED_PRECONDITION)));
-    leakedResponseStream = Optional.empty();
-  }
-
-  @Test
   public void commitRequestProxied() {
     initialize();
     StreamingCommitCursorRequest.Builder builder = StreamingCommitCursorRequest.newBuilder();

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/ConnectedSubscriberImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/ConnectedSubscriberImplTest.java
@@ -216,16 +216,6 @@ public class ConnectedSubscriberImplTest {
   }
 
   @Test
-  public void duplicateInitial_Abort() {
-    initialize();
-    SubscribeResponse.Builder builder =
-        SubscribeResponse.newBuilder().setInitial(InitialSubscribeResponse.getDefaultInstance());
-    leakedResponseStream.get().onResponse(builder.build());
-    verify(mockOutputStream).onError(argThat(new ApiExceptionMatcher(Code.FAILED_PRECONDITION)));
-    leakedResponseStream = Optional.empty();
-  }
-
-  @Test
   public void emptyMessagesResponse_Abort() {
     initialize();
     SubscribeResponse.Builder builder =


### PR DESCRIPTION
This requires minimal changes and prevents thread explosion issues
