### PR TITLE
chore: use sdk-platform-java-config to consolidate build configs

### DIFF
--- a/.kokoro/presubmit/graalvm-native-17.cfg
+++ b/.kokoro/presubmit/graalvm-native-17.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.3"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.24.0"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.3"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.24.0"
 }
 
 env_vars: {

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ If you are using Maven, add this to your pom.xml file:
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-pubsublite:1.12.20'
+implementation 'com.google.cloud:google-cloud-pubsublite:1.12.21'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-pubsublite" % "1.12.20"
+libraryDependencies += "com.google.cloud" % "google-cloud-pubsublite" % "1.12.21"
 ```
 <!-- {x-version-update-end} -->
 
@@ -483,7 +483,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-pubsublite/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-pubsublite.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-pubsublite/1.12.20
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-pubsublite/1.12.21
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-pubsublite-bom/pom.xml
+++ b/google-cloud-pubsublite-bom/pom.xml
@@ -7,8 +7,8 @@
   <packaging>pom</packaging>
   <parent>
     <groupId>com.google.cloud</groupId>
-    <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.7.1</version>
+    <artifactId>sdk-platform-java-config</artifactId>
+    <version>3.24.0</version>
   </parent>
 
   <name>Google Cloud pubsublite BOM</name>

--- a/owlbot.py
+++ b/owlbot.py
@@ -26,6 +26,8 @@ java.common_templates(
         ".kokoro/*/samples.cfg",
         "samples/install-without-bom/*",
         ".github/workflows/samples.yaml",
-        ".github/CODEOWNERS"
+        ".github/CODEOWNERS",
+        ".kokoro/presubmit/graalvm-native.cfg",
+        ".kokoro/presubmit/graalvm-native-17.cfg"
     ]
 )

--- a/pom.xml
+++ b/pom.xml
@@ -2,8 +2,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>com.google.cloud</groupId>
-    <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.7.1</version>
+    <artifactId>sdk-platform-java-config</artifactId>
+    <version>3.24.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
@@ -18,7 +18,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>3.23.0</version>
+        <version>${google-cloud-shared-dependencies.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Notable Changes:
1) Use `gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform*` docker images for Kokoro GraalVM tests  instead of `gcr.io/cloud-devrel-kokoro-resources/graalvm*`.
2) Use `com.google.cloud:sdk-platform-java-config` as the parent which inherits configs from `java-shared-config` and hosts the `google-cloud-shared-dependencies` version under the `google-cloud-shared-dependencies.version` property.  This artifact is versioned to be the same as google-cloud-shared-dependencies.
3) Adjust renovate-bot settings to update docker images when a new version of `sdk-platform-java-config` is on Maven Central in https://github.com/googleapis/java-pubsublite/pull/1585

Example renovate-bot update PR in google-cloud-java: https://github.com/googleapis/google-cloud-java/pull/10290
