### PR TITLE
chore: include recommended_package in repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -14,5 +14,6 @@
   "distribution_name": "com.google.cloud:google-cloud-pubsublite",
   "codeowner_team": "@googleapis/api-pubsublite",
   "library_type": "GAPIC_COMBO",
-  "api_id": "pubsublite.googleapis.com"
+  "api_id": "pubsublite.googleapis.com",
+  "recommended_package": "com.google.cloud.pubsublite.cloudpubsub"
 }


### PR DESCRIPTION
Adds a field for recommended_package as part of the revamped Library Overviews.
See go/cloud-rad-overviews-handwritten-repos for more details