### PR TITLE
fix: restore google-cloud-pubsublite-bom package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,7 @@
     <module>google-cloud-pubsublite</module>
     <module>grpc-google-cloud-pubsublite-v1</module>
     <module>proto-google-cloud-pubsublite-v1</module>
+    <module>google-cloud-pubsublite-bom</module>
   </modules>
 
   <profiles>


### PR DESCRIPTION
The google-cloud-pubsublite-bom is used in the libraries-bom: https://github.com/googleapis/java-cloud-bom/blob/2c49bcfe0a415e8255a7c9b3cc94951177a1da92/google-cloud-bom/pom.xml#L234 and causing the following failure in the shared-dependencies convergence check:
```
Found 1 artifacts with shared dependencies version: 3.37.0
Warning: cloud-pubsublite:1.14.4[WARNING] 
java.lang.RuntimeException: Failed to converge dependencies
    at com.google.cloud.tools.opensource.cloudbomdashboard.DashboardMain.main (DashboardMain.java:114)
    at org.codehaus.mojo.exec.ExecJavaMojo$1.run (ExecJavaMojo.java:254)
    at java.lang.Thread.run (Thread.java:750)
```

This artifact seems to have been removed unintentionally in https://github.com/googleapis/java-pubsublite/pull/1748
