### PR TITLE
feat: introduce `java.time` variables and methods

### DIFF
--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/Constants.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/Constants.java
@@ -17,17 +17,17 @@
 package com.google.cloud.pubsublite;
 
 import com.google.api.gax.retrying.RetrySettings;
-import org.threeten.bp.Duration;
+import java.time.Duration;
 
 /** Useful general constants for Pub/Sub Lite. */
 public class Constants {
   public static final RetrySettings DEFAULT_RETRY_SETTINGS =
       RetrySettings.newBuilder()
-          .setInitialRetryDelay(Duration.ofMillis(100))
+          .setInitialRetryDelayDuration(Duration.ofMillis(100))
           .setRetryDelayMultiplier(1.3)
-          .setMaxRetryDelay(Duration.ofSeconds(60))
+          .setMaxRetryDelayDuration(Duration.ofSeconds(60))
           .setJittered(true)
-          .setTotalTimeout(Duration.ofMinutes(10))
+          .setTotalTimeoutDuration(Duration.ofMinutes(10))
           .build();
 
   public static final long MAX_PUBLISH_BATCH_COUNT = 1_000;

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/PublisherSettings.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/cloudpubsub/PublisherSettings.java
@@ -51,8 +51,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import io.grpc.CallOptions;
+import java.time.Duration;
 import java.util.Optional;
-import org.threeten.bp.Duration;
 
 /**
  * Settings for instantiating a Pub/Sub Lite publisher emulating the Cloud Pub/Sub Publisher API.
@@ -64,7 +64,7 @@ public abstract class PublisherSettings {
           .setIsEnabled(true)
           .setElementCountThreshold(1000L)
           .setRequestByteThreshold(Constants.MAX_PUBLISH_BATCH_BYTES)
-          .setDelayThreshold(Duration.ofMillis(50))
+          .setDelayThresholdDuration(Duration.ofMillis(50))
           .build();
 
   // Required parameters.

--- a/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ServiceClients.java
+++ b/google-cloud-pubsublite/src/main/java/com/google/cloud/pubsublite/internal/wire/ServiceClients.java
@@ -30,8 +30,8 @@ import com.google.cloud.pubsublite.Endpoints;
 import com.google.cloud.pubsublite.internal.Lazy;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimaps;
+import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
-import org.threeten.bp.Duration;
 
 public final class ServiceClients {
   private static final Lazy<ScheduledExecutorService> GRPC_EXECUTOR =
@@ -42,9 +42,9 @@ public final class ServiceClients {
   private static TransportChannelProvider getTransportChannelProvider() {
     return InstantiatingGrpcChannelProvider.newBuilder()
         .setMaxInboundMessageSize(Integer.MAX_VALUE)
-        .setKeepAliveTime(Duration.ofMinutes(1))
+        .setKeepAliveTimeDuration(Duration.ofMinutes(1))
         .setKeepAliveWithoutCalls(true)
-        .setKeepAliveTimeout(Duration.ofMinutes(1))
+        .setKeepAliveTimeoutDuration(Duration.ofMinutes(1))
         .setChannelPoolSettings(
             ChannelPoolSettings.builder()
                 .setInitialChannelCount(25)

--- a/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/PublisherImplTest.java
+++ b/google-cloud-pubsublite/src/test/java/com/google/cloud/pubsublite/internal/wire/PublisherImplTest.java
@@ -57,6 +57,7 @@ import com.google.cloud.pubsublite.proto.PublishRequest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.ByteString;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -75,7 +76,6 @@ import org.junit.runners.JUnit4;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.stubbing.Answer;
-import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class PublisherImplTest {
@@ -86,7 +86,7 @@ public class PublisherImplTest {
   private static final BatchingSettings BATCHING_SETTINGS_THAT_NEVER_FIRE =
       BatchingSettings.newBuilder()
           .setIsEnabled(true)
-          .setDelayThreshold(Duration.ofDays(10))
+          .setDelayThresholdDuration(Duration.ofDays(10))
           .setRequestByteThreshold(1000000L)
           .setElementCountThreshold(1000000L)
           .build();


### PR DESCRIPTION
This PR introduces `java.time` alternatives to existing `org.threeten.bp.*` methods, as well as switching internal variables (if any) to `java.time`

The main constraint is to keep the changes backwards compatible, so for each existing threeten method "`method1(org.threeten.bp.Duration)`" we will add an alternative with a _Duration_ (or _Timestamp_ when applicable) suffix: "`method1Duration(java.time.Duration)`".

For most cases, the implementation will be held in the `java.time` method and the old threeten method will just delegate the call to it. However, for the case of abstract classes, the implementation will be kept in the threeten method to avoid breaking changes (i.e. users that already overloaded the method in their user code).