### PR TITLE
chore: disable errorprone for JDK 24 onwards

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,8 @@
         <artifactId>error_prone_core</artifactId>
         <!-- 2.32.0 and 2.33.0 break our java 11 build with compiler errors, I reported this to the
         errorprone team, but try upgrading to new versions in the future-->
+        <!-- This version is only compatible with JDKs < 24. We have a profile below that disables
+        errorprone for JDKs >= 24. -->
         <version>2.31.0</version>
       </dependency>
       <dependency>
@@ -172,8 +174,8 @@
             <configuration>
               <fork>true</fork>
               <compilerArgs combine.children="append">
+                <!-- we only use the basic compilation flags without activating errorprone -->
                 <arg>-XDcompilePolicy=simple</arg>
-                <arg>-Xplugin:ErrorProne -XepDisableAllChecks</arg>
               </compilerArgs>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,27 @@
 
   <profiles>
     <profile>
+      <!-- the current errorprone version does not support JDK 24 onwards -->
+      <id>no-errorprone-jdk-24-onwards</id>
+      <activation>
+        <jdk>[24,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <fork>true</fork>
+              <compilerArgs combine.children="append">
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>-Xplugin:ErrorProne -XepDisableAllChecks</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>include-samples</id>
       <modules>
         <module>samples</module>
@@ -168,7 +189,7 @@
     <profile>
       <id>jdk9</id>
       <activation>
-        <jdk>[1.9,)</jdk>
+        <jdk>[1.9,23)</jdk>
       </activation>
       <build>
         <plugins>


### PR DESCRIPTION
This disables errorprone checks for JDK 24 onwards.

The current version of errorprone is locked in order to confirm compatibility with JDK 11, but it's not compatible with JDk 24.

https://github.com/googleapis/java-pubsublite/blob/b9af4ce5597f40fc2e88f3b90b9ee3b4637a30f7/pom.xml#L73-L79

This PR drops errorprone when JDK >= 24 as a temporary workaround in order to get past the compilation stage and run the units against JDK 24+. The PubSub team will discuss a long term solution.
