### PR TITLE
fix: Update renovate config check to use npx

### DIFF
--- a/.github/scripts/update_generation_config.sh
+++ b/.github/scripts/update_generation_config.sh
@@ -48,13 +48,14 @@ function update_config() {
 }
 
 # Update an action to a new version in GitHub action.
+# the second argument must have the git tag (including "v").
 function update_action() {
     local key_word=$1
     local new_value=$2
     local file=$3
     echo "Update ${key_word} to ${new_value} in ${file}"
     # use a different delimiter because the key_word contains "/".
-    sed -i -e "s|${key_word}@v.*$|${key_word}@v${new_value}|" "${file}"
+    sed -i -e "s|${key_word}@[^ ]*$|${key_word}@${new_value}|" "${file}"
 }
 
 # The parameters of this script is:
@@ -143,12 +144,16 @@ rm -rf tmp-googleapis
 update_config "googleapis_commitish" "${latest_commit}" "${generation_config}"
 
 # Update gapic-generator-java version to the latest
-latest_version=$(get_latest_released_version "com.google.api" "gapic-generator-java")
-update_config "gapic_generator_version" "${latest_version}" "${generation_config}"
+latest_gapic_generator_version=$(get_latest_released_version "com.google.api" "gapic-generator-java")
+update_config "gapic_generator_version" "${latest_gapic_generator_version}" "${generation_config}"
 
-# Update composite action version to latest gapic-generator-java version
-update_action "googleapis/sdk-platform-java/.github/scripts" \
-  "${latest_version}" \
+# Update the GitHub Actions reference to the latest.
+# After the google-cloud-java monorepo migration of sdk-platform-java,
+# we cannot rely on the gapic-generator-java version tag. Let's use
+# the shared dependencies BOM version
+latest_shared_dependencies_bom_version=$(get_latest_released_version "com.google.cloud" "google-cloud-shared-dependencies")
+update_action "googleapis/google-cloud-java/sdk-platform-java/.github/scripts" \
+  "google-cloud-shared-dependencies/v${latest_shared_dependencies_bom_version}" \
   "${workflow}"
 
 # Update libraries-bom version to the latest

--- a/.github/workflows/renovate_config_check.yaml
+++ b/.github/workflows/renovate_config_check.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - 'renovate.json'
-      - '.github/workflows/renovate_config_check.yaml'
 
 jobs:
   renovate_bot_config_validation:
@@ -19,6 +18,8 @@ jobs:
       with:
         node-version: '22'
 
-    - name: Run Renovate Config Validator
+    - name: Install Renovate and Config Validator
       run: |
-        npx --package renovate@42.99.0 renovate-config-validator
+        npm install -g npm@latest
+        npm install --global renovate
+        renovate-config-validator

--- a/.github/workflows/renovate_config_check.yaml
+++ b/.github/workflows/renovate_config_check.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'renovate.json'
+      - '.github/workflows/renovate_config_check.yaml'
 
 jobs:
   renovate_bot_config_validation:
@@ -18,8 +19,6 @@ jobs:
       with:
         node-version: '22'
 
-    - name: Install Renovate and Config Validator
+    - name: Run Renovate Config Validator
       run: |
-        npm install -g npm@latest
-        npm install --global renovate
-        renovate-config-validator
+        npx --package renovate@42.99.0 renovate-config-validator

--- a/renovate.json
+++ b/renovate.json
@@ -26,9 +26,9 @@
         "^.github/workflows/unmanaged_dependency_check.yaml$"
       ],
       "matchStrings": [
-        "uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@google-cloud-shared-dependencies/v(?<currentValue>.+?)\\n"
+        "uses: googleapis/google-cloud-java/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@v(?<currentValue>.+?)\\n"
       ],
-      "depNameTemplate": "com.google.cloud:sdk-platform-java-config",
+      "depNameTemplate": "com.google.cloud:gapic-libraries-bom",
       "datasourceTemplate": "maven"
     }
   ],


### PR DESCRIPTION
This PR updates the renovate config check workflow to use npx instead of global installation, avoiding issues with missing modules.